### PR TITLE
Add IoUring, Epoll and KQueue transport types

### DIFF
--- a/fidorial-server/build.gradle.kts
+++ b/fidorial-server/build.gradle.kts
@@ -13,6 +13,9 @@ dependencies {
     implementation(libs.faststats.core)
     implementation(libs.adventure.text.serializer.ansi)
     implementation(libs.logback.classic)
+    runtimeOnly(libs.netty.epoll)
+    runtimeOnly(libs.netty.kqueue)
+    runtimeOnly(libs.netty.iouring)
 }
 
 application {

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/ServerConfig.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/ServerConfig.java
@@ -34,7 +34,8 @@ public record ServerConfig(
         String motd,
         int maxPlayers,
         ProxyMode proxyMode,
-        @Nullable String velocitySecret
+        @Nullable String velocitySecret,
+        boolean useIoUring
 ) {
 
     private static final ComponentLogger LOGGER = getLogger(ServerConfig.class);
@@ -89,7 +90,8 @@ public record ServerConfig(
                 "",
                 100,
                 ProxyMode.NONE,
-                "");
+                "",
+        false);
     }
 
     public static ServerConfig load() throws IOException {
@@ -127,7 +129,8 @@ public record ServerConfig(
                 readString(props, "motd", "<red>Fidorial <white>| <blue>Alternative Minecraft Server"),
                 readInt(props, "max-players", defaults.maxPlayers()),
                 readProxyMode(props, "proxy-mode", defaults.proxyMode()),
-                readString(props, "velocity-secret", "").strip());
+                readString(props, "velocity-secret", "").strip(),
+                readBool(props, "use-io-uring", false));
         LOGGER.info("Configuration chargee depuis {}", file);
         return config;
     }
@@ -218,6 +221,7 @@ public record ServerConfig(
         props.setProperty("max-players", Integer.toString(maxPlayers));
         props.setProperty("proxy-mode", proxyMode.name().toLowerCase(Locale.ROOT));
         props.setProperty("velocity-secret", velocitySecret == null ? "" : velocitySecret);
+        props.setProperty("use-io-uring", Boolean.toString(useIoUring));
         try (OutputStream out = Files.newOutputStream(file)) {
             props.store(out, "Configuration Fidorial");
         }

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/NettyServer.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/NettyServer.java
@@ -8,28 +8,65 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.MultiThreadIoEventLoopGroup;
+import io.netty.channel.ServerChannel;
+import io.netty.channel.epoll.Epoll;
+import io.netty.channel.epoll.EpollIoHandler;
+import io.netty.channel.epoll.EpollServerSocketChannel;
+import io.netty.channel.kqueue.KQueue;
+import io.netty.channel.kqueue.KQueueIoHandler;
+import io.netty.channel.kqueue.KQueueServerSocketChannel;
 import io.netty.channel.nio.NioIoHandler;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.channel.uring.IoUring;
+import io.netty.channel.uring.IoUringIoHandler;
+import io.netty.channel.uring.IoUringServerSocketChannel;
+import net.kyori.adventure.text.logger.slf4j.ComponentLogger;
 import org.jspecify.annotations.Nullable;
+
+import static fr.euphyllia.fidorial.server.adventure.AdventureHelper.getLogger;
 
 public final class NettyServer {
 
+    private static final ComponentLogger LOGGER = getLogger(NettyServer.class);
     private final FidorialServer server;
     private final int port;
-    private final MultiThreadIoEventLoopGroup bossGroup = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
-    private final MultiThreadIoEventLoopGroup workerGroup = new MultiThreadIoEventLoopGroup(NioIoHandler.newFactory());
+    private final MultiThreadIoEventLoopGroup bossGroup;
+    private final MultiThreadIoEventLoopGroup workerGroup;
+    private final Class<? extends ServerChannel> channelClass;
     private @Nullable Channel channel;
 
     public NettyServer(FidorialServer server, int port) {
         this.server = server;
         this.port = port;
+
+        if (server.config().useIoUring() && IoUring.isAvailable()) {
+            LOGGER.info("Using io_uring transport");
+            bossGroup = new MultiThreadIoEventLoopGroup(1, IoUringIoHandler.newFactory());
+            workerGroup = new MultiThreadIoEventLoopGroup(IoUringIoHandler.newFactory());
+            channelClass = IoUringServerSocketChannel.class;
+        } else if (Epoll.isAvailable()) {
+            LOGGER.info("Using epoll transport");
+            bossGroup = new MultiThreadIoEventLoopGroup(1, EpollIoHandler.newFactory());
+            workerGroup = new MultiThreadIoEventLoopGroup(EpollIoHandler.newFactory());
+            channelClass = EpollServerSocketChannel.class;
+        } else if (KQueue.isAvailable()) {
+            LOGGER.info("Using kqueue transport");
+            bossGroup = new MultiThreadIoEventLoopGroup(1, KQueueIoHandler.newFactory());
+            workerGroup = new MultiThreadIoEventLoopGroup(KQueueIoHandler.newFactory());
+            channelClass = KQueueServerSocketChannel.class;
+        } else {
+            LOGGER.info("Using NIO transport");
+            bossGroup = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
+            workerGroup = new MultiThreadIoEventLoopGroup(NioIoHandler.newFactory());
+            channelClass = NioServerSocketChannel.class;
+        }
     }
 
     public void bind() throws InterruptedException {
         ServerBootstrap bootstrap = new ServerBootstrap()
                 .group(bossGroup, workerGroup)
-                .channel(NioServerSocketChannel.class)
+                .channel(channelClass)
                 .childOption(ChannelOption.TCP_NODELAY, true)
                 .childHandler(new ChannelInitializer<SocketChannel>() {
                     @Override

--- a/fidorial-server/src/main/java/module-info.java
+++ b/fidorial-server/src/main/java/module-info.java
@@ -24,4 +24,7 @@ module fr.fidorial.server {
 
     requires static org.jetbrains.annotations;
     requires static org.jspecify;
+    requires io.netty.transport.classes.epoll;
+    requires io.netty.transport.classes.kqueue;
+    requires io.netty.transport.classes.io_uring;
 }

--- a/fidorial-server/src/main/resources/fidorial.properties
+++ b/fidorial-server/src/main/resources/fidorial.properties
@@ -27,3 +27,4 @@ motd=<red>Fidorial <white>| <blue>Alternative Minecraft Server
 # Velocity Proxy
 proxy-mode=NONE
 velocity-secret=
+use-io-uring=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,9 @@ jspecify = "1.0.0"
 
 [libraries]
 netty-all = { module = "io.netty:netty-all", version.ref = "netty" }
+netty-epoll = { module = "io.netty:netty-transport-native-epoll", version.ref = "netty" }
+netty-kqueue = { module = "io.netty:netty-transport-native-kqueue", version.ref = "netty" }
+netty-iouring = { module = "io.netty:netty-transport-native-io_uring", version.ref = "netty" }
 gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
 slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
 logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }


### PR DESCRIPTION
This just selects the most appropriate transport type for the current platform instead of using hardcoded NIO.

Currently IoUring is guarded behind a config defaulting to false