### PR TITLE
Fix WorldManager#world map lookup regression introduced in 948b474

### DIFF
--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/WorldManager.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/WorldManager.java
@@ -153,7 +153,7 @@ public final class WorldManager implements AutoCloseable {
     }
 
     public ServerWorld world(final Key worldKey) {
-        return worlds.get(worldKey.asString());
+        return worlds.get(worldKey);
     }
 
     public LevelData levelData() {


### PR DESCRIPTION
This caused commands such as `/time set night minecraft:overworld` to silently fail