### PR TITLE
Fix an NPE in EntitySelector

### DIFF
--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/entity/EntitySelector.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/entity/EntitySelector.java
@@ -137,9 +137,14 @@ public final class EntitySelector {
 
         final FidorialServer server = (FidorialServer) source.server();
         final Collection<? extends Entity> entities;
+        final Entity executor = source.executor();
+
+        final Collection<? extends Entity> worldEntities = executor != null
+                ? server.worldManager().world(executor.world().key()).entityManager().all()
+                : server.worldManager().overworld().entityManager().all();
 
         if (targetUuid != null) {
-            final Optional<? extends Entity> entity = server.worldManager().world(source.executor().world().key()).entityManager().all().stream()
+            final Optional<? extends Entity> entity = worldEntities.stream()
                     .filter(e -> e.uuid().equals(targetUuid))
                     .findFirst();
 
@@ -161,7 +166,7 @@ public final class EntitySelector {
             entities = List.of(player);
 
         } else if (includesEntities) {
-            entities = server.worldManager().world(source.executor().world().key()).entityManager().all();
+            entities = worldEntities;
         } else {
             entities = server.onlinePlayers();
         }


### PR DESCRIPTION
Accidentally overlooked `source.executor()` being able to return null, such as for the console, which would result in an NPE. This fixes it