### PR TITLE
Bossbars 🔥

### DIFF
--- a/fidorial-api/src/main/java/fr/fidorial/command/Commands.java
+++ b/fidorial-api/src/main/java/fr/fidorial/command/Commands.java
@@ -4,6 +4,7 @@ import com.google.common.base.Preconditions;
 import com.mojang.brigadier.arguments.ArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.builder.RequiredArgumentBuilder;
+import fr.fidorial.command.argument.ForceServerSuggestions;
 
 public interface Commands {
 
@@ -35,6 +36,12 @@ public interface Commands {
         Preconditions.checkNotNull(name, "name");
         Preconditions.checkNotNull(argumentType, "argumentType");
 
-        return RequiredArgumentBuilder.argument(name, argumentType);
+        final RequiredArgumentBuilder<CommandSource, T> builder = RequiredArgumentBuilder.argument(name, argumentType);
+
+        if (argumentType instanceof final ForceServerSuggestions forced) {
+            builder.suggests(forced.suggestionProvider());
+        }
+
+        return builder;
     }
 }

--- a/fidorial-api/src/main/java/fr/fidorial/command/argument/ArgumentProvider.java
+++ b/fidorial-api/src/main/java/fr/fidorial/command/argument/ArgumentProvider.java
@@ -17,6 +17,7 @@ import fr.fidorial.inventory.ItemStack;
 import fr.fidorial.registry.RegistryKey;
 import fr.fidorial.registry.TypedKey;
 import fr.fidorial.world.World;
+import net.kyori.adventure.bossbar.BossBar;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -69,6 +70,12 @@ public interface ArgumentProvider {
     ArgumentType<NamedTextColor> namedColor();
 
     ArgumentType<TextColor> hexColor();
+
+    ArgumentType<BossBar.Color> bossBarColor();
+
+    ArgumentType<BossBar.Overlay> bossBarOverlay();
+
+    ArgumentType<BossBar.Flag> bossBarFlag();
 
     ArgumentType<Component> component();
 

--- a/fidorial-api/src/main/java/fr/fidorial/command/argument/ArgumentTypes.java
+++ b/fidorial-api/src/main/java/fr/fidorial/command/argument/ArgumentTypes.java
@@ -18,6 +18,7 @@ import fr.fidorial.registry.Registry;
 import fr.fidorial.registry.RegistryKey;
 import fr.fidorial.registry.TypedKey;
 import fr.fidorial.world.World;
+import net.kyori.adventure.bossbar.BossBar;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -202,6 +203,33 @@ public final class ArgumentTypes {
      */
     public static ArgumentType<TextColor> hexColor() {
         return provider().hexColor();
+    }
+
+    /**
+     * A boss bar color argument.
+     *
+     * @return argument
+     */
+    public static ArgumentType<BossBar.Color> bossBarColor() {
+        return provider().bossBarColor();
+    }
+
+    /**
+     * A boss bar overlay argument.
+     *
+     * @return argument
+     */
+    public static ArgumentType<BossBar.Overlay> bossBarOverlay() {
+        return provider().bossBarOverlay();
+    }
+
+    /**
+     * A boss bar flag argument.
+     *
+     * @return argument
+     */
+    public static ArgumentType<BossBar.Flag> bossBarFlag() {
+        return provider().bossBarFlag();
     }
 
     /**

--- a/fidorial-api/src/main/java/fr/fidorial/command/argument/ForceServerSuggestions.java
+++ b/fidorial-api/src/main/java/fr/fidorial/command/argument/ForceServerSuggestions.java
@@ -1,0 +1,16 @@
+package fr.fidorial.command.argument;
+
+import com.mojang.brigadier.suggestion.SuggestionProvider;
+import fr.fidorial.command.CommandSource;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * Marks an ArgumentType that has no vanilla client-side parser equivalent,
+ * so the client must always be told to ask the server for suggestions
+ * (minecraft:ask_server), regardless of whether .suggests(...) was
+ * attached at command-registration time.
+ */
+@ApiStatus.Internal
+public interface ForceServerSuggestions {
+    SuggestionProvider<CommandSource> suggestionProvider();
+}

--- a/fidorial-api/src/main/java/fr/fidorial/entity/Player.java
+++ b/fidorial-api/src/main/java/fr/fidorial/entity/Player.java
@@ -5,7 +5,9 @@ import fr.fidorial.command.CommandSource;
 import fr.fidorial.inventory.EnderChestInventory;
 import fr.fidorial.inventory.PlayerInventory;
 import fr.fidorial.permission.PermissionHolder;
+import net.kyori.adventure.bossbar.BossBar;
 
+import java.util.Collection;
 import java.util.UUID;
 
 public interface Player extends LivingEntity, PermissionHolder, CommandSource, CommandSender {
@@ -33,4 +35,6 @@ public interface Player extends LivingEntity, PermissionHolder, CommandSource, C
     GameMode gameMode();
 
     void setGameMode(GameMode gameMode);
+
+    Collection<? extends BossBar> bossBars();
 }

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/FidorialServer.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/FidorialServer.java
@@ -45,6 +45,7 @@ import fr.euphyllia.fidorial.server.service.SimpleServiceRegistry;
 import fr.euphyllia.fidorial.server.translation.BuiltInTranslationStore;
 import fr.euphyllia.fidorial.server.world.BlockEditService;
 import fr.euphyllia.fidorial.server.world.BlockStateRegistry;
+import fr.euphyllia.fidorial.server.world.BossBarRegistry;
 import fr.euphyllia.fidorial.server.world.ChunkNetworkSerializer;
 import fr.euphyllia.fidorial.server.world.FlatChunkGenerator;
 import fr.euphyllia.fidorial.server.world.FlatWorld;
@@ -152,6 +153,7 @@ public final class FidorialServer implements Server {
     private final FluidEngine fluidEngine =
             new FluidEngine(worldManager, regionizer, blockStateRegistry, this::broadcast);
     private final WeatherEngine weatherEngine = new WeatherEngine(worldManager.levelData(), this::broadcast);
+    private final BossBarRegistry bossBarRegistry = new BossBarRegistry(worldManager.levelData(), this::players);
     private final DayNightThread dayNightEngine = new DayNightThread(worldManager, registries.dynamic());
     private final ChunkNetworkSerializer lightSerializer = new ChunkNetworkSerializer(blockStateRegistry, 0);
     private final LightUpdateDispatcher lightDispatcher = new LightUpdateDispatcher(
@@ -241,6 +243,7 @@ public final class FidorialServer implements Server {
         closeQuietly("chunks", chunkWorker::shutdown);
         closeQuietly("meteo", weatherEngine::close);
         closeQuietly("cycle jour/nuit", dayNightEngine::close);
+        closeQuietly("bossbars", bossBarRegistry::close);
         closeQuietly("monde", worldManager::close);
         closeQuietly("metriques", metrics::shutdown);
         LOGGER.info("Stop complete");
@@ -293,6 +296,7 @@ public final class FidorialServer implements Server {
         worldManager.overworld();
         weatherEngine.start();
         dayNightEngine.start();
+        bossBarRegistry.loadFromLevelData();
     }
 
     private void registerDefaultServices() {
@@ -304,6 +308,7 @@ public final class FidorialServer implements Server {
         services.register(PlayerInventoryStorage.class, defaultInventoryStorage, this, ServicePriority.LOWEST);
         services.register(PlayerDataStorage.class, defaultPlayerDataStorage, this, ServicePriority.LOWEST);
         services.register(PlayerEnderChestStorage.class, defaultEnderChestStorage, this, ServicePriority.LOWEST);
+        services.register(BossBarRegistry.class, bossBarRegistry, this, ServicePriority.LOWEST);
     }
 
     private void loadPlugins() throws IOException {
@@ -540,6 +545,10 @@ public final class FidorialServer implements Server {
 
     public PlayerDataStorage playerDataStorage() {
         return services.find(PlayerDataStorage.class).orElse(defaultPlayerDataStorage);
+    }
+
+    public BossBarRegistry bossBarRegistry() {
+        return services.find(BossBarRegistry.class).orElse(bossBarRegistry);
     }
 
     public BlockStateRegistry blockStateRegistry() {

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/FidorialServer.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/FidorialServer.java
@@ -610,6 +610,9 @@ public final class FidorialServer implements Server {
     }
 
     public void removePlayerConnection(final ClientConnection connection) {
+        if (connection.player() != null) {
+            connection.player().clearActiveBossBars();
+        }
         connections.remove(connection);
         entityTracker.removeViewer(connection);
         refreshPlayerSnapshot();

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/ArgumentProviderImpl.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/ArgumentProviderImpl.java
@@ -9,6 +9,9 @@ import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.mojang.brigadier.arguments.LongArgumentType;
 import com.mojang.brigadier.arguments.StringArgumentType;
 import fr.euphyllia.fidorial.server.FidorialServer;
+import fr.euphyllia.fidorial.server.command.brigadier.argument.bossbar.BossBarColorArgument;
+import fr.euphyllia.fidorial.server.command.brigadier.argument.bossbar.BossBarFlagArgument;
+import fr.euphyllia.fidorial.server.command.brigadier.argument.bossbar.BossBarOverlayArgument;
 import fr.euphyllia.fidorial.server.command.brigadier.argument.chat.ComponentArgument;
 import fr.euphyllia.fidorial.server.command.brigadier.argument.chat.HexColorArgument;
 import fr.euphyllia.fidorial.server.command.brigadier.argument.chat.NamedColorArgument;
@@ -48,6 +51,7 @@ import fr.fidorial.inventory.ItemStack;
 import fr.fidorial.registry.RegistryKey;
 import fr.fidorial.registry.TypedKey;
 import fr.fidorial.world.World;
+import net.kyori.adventure.bossbar.BossBar;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -137,6 +141,21 @@ public class ArgumentProviderImpl implements ArgumentProvider {
     @Override
     public ArgumentType<TextColor> hexColor() {
         return HexColorArgument.hexColor(TextColor::color);
+    }
+
+    @Override
+    public ArgumentType<BossBar.Color> bossBarColor() {
+        return BossBarColorArgument.bossBarColor();
+    }
+
+    @Override
+    public ArgumentType<BossBar.Overlay> bossBarOverlay() {
+        return BossBarOverlayArgument.bossBarOverlay();
+    }
+
+    @Override
+    public ArgumentType<BossBar.Flag> bossBarFlag() {
+        return BossBarFlagArgument.bossBarFlag();
     }
 
     @Override

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/bossbar/BossBarColorArgument.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/bossbar/BossBarColorArgument.java
@@ -37,7 +37,7 @@ public final class BossBarColorArgument implements ArgumentType<BossBar.Color>, 
 
     public static final DynamicCommandExceptionType ERROR_INVALID_VALUE =
             new DynamicCommandExceptionType(value -> MSG_SERIALIZER.serialize(
-                    Component.translatable("argument.bossbar.color.invalid",
+                    Component.translatable("argument.enum.invalid",
                             Component.text(String.valueOf(value)))));
 
     public static BossBarColorArgument bossBarColor() {

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/bossbar/BossBarColorArgument.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/bossbar/BossBarColorArgument.java
@@ -1,0 +1,116 @@
+package fr.euphyllia.fidorial.server.command.brigadier.argument.bossbar;
+
+import com.google.gson.JsonObject;
+import com.mojang.brigadier.StringReader;
+import com.mojang.brigadier.arguments.ArgumentType;
+import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.brigadier.exceptions.DynamicCommandExceptionType;
+import com.mojang.brigadier.suggestion.SuggestionProvider;
+import com.mojang.brigadier.suggestion.Suggestions;
+import com.mojang.brigadier.suggestion.SuggestionsBuilder;
+import fr.euphyllia.fidorial.server.command.brigadier.packet.registry.ArgumentTypeRegistrar;
+import fr.euphyllia.fidorial.server.network.PacketBuffer;
+import fr.fidorial.command.CommandSource;
+import fr.fidorial.command.argument.ForceServerSuggestions;
+import net.kyori.adventure.bossbar.BossBar;
+import net.kyori.adventure.text.Component;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Locale;
+import java.util.concurrent.CompletableFuture;
+
+import static fr.euphyllia.fidorial.server.adventure.brigadier.BrigadierAdventureHelper.MSG_SERIALIZER;
+
+public final class BossBarColorArgument implements ArgumentType<BossBar.Color>, ForceServerSuggestions {
+
+    private static final Collection<String> EXAMPLES = Arrays.asList("red", "blue");
+
+    public static final SuggestionProvider<CommandSource> SUGGESTIONS = (_, builder) -> {
+        for (final BossBar.Color color : BossBar.Color.values()) {
+            builder.suggest(color.name().toLowerCase(Locale.ROOT));
+        }
+        return builder.buildFuture();
+    };
+
+    public static final DynamicCommandExceptionType ERROR_INVALID_VALUE =
+            new DynamicCommandExceptionType(value -> MSG_SERIALIZER.serialize(
+                    Component.translatable("argument.bossbar.color.invalid",
+                            Component.text(String.valueOf(value)))));
+
+    public static BossBarColorArgument bossBarColor() {
+        return new BossBarColorArgument();
+    }
+
+    @Override
+    public BossBar.Color parse(final StringReader reader) throws CommandSyntaxException {
+        final String value = reader.readUnquotedString();
+
+        for (final BossBar.Color color : BossBar.Color.values()) {
+            if (color.name().equalsIgnoreCase(value)) {
+                return color;
+            }
+        }
+
+        throw ERROR_INVALID_VALUE.createWithContext(reader, value);
+    }
+
+    @Override
+    public <S> CompletableFuture<Suggestions> listSuggestions(
+            final CommandContext<S> context,
+            final SuggestionsBuilder builder
+    ) {
+        for (final BossBar.Color color : BossBar.Color.values()) {
+            builder.suggest(color.name().toLowerCase(Locale.ROOT));
+        }
+        return builder.buildFuture();
+    }
+
+
+    @Override
+    public SuggestionProvider<CommandSource> suggestionProvider() {
+        return SUGGESTIONS;
+    }
+
+    @Override
+    public Collection<String> getExamples() {
+        return EXAMPLES;
+    }
+
+    public static final class Info implements ArgumentTypeRegistrar<BossBarColorArgument, Info.Spec> {
+
+        @Override
+        public void serialize(final Spec spec, final PacketBuffer buf) {
+            buf.writeVarInt(StringArgumentType.StringType.SINGLE_WORD.ordinal());
+        }
+
+        @Override
+        public Spec deserialize(final PacketBuffer buf) {
+            return new Spec();
+        }
+
+        @Override
+        public void serializeJson(final Spec spec, final JsonObject json) {
+        }
+
+        @Override
+        public Spec access(final BossBarColorArgument argument) {
+            return new Spec();
+        }
+
+        public record Spec() implements ArgumentTypeRegistrar.Spec<BossBarColorArgument> {
+
+            @Override
+            public BossBarColorArgument instantiate() {
+                return BossBarColorArgument.bossBarColor();
+            }
+
+            @Override
+            public ArgumentTypeRegistrar<BossBarColorArgument, ?> type() {
+                return new Info();
+            }
+        }
+    }
+}

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/bossbar/BossBarFlagArgument.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/bossbar/BossBarFlagArgument.java
@@ -1,0 +1,114 @@
+package fr.euphyllia.fidorial.server.command.brigadier.argument.bossbar;
+
+import com.google.gson.JsonObject;
+import com.mojang.brigadier.StringReader;
+import com.mojang.brigadier.arguments.ArgumentType;
+import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.brigadier.exceptions.DynamicCommandExceptionType;
+import com.mojang.brigadier.suggestion.SuggestionProvider;
+import com.mojang.brigadier.suggestion.Suggestions;
+import com.mojang.brigadier.suggestion.SuggestionsBuilder;
+import fr.euphyllia.fidorial.server.command.brigadier.packet.registry.ArgumentTypeRegistrar;
+import fr.euphyllia.fidorial.server.network.PacketBuffer;
+import fr.fidorial.command.CommandSource;
+import fr.fidorial.command.argument.ForceServerSuggestions;
+import net.kyori.adventure.bossbar.BossBar;
+import net.kyori.adventure.text.Component;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.CompletableFuture;
+
+import static fr.euphyllia.fidorial.server.adventure.brigadier.BrigadierAdventureHelper.MSG_SERIALIZER;
+
+public final class BossBarFlagArgument implements ArgumentType<BossBar.Flag>, ForceServerSuggestions {
+
+    private static final List<String> EXAMPLES = List.of("darken_screen", "play_boss_music");
+
+    public static final SuggestionProvider<CommandSource> SUGGESTIONS = (_, builder) -> {
+        for (final BossBar.Flag flag : BossBar.Flag.values()) {
+            builder.suggest(flag.name().toLowerCase(Locale.ROOT));
+        }
+        return builder.buildFuture();
+    };
+
+    public static final DynamicCommandExceptionType ERROR_INVALID_VALUE =
+            new DynamicCommandExceptionType(value -> MSG_SERIALIZER.serialize(
+                    Component.translatable(
+                            "argument.bossbar.flag.invalid",
+                            Component.text(String.valueOf(value)))));
+
+    public static BossBarFlagArgument bossBarFlag() {
+        return new BossBarFlagArgument();
+    }
+
+    @Override
+    public BossBar.Flag parse(final StringReader reader) throws CommandSyntaxException {
+        final String value = reader.readUnquotedString();
+
+        for (final BossBar.Flag flag : BossBar.Flag.values()) {
+            if (flag.name().equalsIgnoreCase(value)) {
+                return flag;
+            }
+        }
+        throw ERROR_INVALID_VALUE.createWithContext(reader, value);
+    }
+
+    @Override
+    public <S> CompletableFuture<Suggestions> listSuggestions(
+            final CommandContext<S> context,
+            final SuggestionsBuilder builder
+    ) {
+        for (final BossBar.Flag flag : BossBar.Flag.values()) {
+            builder.suggest(flag.name().toLowerCase(Locale.ROOT));
+        }
+        return builder.buildFuture();
+    }
+
+    @Override
+    public List<String> getExamples() {
+        return EXAMPLES;
+    }
+
+    @Override
+    public SuggestionProvider<CommandSource> suggestionProvider() {
+        return SUGGESTIONS;
+    }
+
+    public static final class Info implements ArgumentTypeRegistrar<BossBarFlagArgument, Info.Spec> {
+
+        @Override
+        public void serialize(final Spec spec, final PacketBuffer buf) {
+            buf.writeVarInt(StringArgumentType.StringType.SINGLE_WORD.ordinal());
+        }
+
+        @Override
+        public Spec deserialize(final PacketBuffer buf) {
+            return new Spec();
+        }
+
+        @Override
+        public void serializeJson(final Spec spec, final JsonObject json) {
+        }
+
+        @Override
+        public Spec access(final BossBarFlagArgument argument) {
+            return new Spec();
+        }
+
+        public record Spec() implements ArgumentTypeRegistrar.Spec<BossBarFlagArgument> {
+
+            @Override
+            public BossBarFlagArgument instantiate() {
+                return BossBarFlagArgument.bossBarFlag();
+            }
+
+            @Override
+            public ArgumentTypeRegistrar<BossBarFlagArgument, ?> type() {
+                return new Info();
+            }
+        }
+    }
+}

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/bossbar/BossBarFlagArgument.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/bossbar/BossBarFlagArgument.java
@@ -37,7 +37,7 @@ public final class BossBarFlagArgument implements ArgumentType<BossBar.Flag>, Fo
     public static final DynamicCommandExceptionType ERROR_INVALID_VALUE =
             new DynamicCommandExceptionType(value -> MSG_SERIALIZER.serialize(
                     Component.translatable(
-                            "argument.bossbar.flag.invalid",
+                            "argument.enum.invalid",
                             Component.text(String.valueOf(value)))));
 
     public static BossBarFlagArgument bossBarFlag() {

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/bossbar/BossBarOverlayArgument.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/bossbar/BossBarOverlayArgument.java
@@ -1,0 +1,114 @@
+package fr.euphyllia.fidorial.server.command.brigadier.argument.bossbar;
+
+import com.google.gson.JsonObject;
+import com.mojang.brigadier.StringReader;
+import com.mojang.brigadier.arguments.ArgumentType;
+import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.brigadier.exceptions.DynamicCommandExceptionType;
+import com.mojang.brigadier.suggestion.SuggestionProvider;
+import com.mojang.brigadier.suggestion.Suggestions;
+import com.mojang.brigadier.suggestion.SuggestionsBuilder;
+import fr.euphyllia.fidorial.server.command.brigadier.packet.registry.ArgumentTypeRegistrar;
+import fr.euphyllia.fidorial.server.network.PacketBuffer;
+import fr.fidorial.command.CommandSource;
+import fr.fidorial.command.argument.ForceServerSuggestions;
+import net.kyori.adventure.bossbar.BossBar;
+import net.kyori.adventure.text.Component;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.CompletableFuture;
+
+import static fr.euphyllia.fidorial.server.adventure.brigadier.BrigadierAdventureHelper.MSG_SERIALIZER;
+
+public final class BossBarOverlayArgument implements ArgumentType<BossBar.Overlay>, ForceServerSuggestions {
+
+    private static final List<String> EXAMPLES = List.of("progress", "notched_10");
+
+    public static final SuggestionProvider<CommandSource> SUGGESTIONS = (_, builder) -> {
+        for (final BossBar.Overlay overlay : BossBar.Overlay.values()) {
+            builder.suggest(overlay.name().toLowerCase(Locale.ROOT));
+        }
+        return builder.buildFuture();
+    };
+
+    public static final DynamicCommandExceptionType ERROR_INVALID_VALUE =
+            new DynamicCommandExceptionType(value -> MSG_SERIALIZER.serialize(
+                    Component.translatable(
+                            "argument.bossbar.overlay.invalid",
+                            Component.text(String.valueOf(value)))));
+
+    public static BossBarOverlayArgument bossBarOverlay() {
+        return new BossBarOverlayArgument();
+    }
+
+    @Override
+    public BossBar.Overlay parse(final StringReader reader) throws CommandSyntaxException {
+        final String value = reader.readUnquotedString();
+
+        for (final BossBar.Overlay overlay : BossBar.Overlay.values()) {
+            if (overlay.name().equalsIgnoreCase(value)) {
+                return overlay;
+            }
+        }
+        throw ERROR_INVALID_VALUE.createWithContext(reader, value);
+    }
+
+    @Override
+    public <S> CompletableFuture<Suggestions> listSuggestions(
+            final CommandContext<S> context,
+            final SuggestionsBuilder builder
+    ) {
+        for (final BossBar.Overlay overlay : BossBar.Overlay.values()) {
+            builder.suggest(overlay.name().toLowerCase(Locale.ROOT));
+        }
+        return builder.buildFuture();
+    }
+
+    @Override
+    public List<String> getExamples() {
+        return EXAMPLES;
+    }
+
+    @Override
+    public SuggestionProvider<CommandSource> suggestionProvider() {
+        return SUGGESTIONS;
+    }
+
+    public static final class Info implements ArgumentTypeRegistrar<BossBarOverlayArgument, Info.Spec> {
+
+        @Override
+        public void serialize(final Spec spec, final PacketBuffer buf) {
+            buf.writeVarInt(StringArgumentType.StringType.SINGLE_WORD.ordinal());
+        }
+
+        @Override
+        public Spec deserialize(final PacketBuffer buf) {
+            return new Spec();
+        }
+
+        @Override
+        public void serializeJson(final Spec spec, final JsonObject json) {
+        }
+
+        @Override
+        public Spec access(final BossBarOverlayArgument argument) {
+            return new Spec();
+        }
+
+        public record Spec() implements ArgumentTypeRegistrar.Spec<BossBarOverlayArgument> {
+
+            @Override
+            public BossBarOverlayArgument instantiate() {
+                return BossBarOverlayArgument.bossBarOverlay();
+            }
+
+            @Override
+            public ArgumentTypeRegistrar<BossBarOverlayArgument, ?> type() {
+                return new Info();
+            }
+        }
+    }
+}

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/bossbar/BossBarOverlayArgument.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/bossbar/BossBarOverlayArgument.java
@@ -37,7 +37,7 @@ public final class BossBarOverlayArgument implements ArgumentType<BossBar.Overla
     public static final DynamicCommandExceptionType ERROR_INVALID_VALUE =
             new DynamicCommandExceptionType(value -> MSG_SERIALIZER.serialize(
                     Component.translatable(
-                            "argument.bossbar.overlay.invalid",
+                            "argument.enum.invalid",
                             Component.text(String.valueOf(value)))));
 
     public static BossBarOverlayArgument bossBarOverlay() {

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/packet/CommandTreeSerializer.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/packet/CommandTreeSerializer.java
@@ -10,6 +10,7 @@ import fr.euphyllia.fidorial.server.command.brigadier.packet.registry.ArgumentTy
 import fr.euphyllia.fidorial.server.command.brigadier.packet.registry.NetworkArgumentIds;
 import fr.euphyllia.fidorial.server.command.brigadier.packet.util.PermissionlessCommandSource;
 import fr.euphyllia.fidorial.server.network.PacketBuffer;
+import fr.euphyllia.fidorial.server.registry.data.ArgumentTypeIds;
 import fr.fidorial.command.CommandSource;
 import net.kyori.adventure.key.Key;
 
@@ -182,7 +183,23 @@ public final class CommandTreeSerializer {
     }
 
     private static void writeArgumentType(final PacketBuffer buf, final ArgumentType<?> argument) {
+        if (argument instanceof fr.fidorial.command.argument.ForceServerSuggestions) {
+            writeAliasedAsString(buf, argument, ArgumentTypeRegistry.registrar(argument));
+            return;
+        }
+
         writeArgumentTypeCaptured(buf, argument, ArgumentTypeRegistry.registrar(argument));
+    }
+
+    private static <A extends ArgumentType<?>, S extends ArgumentTypeRegistrar.Spec<A>> void writeAliasedAsString(
+            final PacketBuffer buf,
+            final A argument,
+            final ArgumentTypeRegistrar<A, S> registrar
+    ) {
+        buf.writeVarInt(ArgumentTypeIds.STRING_ARGUMENT_ID);
+
+        final S spec = registrar.access(argument);
+        registrar.serialize(spec, buf);
     }
 
     private static <A extends ArgumentType<?>, S extends ArgumentTypeRegistrar.Spec<A>> void writeArgumentTypeCaptured(

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/packet/registry/ArgumentTypes.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/packet/registry/ArgumentTypes.java
@@ -1,6 +1,9 @@
 package fr.euphyllia.fidorial.server.command.brigadier.packet.registry;
 
 import com.mojang.brigadier.arguments.ArgumentType;
+import fr.euphyllia.fidorial.server.command.brigadier.argument.bossbar.BossBarColorArgument;
+import fr.euphyllia.fidorial.server.command.brigadier.argument.bossbar.BossBarFlagArgument;
+import fr.euphyllia.fidorial.server.command.brigadier.argument.bossbar.BossBarOverlayArgument;
 import fr.euphyllia.fidorial.server.command.brigadier.argument.chat.ComponentArgument;
 import fr.euphyllia.fidorial.server.command.brigadier.argument.chat.HexColorArgument;
 import fr.euphyllia.fidorial.server.command.brigadier.argument.chat.NamedColorArgument;
@@ -60,6 +63,11 @@ public final class ArgumentTypes {
         register(new ResourceArgument.Info<>(), ArgumentTypeIds.RESOURCE_ARGUMENT_ID);
         register(new ResourceKeyArgument.Info<>(), ArgumentTypeIds.RESOURCE_KEY_ARGUMENT_ID);
         register(new UuidArgument.Info(), ArgumentTypeIds.UUID_ARGUMENT_ID);
+        // start - custom arguments
+        ArgumentTypeRegistry.register(new BossBarColorArgument.Info());
+        ArgumentTypeRegistry.register(new BossBarOverlayArgument.Info());
+        ArgumentTypeRegistry.register(new BossBarFlagArgument.Info());
+        // end - custom arguments
     }
 
     private static <A extends ArgumentType<?>> void register(final ArgumentTypeRegistrar<A, ?> registrar, final int networkId) {

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/player/ServerPlayer.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/player/ServerPlayer.java
@@ -333,6 +333,13 @@ public final class ServerPlayer extends AbstractEntity implements Player, Permis
         return result;
     }
 
+    public void clearActiveBossBars() {
+        for (final Map.Entry<BossBar, BossBarEntry> entry : activeBossBars.entrySet()) {
+            entry.getKey().removeListener(entry.getValue().listener());
+        }
+        activeBossBars.clear();
+    }
+
     @Override
     public void kick(final String reason) {
         connection.disconnect(reason);

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/player/ServerPlayer.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/player/ServerPlayer.java
@@ -6,6 +6,7 @@ import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.inventory.ContainerMenu;
 import fr.euphyllia.fidorial.server.network.ClientConnection;
 import fr.euphyllia.fidorial.server.network.nbt.ComponentResolver;
+import fr.euphyllia.fidorial.server.protocol.packet.clientbound.play.ClientboundBossEventPacket;
 import fr.euphyllia.fidorial.server.protocol.packet.clientbound.play.ClientboundContainerClosePacket;
 import fr.euphyllia.fidorial.server.protocol.packet.clientbound.play.ClientboundEntityEventPacket;
 import fr.euphyllia.fidorial.server.protocol.packet.clientbound.play.ClientboundGameEventPacket;
@@ -31,12 +32,18 @@ import fr.fidorial.translation.TranslationStore;
 import fr.fidorial.world.BlockPos;
 import fr.fidorial.world.Location;
 import fr.fidorial.world.World;
+import net.kyori.adventure.bossbar.BossBar;
 import net.kyori.adventure.sound.Sound;
 import net.kyori.adventure.sound.SoundStop;
 import net.kyori.adventure.text.Component;
 import org.jspecify.annotations.Nullable;
 
+import java.util.Collection;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 public final class ServerPlayer extends AbstractEntity implements Player, PermissionStateHolder {
 
@@ -274,6 +281,58 @@ public final class ServerPlayer extends AbstractEntity implements Player, Permis
         connection.send(new ClientboundStopSoundPacket(stop.source(), stop.sound()));
     }
 
+    private record BossBarEntry(UUID id, BossBar.Listener listener) {
+    }
+    private final Map<BossBar, BossBarEntry> activeBossBars = new ConcurrentHashMap<>();
+
+    @Override
+    public void showBossBar(final BossBar bar) {
+        if (activeBossBars.containsKey(bar)) return;
+        final UUID id = UUID.randomUUID();
+        final BossBar.Listener listener = new BossBar.Listener() {
+            @Override
+            public void bossBarProgressChanged(BossBar bar, float old, float now) {
+                connection.send(new ClientboundBossEventPacket.UpdateProgress(id, now));
+            }
+            @Override
+            public void bossBarNameChanged(BossBar bar, Component old, Component now) {
+                connection.send(new ClientboundBossEventPacket.UpdateName(id, now));
+            }
+            @Override
+            public void bossBarColorChanged(BossBar bar, BossBar.Color old, BossBar.Color now) {
+                connection.send(new ClientboundBossEventPacket.UpdateStyle(id, now, bar.overlay()));
+            }
+            @Override
+            public void bossBarOverlayChanged(BossBar bar, BossBar.Overlay old, BossBar.Overlay now) {
+                connection.send(new ClientboundBossEventPacket.UpdateStyle(id, bar.color(), now));
+            }
+            @Override
+            public void bossBarFlagsChanged(BossBar ba, Set<BossBar.Flag> added, Set<BossBar.Flag> removed) {
+                connection.send(new ClientboundBossEventPacket.UpdateProperties(id, encodeFlags(ba.flags())));
+            }
+        };
+        activeBossBars.put(bar, new BossBarEntry(id, listener));
+        bar.addListener(listener);
+        connection.send(new ClientboundBossEventPacket.Add(id, bar.name(), bar.progress(),
+                bar.color(), bar.overlay(), encodeFlags(bar.flags())));
+    }
+
+    @Override
+    public void hideBossBar(final BossBar bar) {
+        final BossBarEntry entry = activeBossBars.remove(bar);
+        if (entry == null) return;
+        bar.removeListener(entry.listener());
+        connection.send(new ClientboundBossEventPacket.Remove(entry.id()));
+    }
+
+    private static int encodeFlags(final Set<BossBar.Flag> flags) {
+        int result = 0;
+        if (flags.contains(BossBar.Flag.DARKEN_SCREEN)) result |= 1;
+        if (flags.contains(BossBar.Flag.PLAY_BOSS_MUSIC)) result |= 2;
+        if (flags.contains(BossBar.Flag.CREATE_WORLD_FOG)) result |= 4;
+        return result;
+    }
+
     @Override
     public void kick(final String reason) {
         connection.disconnect(reason);
@@ -293,6 +352,11 @@ public final class ServerPlayer extends AbstractEntity implements Player, Permis
         connection.send(new ClientboundGameEventPacket(ClientboundGameEventPacket.CHANGE_GAME_MODE, gameMode.id()));
         connection.send(ClientboundPlayerAbilitiesPacket.forGameMode(gameMode));
         connection.server().broadcast(new ClientboundPlayerInfoGameModePacket(uuid(), gameMode.id()));
+    }
+
+    @Override
+    public Collection<? extends BossBar> bossBars() {
+        return Set.copyOf(activeBossBars.keySet());
     }
 
     public int selectedSlot() {

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/listener/PlayPacketHandler.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/listener/PlayPacketHandler.java
@@ -203,6 +203,7 @@ public final class PlayPacketHandler implements PlayPacketListener {
         connection.send(new ClientboundGameEventPacket(ClientboundGameEventPacket.START_WAITING_FOR_CHUNKS, 0f));
         server.weatherEngine().syncTo(connection::send);
         server.dayNightEngine().syncTo(world, connection::send);
+        server.bossBarRegistry().syncTo(player);
     }
 
     private void openChunkView(final ServerWorld world, final RegistryHolder dynamic, final ChunkPos spawnChunk) {

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/protocol/packet/clientbound/play/ClientboundBossEventPacket.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/protocol/packet/clientbound/play/ClientboundBossEventPacket.java
@@ -1,0 +1,64 @@
+package fr.euphyllia.fidorial.server.protocol.packet.clientbound.play;
+
+import fr.euphyllia.fidorial.server.network.PacketBuffer;
+import fr.euphyllia.fidorial.server.protocol.catalog.PlayClientboundPackets;
+import fr.euphyllia.fidorial.server.protocol.packet.ClientboundPacket;
+import net.kyori.adventure.bossbar.BossBar;
+import net.kyori.adventure.text.Component;
+
+import java.util.UUID;
+
+public sealed interface ClientboundBossEventPacket extends ClientboundPacket {
+
+    UUID id();
+
+    @Override
+    default String name() {
+        return PlayClientboundPackets.BOSS_EVENT;
+    }
+
+    record Add(UUID id, Component title, float progress, BossBar.Color color,
+               BossBar.Overlay overlay, int flags) implements ClientboundBossEventPacket {
+        @Override
+        public void write(final PacketBuffer buf) {
+            buf.writeUuid(id).writeVarInt(0).writeComponent(title)
+                    .writeFloat(progress).writeVarInt(color.ordinal())
+                    .writeVarInt(overlay.ordinal()).writeByte((byte) flags);
+        }
+    }
+
+    record Remove(UUID id) implements ClientboundBossEventPacket {
+        @Override
+        public void write(final PacketBuffer buf) {
+            buf.writeUuid(id).writeVarInt(1);
+        }
+    }
+
+    record UpdateProgress(UUID id, float progress) implements ClientboundBossEventPacket {
+        @Override
+        public void write(final PacketBuffer buf) {
+            buf.writeUuid(id).writeVarInt(2).writeFloat(progress);
+        }
+    }
+
+    record UpdateName(UUID id, Component title) implements ClientboundBossEventPacket {
+        @Override
+        public void write(final PacketBuffer buf) {
+            buf.writeUuid(id).writeVarInt(3).writeComponent(title);
+        }
+    }
+
+    record UpdateStyle(UUID id, BossBar.Color color, BossBar.Overlay overlay) implements ClientboundBossEventPacket {
+        @Override
+        public void write(final PacketBuffer buf) {
+            buf.writeUuid(id).writeVarInt(4).writeVarInt(color.ordinal()).writeVarInt(overlay.ordinal());
+        }
+    }
+
+    record UpdateProperties(UUID id, int flags) implements ClientboundBossEventPacket {
+        @Override
+        public void write(final PacketBuffer buf) {
+            buf.writeUuid(id).writeVarInt(5).writeByte((byte) flags);
+        }
+    }
+}

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/BossBarRegistry.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/BossBarRegistry.java
@@ -1,0 +1,241 @@
+package fr.euphyllia.fidorial.server.world;
+
+import fr.euphyllia.fidorial.server.entity.player.ServerPlayer;
+import fr.euphyllia.fidorial.server.world.storage.LevelData;
+import net.kyori.adventure.bossbar.BossBar;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.text.Component;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+
+public final class BossBarRegistry {
+
+    public record BossBarEntry(
+            Key id,
+            BossBar bar,
+            boolean visible,
+            Set<UUID> players
+    ) {
+    }
+
+    private record Entry(
+            Key id,
+            BossBar bar,
+            boolean visible,
+            Set<UUID> players,
+            BossBar.Listener listener
+    ) {
+    }
+
+    private final Map<Key, Entry> registered = new ConcurrentHashMap<>();
+
+    private final LevelData levelData;
+    private final Supplier<Iterable<ServerPlayer>> onlinePlayers;
+
+    public BossBarRegistry(
+            final LevelData levelData,
+            final Supplier<Iterable<ServerPlayer>> onlinePlayers
+    ) {
+        this.levelData = levelData;
+        this.onlinePlayers = onlinePlayers;
+    }
+
+    public void register(
+            final Key id,
+            final BossBar bar,
+            final boolean visible,
+            final Set<UUID> players
+    ) {
+        if (registered.containsKey(id)) {
+            unregister(id);
+        }
+
+        final Set<UUID> immutablePlayers = Set.copyOf(players);
+
+        final BossBar.Listener listener = new BossBar.Listener() {
+            @Override
+            public void bossBarProgressChanged(
+                    final BossBar b,
+                    final float oldProgress,
+                    final float newProgress
+            ) {
+                persist(id, b, visible, immutablePlayers);
+            }
+
+            @Override
+            public void bossBarNameChanged(
+                    final BossBar b,
+                    final Component oldName,
+                    final Component newName
+            ) {
+                persist(id, b, visible, immutablePlayers);
+            }
+
+            @Override
+            public void bossBarColorChanged(
+                    final BossBar b,
+                    final BossBar.Color oldColor,
+                    final BossBar.Color newColor
+            ) {
+                persist(id, b, visible, immutablePlayers);
+            }
+
+            @Override
+            public void bossBarOverlayChanged(
+                    final BossBar b,
+                    final BossBar.Overlay oldOverlay,
+                    final BossBar.Overlay newOverlay
+            ) {
+                persist(id, b, visible, immutablePlayers);
+            }
+
+            @Override
+            public void bossBarFlagsChanged(
+                    final BossBar b,
+                    final Set<BossBar.Flag> added,
+                    final Set<BossBar.Flag> removed
+            ) {
+                persist(id, b, visible, immutablePlayers);
+            }
+        };
+
+        bar.addListener(listener);
+
+        registered.put(
+                id,
+                new Entry(
+                        id,
+                        bar,
+                        visible,
+                        immutablePlayers,
+                        listener
+                )
+        );
+
+        persist(id, bar, visible, immutablePlayers);
+
+        if (visible) {
+            for (final ServerPlayer player : onlinePlayers.get()) {
+                if (immutablePlayers.isEmpty() || immutablePlayers.contains(player.uuid())) {
+                    player.showBossBar(bar);
+                }
+            }
+        }
+    }
+
+    public void unregister(final Key id) {
+        final Entry entry = registered.remove(id);
+
+        if (entry == null) {
+            return;
+        }
+
+        entry.bar().removeListener(entry.listener());
+
+        levelData.bossBars.remove(id);
+
+        for (final ServerPlayer player : onlinePlayers.get()) {
+            player.hideBossBar(entry.bar());
+        }
+    }
+
+    public void close() {
+        for (final Entry entry : registered.values()) {
+            entry.bar().removeListener(entry.listener());
+        }
+
+        registered.clear();
+    }
+
+    public Optional<BossBar> get(final Key id) {
+        final Entry entry = registered.get(id);
+
+        return entry == null
+                ? Optional.empty()
+                : Optional.of(entry.bar());
+    }
+
+    public Optional<BossBarEntry> getEntry(final Key id) {
+        final Entry entry = registered.get(id);
+
+        if (entry == null) {
+            return Optional.empty();
+        }
+
+        return Optional.of(toPublicEntry(entry));
+    }
+
+    public Collection<BossBarEntry> entries() {
+        return registered.values()
+                .stream()
+                .map(this::toPublicEntry)
+                .toList();
+    }
+
+    private BossBarEntry toPublicEntry(final Entry entry) {
+        return new BossBarEntry(
+                entry.id(),
+                entry.bar(),
+                entry.visible(),
+                entry.players()
+        );
+    }
+
+    private void persist(
+            final Key id,
+            final BossBar bar,
+            final boolean visible,
+            final Set<UUID> players
+    ) {
+        levelData.bossBars.put(
+                id,
+                new LevelData.BossBarData(
+                        bar.name(),
+                        bar.progress(),
+                        bar.color(),
+                        bar.overlay(),
+                        bar.flags(),
+                        visible,
+                        players
+                )
+        );
+    }
+
+    public void syncTo(final ServerPlayer player) {
+        for (final Entry entry : registered.values()) {
+            if (entry.visible()
+                    && (entry.players().isEmpty()
+                    || entry.players().contains(player.uuid()))) {
+
+                player.showBossBar(entry.bar());
+            }
+        }
+    }
+
+    public void loadFromLevelData() {
+        for (final Map.Entry<Key, LevelData.BossBarData> entry : levelData.bossBars.entrySet()) {
+            final LevelData.BossBarData data = entry.getValue();
+
+            final BossBar bar = BossBar.bossBar(
+                    data.name(),
+                    data.progress(),
+                    data.color(),
+                    data.overlay(),
+                    data.flags()
+            );
+
+            register(
+                    entry.getKey(),
+                    bar,
+                    data.visible(),
+                    data.players()
+            );
+        }
+    }
+}

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/entity/AnvilEntitySerializer.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/entity/AnvilEntitySerializer.java
@@ -177,13 +177,13 @@ public class AnvilEntitySerializer {
         return list.get(index) instanceof NbtFloat(final float value) ? value : 0f;
     }
 
-    static int[] uuidToInts(final UUID uuid) {
+    public static int[] uuidToInts(final UUID uuid) {
         final long msb = uuid.getMostSignificantBits();
         final long lsb = uuid.getLeastSignificantBits();
         return new int[] {(int) (msb >> 32), (int) msb, (int) (lsb >> 32), (int) lsb};
     }
 
-    static UUID uuidFromInts(final int[] ints) {
+    public static UUID uuidFromInts(final int[] ints) {
         final long msb = ((long) ints[0] << 32) | (ints[1] & 0xFFFFFFFFL);
         final long lsb = ((long) ints[2] << 32) | (ints[3] & 0xFFFFFFFFL);
         return new UUID(msb, lsb);

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/storage/LevelData.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/storage/LevelData.java
@@ -1,24 +1,34 @@
 package fr.euphyllia.fidorial.server.world.storage;
 
 import fr.euphyllia.fidorial.server.world.chunk.AnvilChunkSerializer;
+import fr.euphyllia.fidorial.server.world.entity.AnvilEntitySerializer;
 import fr.euphyllia.fidorial.server.world.nbt.Nbt;
 import fr.euphyllia.fidorial.server.world.nbt.NbtCompound;
+import fr.euphyllia.fidorial.server.world.nbt.NbtIntArray;
 import fr.euphyllia.fidorial.server.world.nbt.NbtIo;
 import fr.euphyllia.fidorial.server.world.nbt.NbtList;
 import fr.euphyllia.fidorial.server.world.nbt.NbtType;
+import net.kyori.adventure.bossbar.BossBar;
 import net.kyori.adventure.key.Key;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
 import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 
 public class LevelData {
 
     private static final String FIDORIAL = "Fidorial";
     private static final String WORLD_CLOCKS = "WorldClocks";
+    private static final String CUSTOM_BOSS_EVENTS = "CustomBossEvents";
 
     public String levelName = "Fidorial";
     public long seed = 0L;
@@ -44,6 +54,7 @@ public class LevelData {
     public boolean doDaylightCycle = true;
 
     public final Map<Key, WorldTime> worldTimes = new LinkedHashMap<>();
+    public final Map<Key, BossBarData> bossBars = new LinkedHashMap<>();
 
     public @Nullable WorldTime worldTime(final Key dimensionId) {
         final WorldTime stored = worldTimes.get(dimensionId);
@@ -66,6 +77,17 @@ public class LevelData {
     }
 
     public record WorldTime(long worldAge, long dayTime, boolean doDaylightCycle) {
+    }
+
+    public record BossBarData(
+            Component name,
+            float progress,
+            BossBar.Color color,
+            BossBar.Overlay overlay,
+            Set<BossBar.Flag> flags,
+            boolean visible,
+            Set<UUID> players
+    ) {
     }
 
     public static LevelData read(final Path levelDat) throws IOException {
@@ -97,6 +119,7 @@ public class LevelData {
             l.doDaylightCycle = !"false".equals(gameRules.getString("doDaylightCycle"));
         }
         l.readWorldClocks(data);
+        l.readCustomBossEvents(data);
 
         final NbtCompound wgs = data.getCompound("WorldGenSettings");
         if (wgs != null) l.seed = wgs.getLong("seed");
@@ -105,28 +128,58 @@ public class LevelData {
 
     private void readWorldClocks(final NbtCompound data) {
         final NbtCompound fidorial = data.getCompound(FIDORIAL);
-        if (fidorial == null) {
-            return;
-        }
+        if (fidorial == null) return;
+
         final NbtList clocks = fidorial.getList(WORLD_CLOCKS);
-        if (clocks == null) {
-            return;
-        }
+        if (clocks == null) return;
+
         for (final Nbt entry : clocks) {
-            if (!(entry instanceof final NbtCompound clock)) {
-                continue;
-            }
+            if (!(entry instanceof final NbtCompound clock)) continue;
             final String dimension = clock.getString("Dimension");
-            if (dimension.isEmpty()) {
-                continue;
-            }
+            if (dimension.isEmpty()) continue;
             final Key key = Key.key(dimension);
-            worldTimes.put(
-                    key,
-                    new WorldTime(
-                            clock.getLong("WorldAge"),
-                            clock.getLong("DayTime"),
-                            !clock.contains("DoDaylightCycle") || clock.getBoolean("DoDaylightCycle")));
+            worldTimes.put(key, new WorldTime(
+                    clock.getLong("WorldAge"),
+                    clock.getLong("DayTime"),
+                    !clock.contains("DoDaylightCycle") || clock.getBoolean("DoDaylightCycle")));
+        }
+    }
+
+    private void readCustomBossEvents(final NbtCompound data) {
+        final NbtCompound events = data.getCompound(CUSTOM_BOSS_EVENTS);
+        if (events == null) return;
+
+        for (final String id : events.keys()) {
+            final NbtCompound bar = events.getCompound(id);
+            if (bar == null) continue;
+
+            final Set<UUID> players = new HashSet<>();
+            final NbtList playerList = bar.getList("Players");
+            if (playerList != null) {
+                for (final Nbt entry : playerList) {
+                    if (entry instanceof NbtIntArray(int[] value)) {
+                        players.add(AnvilEntitySerializer.uuidFromInts(value));
+                    }
+                }
+            }
+
+            final Set<BossBar.Flag> flags = new HashSet<>();
+            if (bar.getBoolean("DarkenScreen")) flags.add(BossBar.Flag.DARKEN_SCREEN);
+            if (bar.getBoolean("PlayBossMusic")) flags.add(BossBar.Flag.PLAY_BOSS_MUSIC);
+            if (bar.getBoolean("CreateWorldFog")) flags.add(BossBar.Flag.CREATE_WORLD_FOG);
+
+            final int max = bar.contains("Max") ? bar.getInt("Max") : 100;
+            final int value = bar.getInt("Value");
+            final float progress = max > 0 ? Math.clamp(value / (float) max, 0f, 1f) : 0f;
+
+            bossBars.put(Key.key(id), new BossBarData(
+                    GsonComponentSerializer.gson().deserialize(bar.getString("Name")),
+                    progress,
+                    BossBar.Color.valueOf(bar.getString("Color").toUpperCase(Locale.ROOT)),
+                    BossBar.Overlay.valueOf(bar.getString("Overlay").toUpperCase(Locale.ROOT)),
+                    flags,
+                    bar.getBoolean("Visible"),
+                    players));
         }
     }
 
@@ -172,6 +225,7 @@ public class LevelData {
         data.put("GameRules", gameRules);
 
         data.put(FIDORIAL, buildFidorialData());
+        data.put(CUSTOM_BOSS_EVENTS, buildCustomBossEvents());
 
         // Bordure de monde (valeurs par défaut vanilla)
         data.putDouble("BorderCenterX", 0d);
@@ -217,6 +271,36 @@ public class LevelData {
         final NbtCompound fidorial = new NbtCompound();
         fidorial.put(WORLD_CLOCKS, clocks);
         return fidorial;
+    }
+
+    // this is the framework for built-in /bossbars command which DOES persist, unlike plugin ones
+    private NbtCompound buildCustomBossEvents() {
+        final NbtCompound root = new NbtCompound();
+
+        for (final Map.Entry<Key, BossBarData> entry : bossBars.entrySet()) {
+            final BossBarData value = entry.getValue();
+            final NbtCompound bar = new NbtCompound();
+
+            final NbtList players = new NbtList(NbtType.INT_ARRAY);
+            for (final UUID uuid : value.players()) {
+                players.add(new NbtIntArray(AnvilEntitySerializer.uuidToInts(uuid)));
+            }
+            bar.put("Players", players);
+
+            bar.putString("Color", value.color().name().toLowerCase(Locale.ROOT));
+            bar.putString("Overlay", value.overlay().name().toLowerCase(Locale.ROOT));
+            bar.putBoolean("CreateWorldFog", value.flags().contains(BossBar.Flag.CREATE_WORLD_FOG));
+            bar.putBoolean("DarkenScreen", value.flags().contains(BossBar.Flag.DARKEN_SCREEN));
+            bar.putBoolean("PlayBossMusic", value.flags().contains(BossBar.Flag.PLAY_BOSS_MUSIC));
+            bar.putInt("Max", 100);
+            bar.putInt("Value", Math.round(value.progress() * 100f));
+            bar.putString("Name", GsonComponentSerializer.gson().serialize(value.name()));
+            bar.putBoolean("Visible", value.visible());
+
+            root.put(entry.getKey().asString(), bar);
+        }
+
+        return root;
     }
 
     private NbtCompound buildWorldGenSettings() {

--- a/fidorial-test-plugin/src/main/java/fr/euphyllia/fidorial/testplugin/command/ApiTestCommand.java
+++ b/fidorial-test-plugin/src/main/java/fr/euphyllia/fidorial/testplugin/command/ApiTestCommand.java
@@ -2,12 +2,15 @@ package fr.euphyllia.fidorial.testplugin.command;
 
 import com.mojang.brigadier.Command;
 import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.brigadier.exceptions.DynamicCommandExceptionType;
 import com.mojang.brigadier.tree.LiteralCommandNode;
 import fr.euphyllia.fidorial.testplugin.CounterService;
 import fr.euphyllia.fidorial.testplugin.TestPlugin;
 import fr.euphyllia.fidorial.testplugin.terrain.HillsGenerator;
 import fr.fidorial.command.CommandSender;
 import fr.fidorial.command.CommandSource;
+import fr.fidorial.command.MessageComponentSerializer;
 import fr.fidorial.command.argument.ArgumentTypes;
 import fr.fidorial.entity.Player;
 import fr.fidorial.scheduler.RegionTps;
@@ -17,6 +20,7 @@ import fr.fidorial.world.World;
 import fr.fidorial.world.WorldBuilder;
 import fr.fidorial.world.generation.WorldGenerator;
 import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.bossbar.BossBar;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.sound.Sound;
 import net.kyori.adventure.sound.SoundStop;
@@ -28,19 +32,47 @@ import net.kyori.adventure.text.format.NamedTextColor;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 import static fr.fidorial.command.Commands.argument;
 import static fr.fidorial.command.Commands.literal;
 
 public final class ApiTestCommand {
-
     private final TestPlugin plugin;
+
+    private final Map<UUID, Map<Key, BossBar>> playerBossBars = new ConcurrentHashMap<>();
 
     public ApiTestCommand(final TestPlugin plugin) {
         this.plugin = plugin;
     }
+
+    private Map<Key, BossBar> bossBarsOf(final Player player) {
+        return playerBossBars.getOrDefault(player.uuid(), Map.of());
+    }
+
+    private static final DynamicCommandExceptionType ERROR_BOSSBAR_EXISTS =
+            new DynamicCommandExceptionType(
+                    id -> MessageComponentSerializer.message().serialize(
+                            Component.translatable(
+                                    "commands.bossbar.create.failed",
+                                    Component.text(id.toString())
+                            )
+                    )
+            );
+
+    private static final DynamicCommandExceptionType ERROR_BOSSBAR_UNKNOWN =
+            new DynamicCommandExceptionType(
+                    id -> MessageComponentSerializer.message().serialize(
+                            Component.translatable(
+                                    "commands.bossbar.unknown",
+                                    Component.text(id.toString())
+                            )
+                    )
+            );
 
     public LiteralCommandNode<CommandSource> create() {
         return literal("apitest")
@@ -81,6 +113,44 @@ public final class ApiTestCommand {
                         .then(argument("key", ArgumentTypes.key()).executes(ApiTestCommand::stopSound)))
                 .then(literal("callback")
                         .executes(ctx -> clickCallback(ctx, plugin)))
+                // TODO: should become a standalone command in fidorial tbh like vanilla /bossbar, and be expanded to match vanilla args too (with our additional flags)
+                .then(literal("bossbar")
+                        .then(literal("show")
+                                .then(argument("name", ArgumentTypes.key())
+                                        .executes(this::bossBarShow)
+                                        .then(argument("progress", ArgumentTypes.floatArg(0f, 1f))
+                                                .executes(this::bossBarShowWithProgress)
+                                                .then(argument("color", ArgumentTypes.bossBarColor())
+                                                        .then(argument("overlay", ArgumentTypes.bossBarOverlay())
+                                                                .then(argument("flag", ArgumentTypes.bossBarFlag())
+                                                                        .executes(this::bossBarShowCustom)))))))
+                        .then(literal("hide")
+                                .requires(source -> {
+                                    final CommandSender sender = source.sender();
+                                    if (!(sender instanceof Player player)) {
+                                        // placeholder, the server command should support non players executors as it will need the players selected
+                                        // look at mc brigadier commands https://mcsrc.dev/1/26.2/net/minecraft/server/commands/BossBarCommands
+                                        return false;
+                                    }
+
+                                    return !bossBarsOf(player).isEmpty();
+                                })
+                                .then(argument("name", ArgumentTypes.key())
+                                        .suggests((ctx, builder) -> {
+                                            final CommandSender sender = ctx.getSource().sender();
+
+                                            if (!(sender instanceof Player player)) {
+                                                return builder.buildFuture();
+                                            }
+
+                                            bossBarsOf(player).keySet().forEach(key ->
+                                                    builder.suggest(key.asString())
+                                            );
+
+                                            return builder.buildFuture();
+                                        })
+                                        .executes(this::bossBarHide)))
+                )
                 .build();
     }
 
@@ -144,6 +214,8 @@ public final class ApiTestCommand {
         final CommandSender sender = ctx.getSource().sender();
 
         if (!(sender instanceof final Player player)) {
+            // placeholder, the server command should support non players executors as it will need the players selected
+            // look at mc brigadier commands https://mcsrc.dev/1/26.2/net/minecraft/server/commands/BossBarCommands
             msg(sender, "<red>[TestPlugin] Run this command in-game.</red>");
             return Command.SINGLE_SUCCESS;
         }
@@ -396,6 +468,112 @@ public final class ApiTestCommand {
 
         Component callbackComponent = Component.text("[Click me!]", NamedTextColor.GREEN).clickEvent(ClickEvent.callback(callback, options));
         ctx.getSource().sender().sendMessage(callbackComponent);
+        return Command.SINGLE_SUCCESS;
+    }
+
+    private int bossBarShow(final CommandContext<CommandSource> ctx) throws CommandSyntaxException {
+        return createBossBar(ctx, ctx.getArgument("name", Key.class), 1.0f);
+    }
+
+    private int bossBarShowCustom(final CommandContext<CommandSource> ctx) throws CommandSyntaxException {
+        return createBossBar(
+                ctx,
+                ctx.getArgument("name", Key.class),
+                ctx.getArgument("progress", Float.class),
+                ctx.getArgument("color", BossBar.Color.class),
+                ctx.getArgument("overlay", BossBar.Overlay.class),
+                Set.of(ctx.getArgument("flag", BossBar.Flag.class))
+        );
+    }
+
+    private int bossBarShowWithProgress(final CommandContext<CommandSource> ctx) throws CommandSyntaxException {
+        return createBossBar(ctx, ctx.getArgument("name", Key.class), ctx.getArgument("progress", Float.class));
+    }
+
+    private int createBossBar(final CommandContext<CommandSource> ctx, final Key name, final float progress) throws CommandSyntaxException {
+        return createBossBar(
+                ctx,
+                name,
+                progress,
+                BossBar.Color.RED,
+                BossBar.Overlay.PROGRESS,
+                Set.of(BossBar.Flag.DARKEN_SCREEN)
+        );
+    }
+
+    private int createBossBar(
+            final CommandContext<CommandSource> ctx,
+            final Key name,
+            final float progress,
+            final BossBar.Color color,
+            final BossBar.Overlay overlay,
+            final Set<BossBar.Flag> flags
+    ) throws CommandSyntaxException {
+        final CommandSender sender = ctx.getSource().sender();
+
+        if (!(sender instanceof final Player player)) {
+            msg(sender, "<red>[TestPlugin] Run this command in-game.</red>");
+            return Command.SINGLE_SUCCESS;
+        }
+
+        final Map<Key, BossBar> bars = playerBossBars.computeIfAbsent(
+                player.uuid(),
+                _ -> new ConcurrentHashMap<>()
+        );
+
+        if (bars.containsKey(name)) {
+            throw ERROR_BOSSBAR_EXISTS.create(name);
+        }
+
+        final BossBar bar = BossBar.bossBar(
+                Component.text("Test Boss Bar", NamedTextColor.RED),
+                Math.clamp(progress, 0.0f, 1.0f),
+                color,
+                overlay,
+                flags
+        );
+
+        bars.put(name, bar);
+        player.showBossBar(bar);
+        player.refreshCommands();
+
+        player.sendMessage(
+                Component.translatable(
+                        "commands.bossbar.create.success",
+                        Component.text(name.toString())
+                )
+        );
+
+        return Command.SINGLE_SUCCESS;
+    }
+
+    private int bossBarHide(final CommandContext<CommandSource> ctx) throws CommandSyntaxException {
+        final CommandSender sender = ctx.getSource().sender();
+
+        if (!(sender instanceof final Player player)) {
+            msg(sender, "<red>[TestPlugin] Run this command in-game.</red>");
+            return Command.SINGLE_SUCCESS;
+        }
+
+        final Key key = ctx.getArgument("name", Key.class);
+
+        final Map<Key, BossBar> bars = playerBossBars.get(player.uuid());
+        final BossBar bar = bars == null ? null : bars.remove(key);
+
+        if (bar == null) {
+            throw ERROR_BOSSBAR_UNKNOWN.create(key);
+        }
+
+        player.hideBossBar(bar);
+        player.refreshCommands();
+
+        player.sendMessage(
+                Component.translatable(
+                        "commands.bossbar.hide.success",
+                        Component.text(key.toString())
+                )
+        );
+
         return Command.SINGLE_SUCCESS;
     }
 }


### PR DESCRIPTION
This also lays the groundwork for the future bossbars command (which has persistent boss bars, saved into the level data) with `BossBarRegistry`

<img width="905" height="142" alt="image" src="https://github.com/user-attachments/assets/ccc19e2e-ce1d-4d50-ba81-ac293a93b66c" />
<img width="454" height="91" alt="image" src="https://github.com/user-attachments/assets/2ab788d4-8ac0-470b-b21d-6e43cf036570" />
