### PR TITLE
Fix ChunkViewTracker still sending packets after the connection is closed AND MANY MOREEE

### DIFF
--- a/fidorial-api/src/main/java/fr/fidorial/Server.java
+++ b/fidorial-api/src/main/java/fr/fidorial/Server.java
@@ -12,24 +12,16 @@ import fr.fidorial.translation.TranslationStore;
 import fr.fidorial.world.World;
 import fr.fidorial.world.WorldBuilder;
 import fr.fidorial.world.generation.WorldGenerator;
-import net.kyori.adventure.audience.Audience;
-import net.kyori.adventure.chat.ChatType;
-import net.kyori.adventure.chat.SignedMessage;
+import net.kyori.adventure.audience.ForwardingAudience;
 import net.kyori.adventure.key.Key;
-import net.kyori.adventure.pointer.Pointers;
 import net.kyori.adventure.text.Component;
-import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Contract;
 
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.function.Consumer;
-import java.util.function.Predicate;
 
-public interface Server /* extends ForwardingAudience */ { // we need more functions in the server to implement all the overrides properly
+public interface Server extends ForwardingAudience {
 
     /**
      * Gets the server name.
@@ -189,51 +181,4 @@ public interface Server /* extends ForwardingAudience */ { // we need more funct
     void shutdown();
 
     TranslationStore translationStore();
-
-    // remove once we extend ForwardingAudience
-
-    @ApiStatus.OverrideOnly
-    Iterable<? extends Audience> audiences();
-
-    default Pointers pointers() {
-        return Pointers.empty(); // unsupported
-    }
-
-    default Audience filterAudience(final Predicate<? super Audience> filter) {
-        List<Audience> audiences = null;
-        for (final Audience audience : this.audiences()) {
-            if (filter.test(audience)) {
-                final Audience filtered = audience.filterAudience(filter);
-                if (filtered != Audience.empty()) {
-                    if (audiences == null) {
-                        audiences = new ArrayList<>();
-                    }
-                    audiences.add(filtered);
-                }
-            }
-        }
-        return audiences != null
-                ? Audience.audience(audiences)
-                : Audience.empty();
-    }
-
-    default void forEachAudience(final Consumer<? super Audience> action) {
-        for (final Audience audience : this.audiences()) audience.forEachAudience(action);
-    }
-
-    default void sendMessage(final Component message) {
-        for (final Audience audience : this.audiences()) audience.sendMessage(message);
-    }
-
-    default void sendMessage(final Component message, final ChatType.Bound boundChatType) {
-        for (final Audience audience : this.audiences()) audience.sendMessage(message, boundChatType);
-    }
-
-    default void sendMessage(final SignedMessage signedMessage, final ChatType.Bound boundChatType) {
-        for (final Audience audience : this.audiences()) audience.sendMessage(signedMessage, boundChatType);
-    }
-
-    default void deleteMessage(final SignedMessage.Signature signature) {
-        for (final Audience audience : this.audiences()) audience.deleteMessage(signature);
-    }
 }

--- a/fidorial-api/src/main/java/fr/fidorial/entity/Entity.java
+++ b/fidorial-api/src/main/java/fr/fidorial/entity/Entity.java
@@ -4,11 +4,14 @@ import fr.fidorial.command.CommandSource;
 import fr.fidorial.world.ChunkPos;
 import fr.fidorial.world.Location;
 import fr.fidorial.world.World;
+import net.kyori.adventure.sound.Sound;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.event.HoverEvent;
+import net.kyori.adventure.text.event.HoverEventSource;
 
 import java.util.UUID;
 
-public interface Entity extends CommandSource {
+public interface Entity extends CommandSource, HoverEventSource<HoverEvent.ShowEntity>, Sound.Emitter, Sound.Source.Provider {
 
     int entityId();
 

--- a/fidorial-api/src/main/java/fr/fidorial/entity/Player.java
+++ b/fidorial-api/src/main/java/fr/fidorial/entity/Player.java
@@ -6,6 +6,7 @@ import fr.fidorial.inventory.EnderChestInventory;
 import fr.fidorial.inventory.PlayerInventory;
 import fr.fidorial.permission.PermissionHolder;
 import net.kyori.adventure.bossbar.BossBar;
+import net.kyori.adventure.text.Component;
 
 import java.util.Collection;
 import java.util.UUID;
@@ -26,7 +27,7 @@ public interface Player extends LivingEntity, PermissionHolder, CommandSource, C
         return profile().name();
     }
 
-    void kick(String reason);
+    void kick(Component reason);
 
     PlayerInventory inventory();
 

--- a/fidorial-api/src/main/java/fr/fidorial/world/World.java
+++ b/fidorial-api/src/main/java/fr/fidorial/world/World.java
@@ -2,7 +2,7 @@ package fr.fidorial.world;
 
 import fr.fidorial.entity.Entity;
 import fr.fidorial.world.time.DayNightCycle;
-import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.audience.ForwardingAudience;
 import net.kyori.adventure.key.Keyed;
 
 import java.util.Collection;
@@ -10,7 +10,7 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
-public interface World extends Keyed /* ForwardingAudience */ { // make it extend when we have enough features
+public interface World extends Keyed, ForwardingAudience {
 
     int minY();
 
@@ -49,9 +49,6 @@ public interface World extends Keyed /* ForwardingAudience */ { // make it exten
     Entity entity(UUID uuid);
 
     Entity entity(int entityId);
-
-    // to remove once we extend forwarding audience
-    Iterable<? extends Audience> audiences();
 
     CompletableFuture<Boolean> unloadChunkAsync(int chunkX, int chunkZ);
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/FidorialServer.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/FidorialServer.java
@@ -173,7 +173,7 @@ public final class FidorialServer implements Server {
             .metrics(Metrics.Factory::create)
             .create();
     private final ConsoleSender console = new ConsoleSender(this);
-    private @Nullable Iterable<? extends Audience> adventure$audiences;
+    private volatile @Nullable Iterable<? extends Audience> adventure$audiences;
 
     private @Nullable Favicon favicon = loadFavicon();
     private Component description = MiniMessage
@@ -234,8 +234,8 @@ public final class FidorialServer implements Server {
         }
         LOGGER.info("Stopping the Fidorial server...");
         events.post(new ServerStoppingEvent(this));
-        closeQuietly("plugins", pluginManager::close);
         onlinePlayers().forEach(player -> player.kick(Component.translatable("commands.stop.stopping")));
+        closeQuietly("plugins", pluginManager::close);
         closeQuietly("click callbacks", clickCallbackManager::close);
         closeQuietly("bossbars", bossBarRegistry::close);
         closeQuietly("cycle jour/nuit", dayNightEngine::close);
@@ -347,11 +347,13 @@ public final class FidorialServer implements Server {
 
     @Override
     public Iterable<? extends Audience> audiences() {
-        if (this.adventure$audiences == null) {
-            this.adventure$audiences = Iterables.concat(
+        Iterable<? extends Audience> audiences = this.adventure$audiences;
+        if (audiences == null) {
+            audiences = Iterables.concat(
                     Collections.singleton(console), onlinePlayers());
+            this.adventure$audiences = audiences;
         }
-        return this.adventure$audiences;
+        return audiences;
     }
 
     @Override
@@ -455,11 +457,7 @@ public final class FidorialServer implements Server {
 
     @Override
     public Collection<? extends Player> onlinePlayers() {
-        return connections.stream()
-                .map(ClientConnection::player)
-                .filter(Objects::nonNull)
-                .map(p -> (Player) p)
-                .toList();
+        return playerSnapshot;
     }
 
     @Override

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/FidorialServer.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/FidorialServer.java
@@ -238,7 +238,7 @@ public final class FidorialServer implements Server {
         closeQuietly("plugins", pluginManager::close);
         closeQuietly("click callbacks", clickCallbackManager::close);
         closeQuietly("bossbars", bossBarRegistry::close);
-        closeQuietly("cycle jour/nuit", dayNightEngine::close);
+        closeQuietly("day/night cycle", dayNightEngine::close);
         closeQuietly("reseau", network::shutdown);
         closeQuietly("auto-save", autoSave::shutdownNow);
         closeQuietly("ia", aiWorker::shutdown);

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/FidorialServer.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/FidorialServer.java
@@ -235,15 +235,16 @@ public final class FidorialServer implements Server {
         LOGGER.info("Stopping the Fidorial server...");
         events.post(new ServerStoppingEvent(this));
         closeQuietly("plugins", pluginManager::close);
+        onlinePlayers().forEach(player -> player.kick(Component.translatable("commands.stop.stopping")));
         closeQuietly("click callbacks", clickCallbackManager::close);
         closeQuietly("bossbars", bossBarRegistry::close);
+        closeQuietly("cycle jour/nuit", dayNightEngine::close);
         closeQuietly("reseau", network::shutdown);
         closeQuietly("auto-save", autoSave::shutdownNow);
         closeQuietly("ia", aiWorker::shutdown);
         closeQuietly("regions", regionizer::shutdown);
         closeQuietly("chunks", chunkWorker::shutdown);
         closeQuietly("meteo", weatherEngine::close);
-        closeQuietly("cycle jour/nuit", dayNightEngine::close);
         closeQuietly("monde", worldManager::close);
         closeQuietly("metriques", metrics::shutdown);
         LOGGER.info("Stop complete");

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/AbstractEntity.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/AbstractEntity.java
@@ -12,11 +12,13 @@ import fr.fidorial.entity.EntityType;
 import fr.fidorial.world.Location;
 import fr.fidorial.world.World;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.logger.slf4j.ComponentLogger;
 import org.jspecify.annotations.Nullable;
 
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.UnaryOperator;
 
 public abstract class AbstractEntity implements Entity {
 
@@ -186,5 +188,10 @@ public abstract class AbstractEntity implements Entity {
             LOGGER.error("An error occurred while teleporting the player : ", exception);
             return false;
         }
+    }
+
+    @Override
+    public HoverEvent<HoverEvent.ShowEntity> asHoverEvent(final UnaryOperator<HoverEvent.ShowEntity> op) {
+        return HoverEvent.showEntity(op.apply(HoverEvent.ShowEntity.showEntity(type().key(), uuid(), displayName())));
     }
 }

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/Category.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/Category.java
@@ -1,0 +1,27 @@
+package fr.euphyllia.fidorial.server.entity;
+
+import net.kyori.adventure.sound.Sound;
+
+public interface Category {
+
+    interface Monster extends fr.fidorial.entity.Entity {
+        @Override
+        default Sound.Source soundSource() {
+            return Sound.Source.HOSTILE;
+        }
+    }
+
+    interface Ambient extends fr.fidorial.entity.Entity {
+        @Override
+        default Sound.Source soundSource() {
+            return Sound.Source.AMBIENT;
+        }
+    }
+
+    interface Neutral extends fr.fidorial.entity.Entity {
+        @Override
+        default Sound.Source soundSource() {
+            return Sound.Source.NEUTRAL;
+        }
+    }
+}

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/Entity.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/Entity.java
@@ -1,4 +1,8 @@
 package fr.euphyllia.fidorial.server.entity;
 
-public interface Entity {
+import net.kyori.adventure.sound.Sound;
+import net.kyori.adventure.text.event.HoverEvent;
+import net.kyori.adventure.text.event.HoverEventSource;
+
+public interface Entity extends HoverEventSource<HoverEvent.ShowEntity>, Sound.Emitter, Sound.Source.Provider {
 }

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/Entity.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/Entity.java
@@ -1,8 +1,4 @@
 package fr.euphyllia.fidorial.server.entity;
 
-import net.kyori.adventure.sound.Sound;
-import net.kyori.adventure.text.event.HoverEvent;
-import net.kyori.adventure.text.event.HoverEventSource;
-
-public interface Entity extends HoverEventSource<HoverEvent.ShowEntity>, Sound.Emitter, Sound.Source.Provider {
+public interface Entity {
 }

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/ambient/Bat.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/ambient/Bat.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.ambient;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class Bat extends Mob {
+public final class Bat extends Mob implements Category.Ambient {
 
     public static final float MAX_HEALTH = 6f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/creature/Allay.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/creature/Allay.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.creature;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class Allay extends Mob {
+public final class Allay extends Mob implements Category.Neutral {
 
     public static final float MAX_HEALTH = 20f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/creature/Armadillo.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/creature/Armadillo.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.creature;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class Armadillo extends Mob {
+public final class Armadillo extends Mob implements Category.Neutral {
 
     public static final float MAX_HEALTH = 12f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/creature/Bee.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/creature/Bee.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.creature;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class Bee extends Mob {
+public final class Bee extends Mob implements Category.Neutral {
 
     public static final float MAX_HEALTH = 10f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/creature/Camel.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/creature/Camel.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.creature;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class Camel extends Mob {
+public final class Camel extends Mob implements Category.Neutral {
 
     public static final float MAX_HEALTH = 32f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/creature/Cat.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/creature/Cat.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.creature;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class Cat extends Mob {
+public final class Cat extends Mob implements Category.Neutral {
 
     public static final float MAX_HEALTH = 10f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/creature/Chicken.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/creature/Chicken.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.creature;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.ai.goal.LookAtTargetGoal;
 import fr.euphyllia.fidorial.server.entity.ai.goal.RandomStrollGoal;
@@ -15,7 +16,7 @@ import net.kyori.adventure.sound.Sound;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 
-public final class Chicken extends PathfinderMob {
+public final class Chicken extends PathfinderMob implements Category.Neutral {
 
     public static final float MAX_HEALTH = 4f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/creature/Cow.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/creature/Cow.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.creature;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class Cow extends Mob {
+public final class Cow extends Mob implements Category.Neutral {
 
     public static final float MAX_HEALTH = 10f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/creature/Donkey.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/creature/Donkey.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.creature;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class Donkey extends Mob {
+public final class Donkey extends Mob implements Category.Neutral {
 
     public static final float MAX_HEALTH = 15f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/creature/Fox.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/creature/Fox.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.creature;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class Fox extends Mob {
+public final class Fox extends Mob implements Category.Neutral {
 
     public static final float MAX_HEALTH = 10f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/creature/Frog.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/creature/Frog.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.creature;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class Frog extends Mob {
+public final class Frog extends Mob implements Category.Neutral {
 
     public static final float MAX_HEALTH = 10f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/creature/Goat.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/creature/Goat.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.creature;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class Goat extends Mob {
+public final class Goat extends Mob implements Category.Neutral {
 
     public static final float MAX_HEALTH = 10f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/creature/HappyGhast.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/creature/HappyGhast.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.creature;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class HappyGhast extends Mob {
+public final class HappyGhast extends Mob implements Category.Neutral {
 
     public static final float MAX_HEALTH = 20f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/creature/Horse.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/creature/Horse.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.creature;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class Horse extends Mob {
+public final class Horse extends Mob implements Category.Neutral {
 
     public static final float MAX_HEALTH = 15f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/creature/Llama.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/creature/Llama.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.creature;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class Llama extends Mob {
+public final class Llama extends Mob implements Category.Neutral {
 
     public static final float MAX_HEALTH = 15f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/creature/Mooshroom.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/creature/Mooshroom.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.creature;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class Mooshroom extends Mob {
+public final class Mooshroom extends Mob implements Category.Neutral {
 
     public static final float MAX_HEALTH = 10f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/creature/Mule.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/creature/Mule.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.creature;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class Mule extends Mob {
+public final class Mule extends Mob implements Category.Neutral {
 
     public static final float MAX_HEALTH = 15f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/creature/Ocelot.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/creature/Ocelot.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.creature;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class Ocelot extends Mob {
+public final class Ocelot extends Mob implements Category.Neutral {
 
     public static final float MAX_HEALTH = 10f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/creature/Panda.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/creature/Panda.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.creature;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class Panda extends Mob {
+public final class Panda extends Mob implements Category.Neutral {
 
     public static final float MAX_HEALTH = 20f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/creature/Parrot.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/creature/Parrot.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.creature;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class Parrot extends Mob {
+public final class Parrot extends Mob implements Category.Neutral {
 
     public static final float MAX_HEALTH = 6f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/creature/Pig.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/creature/Pig.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.creature;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class Pig extends Mob {
+public final class Pig extends Mob implements Category.Neutral {
 
     public static final float MAX_HEALTH = 10f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/creature/PolarBear.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/creature/PolarBear.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.creature;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class PolarBear extends Mob {
+public final class PolarBear extends Mob implements Category.Neutral {
 
     public static final float MAX_HEALTH = 30f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/creature/Rabbit.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/creature/Rabbit.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.creature;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class Rabbit extends Mob {
+public final class Rabbit extends Mob implements Category.Neutral {
 
     public static final float MAX_HEALTH = 3f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/creature/Sheep.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/creature/Sheep.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.creature;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class Sheep extends Mob {
+public final class Sheep extends Mob implements Category.Neutral {
 
     public static final float MAX_HEALTH = 8f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/creature/SkeletonHorse.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/creature/SkeletonHorse.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.creature;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class SkeletonHorse extends Mob {
+public final class SkeletonHorse extends Mob implements Category.Monster {
 
     public static final float MAX_HEALTH = 15f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/creature/Sniffer.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/creature/Sniffer.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.creature;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class Sniffer extends Mob {
+public final class Sniffer extends Mob implements Category.Neutral {
 
     public static final float MAX_HEALTH = 14f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/creature/Strider.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/creature/Strider.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.creature;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class Strider extends Mob {
+public final class Strider extends Mob implements Category.Neutral {
 
     public static final float MAX_HEALTH = 20f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/creature/SulfurCube.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/creature/SulfurCube.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.creature;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class SulfurCube extends Mob {
+public final class SulfurCube extends Mob implements Category.Neutral {
 
     public static final float MAX_HEALTH = 8f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/creature/TraderLlama.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/creature/TraderLlama.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.creature;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class TraderLlama extends Mob {
+public final class TraderLlama extends Mob implements Category.Neutral {
 
     public static final float MAX_HEALTH = 15f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/creature/Turtle.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/creature/Turtle.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.creature;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class Turtle extends Mob {
+public final class Turtle extends Mob implements Category.Neutral {
 
     public static final float MAX_HEALTH = 30f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/creature/WanderingTrader.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/creature/WanderingTrader.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.creature;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class WanderingTrader extends Mob {
+public final class WanderingTrader extends Mob implements Category.Neutral {
 
     public static final float MAX_HEALTH = 20f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/creature/Wolf.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/creature/Wolf.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.creature;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class Wolf extends Mob {
+public final class Wolf extends Mob implements Category.Neutral {
 
     public static final float MAX_HEALTH = 8f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/creature/ZombieHorse.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/creature/ZombieHorse.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.creature;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class ZombieHorse extends Mob {
+public final class ZombieHorse extends Mob implements Category.Monster {
 
     public static final float MAX_HEALTH = 15f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/misc/CopperGolem.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/misc/CopperGolem.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.misc;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class CopperGolem extends Mob {
+public final class CopperGolem extends Mob implements Category.Neutral {
 
     public static final float MAX_HEALTH = 12f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/misc/IronGolem.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/misc/IronGolem.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.misc;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class IronGolem extends Mob {
+public final class IronGolem extends Mob implements Category.Neutral {
 
     public static final float MAX_HEALTH = 100f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/misc/SnowGolem.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/misc/SnowGolem.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.misc;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class SnowGolem extends Mob {
+public final class SnowGolem extends Mob implements Category.Neutral {
 
     public static final float MAX_HEALTH = 4f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/misc/Villager.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/misc/Villager.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.misc;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class Villager extends Mob {
+public final class Villager extends Mob implements Category.Neutral {
 
     public static final float MAX_HEALTH = 20f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Blaze.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Blaze.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.monster;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class Blaze extends Mob {
+public final class Blaze extends Mob implements Category.Monster {
 
     public static final float MAX_HEALTH = 20f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Bogged.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Bogged.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.monster;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class Bogged extends Mob {
+public final class Bogged extends Mob implements Category.Monster {
 
     public static final float MAX_HEALTH = 16f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Breeze.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Breeze.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.monster;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class Breeze extends Mob {
+public final class Breeze extends Mob implements Category.Monster {
 
     public static final float MAX_HEALTH = 30f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/CamelHusk.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/CamelHusk.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.monster;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class CamelHusk extends Mob {
+public final class CamelHusk extends Mob implements Category.Monster {
 
     public static final float MAX_HEALTH = 32f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/CaveSpider.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/CaveSpider.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.monster;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class CaveSpider extends Mob {
+public final class CaveSpider extends Mob implements Category.Monster {
 
     public static final float MAX_HEALTH = 12f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Creaking.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Creaking.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.monster;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class Creaking extends Mob {
+public final class Creaking extends Mob implements Category.Monster {
 
     public static final float MAX_HEALTH = 1f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Creeper.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Creeper.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.monster;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.ai.goal.ChaseTargetGoal;
 import fr.euphyllia.fidorial.server.entity.ai.goal.LookAtTargetGoal;
@@ -18,7 +19,7 @@ import net.kyori.adventure.text.logger.slf4j.ComponentLogger;
 
 import java.util.UUID;
 
-public final class Creeper extends PathfinderMob {
+public final class Creeper extends PathfinderMob implements Category.Monster {
 
     public static final float MAX_HEALTH = 20f;
     private static final ComponentLogger LOGGER = ComponentLogger.logger(Creeper.class);

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Drowned.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Drowned.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.monster;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class Drowned extends Mob {
+public final class Drowned extends Mob implements Category.Monster {
 
     public static final float MAX_HEALTH = 20f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/ElderGuardian.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/ElderGuardian.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.monster;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class ElderGuardian extends Mob {
+public final class ElderGuardian extends Mob implements Category.Monster {
 
     public static final float MAX_HEALTH = 80f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/EnderDragon.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/EnderDragon.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.monster;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class EnderDragon extends Mob {
+public final class EnderDragon extends Mob implements Category.Monster {
 
     public static final float MAX_HEALTH = 200f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Enderman.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Enderman.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.monster;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class Enderman extends Mob {
+public final class Enderman extends Mob implements Category.Monster {
 
     public static final float MAX_HEALTH = 40f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Endermite.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Endermite.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.monster;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class Endermite extends Mob {
+public final class Endermite extends Mob implements Category.Monster {
 
     public static final float MAX_HEALTH = 8f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Evoker.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Evoker.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.monster;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class Evoker extends Mob {
+public final class Evoker extends Mob implements Category.Monster {
 
     public static final float MAX_HEALTH = 24f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Ghast.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Ghast.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.monster;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class Ghast extends Mob {
+public final class Ghast extends Mob implements Category.Monster {
 
     public static final float MAX_HEALTH = 10f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Giant.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Giant.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.monster;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class Giant extends Mob {
+public final class Giant extends Mob implements Category.Monster {
 
     public static final float MAX_HEALTH = 100f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Guardian.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Guardian.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.monster;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class Guardian extends Mob {
+public final class Guardian extends Mob implements Category.Monster {
 
     public static final float MAX_HEALTH = 30f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Hoglin.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Hoglin.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.monster;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class Hoglin extends Mob {
+public final class Hoglin extends Mob implements Category.Monster {
 
     public static final float MAX_HEALTH = 40f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Husk.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Husk.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.monster;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class Husk extends Mob {
+public final class Husk extends Mob implements Category.Monster {
 
     public static final float MAX_HEALTH = 20f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Illusioner.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Illusioner.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.monster;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class Illusioner extends Mob {
+public final class Illusioner extends Mob implements Category.Monster {
 
     public static final float MAX_HEALTH = 32f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/MagmaCube.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/MagmaCube.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.monster;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class MagmaCube extends Mob {
+public final class MagmaCube extends Mob implements Category.Monster {
 
     public static final float MAX_HEALTH = 16f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Parched.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Parched.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.monster;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class Parched extends Mob {
+public final class Parched extends Mob implements Category.Monster {
 
     public static final float MAX_HEALTH = 16f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Phantom.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Phantom.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.monster;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class Phantom extends Mob {
+public final class Phantom extends Mob implements Category.Monster {
 
     public static final float MAX_HEALTH = 20f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Piglin.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Piglin.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.monster;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class Piglin extends Mob {
+public final class Piglin extends Mob implements Category.Monster {
 
     public static final float MAX_HEALTH = 16f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/PiglinBrute.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/PiglinBrute.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.monster;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class PiglinBrute extends Mob {
+public final class PiglinBrute extends Mob implements Category.Monster {
 
     public static final float MAX_HEALTH = 50f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Pillager.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Pillager.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.monster;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class Pillager extends Mob {
+public final class Pillager extends Mob implements Category.Monster {
 
     public static final float MAX_HEALTH = 24f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Ravager.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Ravager.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.monster;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class Ravager extends Mob {
+public final class Ravager extends Mob implements Category.Monster {
 
     public static final float MAX_HEALTH = 100f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Shulker.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Shulker.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.monster;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class Shulker extends Mob {
+public final class Shulker extends Mob implements Category.Monster {
 
     public static final float MAX_HEALTH = 30f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Silverfish.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Silverfish.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.monster;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class Silverfish extends Mob {
+public final class Silverfish extends Mob implements Category.Monster {
 
     public static final float MAX_HEALTH = 8f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Skeleton.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Skeleton.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.monster;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class Skeleton extends Mob {
+public final class Skeleton extends Mob implements Category.Monster {
 
     public static final float MAX_HEALTH = 20f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Slime.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Slime.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.monster;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class Slime extends Mob {
+public final class Slime extends Mob implements Category.Monster {
 
     public static final float MAX_HEALTH = 16f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Spider.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Spider.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.monster;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class Spider extends Mob {
+public final class Spider extends Mob implements Category.Monster {
 
     public static final float MAX_HEALTH = 16f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Stray.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Stray.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.monster;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class Stray extends Mob {
+public final class Stray extends Mob implements Category.Monster {
 
     public static final float MAX_HEALTH = 20f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Vex.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Vex.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.monster;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class Vex extends Mob {
+public final class Vex extends Mob implements Category.Monster {
 
     public static final float MAX_HEALTH = 14f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Vindicator.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Vindicator.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.monster;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class Vindicator extends Mob {
+public final class Vindicator extends Mob implements Category.Monster {
 
     public static final float MAX_HEALTH = 24f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Warden.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Warden.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.monster;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class Warden extends Mob {
+public final class Warden extends Mob implements Category.Monster {
 
     public static final float MAX_HEALTH = 500f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Witch.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Witch.java
@@ -5,10 +5,8 @@ import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
 import fr.fidorial.world.World;
-import net.kyori.adventure.text.event.HoverEvent;
 
 import java.util.UUID;
-import java.util.function.UnaryOperator;
 
 public final class Witch extends Mob implements Category.Monster {
 
@@ -16,10 +14,5 @@ public final class Witch extends Mob implements Category.Monster {
 
     public Witch(int entityId, World world, Location location) {
         super(entityId, UUID.randomUUID(), EntityTypes.WITCH, world, location, MAX_HEALTH);
-    }
-
-    @Override
-    public HoverEvent<HoverEvent.ShowEntity> asHoverEvent(UnaryOperator<HoverEvent.ShowEntity> op) {
-        return null;
     }
 }

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Witch.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Witch.java
@@ -1,17 +1,25 @@
 package fr.euphyllia.fidorial.server.entity.mob.monster;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
 import fr.fidorial.world.World;
+import net.kyori.adventure.text.event.HoverEvent;
 
 import java.util.UUID;
+import java.util.function.UnaryOperator;
 
-public final class Witch extends Mob {
+public final class Witch extends Mob implements Category.Monster {
 
     public static final float MAX_HEALTH = 26f;
 
     public Witch(int entityId, World world, Location location) {
         super(entityId, UUID.randomUUID(), EntityTypes.WITCH, world, location, MAX_HEALTH);
+    }
+
+    @Override
+    public HoverEvent<HoverEvent.ShowEntity> asHoverEvent(UnaryOperator<HoverEvent.ShowEntity> op) {
+        return null;
     }
 }

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Wither.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Wither.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.monster;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class Wither extends Mob {
+public final class Wither extends Mob implements Category.Monster {
 
     public static final float MAX_HEALTH = 300f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/WitherSkeleton.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/WitherSkeleton.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.monster;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class WitherSkeleton extends Mob {
+public final class WitherSkeleton extends Mob implements Category.Monster {
 
     public static final float MAX_HEALTH = 20f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Zoglin.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Zoglin.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.monster;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class Zoglin extends Mob {
+public final class Zoglin extends Mob implements Category.Monster {
 
     public static final float MAX_HEALTH = 40f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Zombie.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/Zombie.java
@@ -1,6 +1,7 @@
 package fr.euphyllia.fidorial.server.entity.mob.monster;
 
 import fr.euphyllia.fidorial.server.FidorialServer;
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.ai.BlockView;
 import fr.euphyllia.fidorial.server.entity.ai.Damage;
@@ -28,7 +29,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 
-public class Zombie extends PathfinderMob {
+public class Zombie extends PathfinderMob implements Category.Monster {
 
     public static final float MAX_HEALTH = 20f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/ZombieNautilus.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/ZombieNautilus.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.monster;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class ZombieNautilus extends Mob {
+public final class ZombieNautilus extends Mob implements Category.Monster {
 
     public static final float MAX_HEALTH = 15f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/ZombieVillager.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/ZombieVillager.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.monster;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class ZombieVillager extends Mob {
+public final class ZombieVillager extends Mob implements Category.Monster {
 
     public static final float MAX_HEALTH = 20f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/ZombifiedPiglin.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/monster/ZombifiedPiglin.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.monster;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class ZombifiedPiglin extends Mob {
+public final class ZombifiedPiglin extends Mob implements Category.Monster {
 
     public static final float MAX_HEALTH = 20f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/water_creature/Axolotl.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/water_creature/Axolotl.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.water_creature;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class Axolotl extends Mob {
+public final class Axolotl extends Mob implements Category.Neutral {
 
     public static final float MAX_HEALTH = 14f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/water_creature/Cod.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/water_creature/Cod.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.water_creature;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class Cod extends Mob {
+public final class Cod extends Mob implements Category.Neutral {
 
     public static final float MAX_HEALTH = 3f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/water_creature/Dolphin.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/water_creature/Dolphin.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.water_creature;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class Dolphin extends Mob {
+public final class Dolphin extends Mob implements Category.Neutral {
 
     public static final float MAX_HEALTH = 10f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/water_creature/GlowSquid.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/water_creature/GlowSquid.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.water_creature;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class GlowSquid extends Mob {
+public final class GlowSquid extends Mob implements Category.Neutral {
 
     public static final float MAX_HEALTH = 10f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/water_creature/Nautilus.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/water_creature/Nautilus.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.water_creature;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class Nautilus extends Mob {
+public final class Nautilus extends Mob implements Category.Neutral {
 
     public static final float MAX_HEALTH = 15f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/water_creature/Pufferfish.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/water_creature/Pufferfish.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.water_creature;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class Pufferfish extends Mob {
+public final class Pufferfish extends Mob implements Category.Neutral {
 
     public static final float MAX_HEALTH = 3f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/water_creature/Salmon.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/water_creature/Salmon.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.water_creature;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class Salmon extends Mob {
+public final class Salmon extends Mob implements Category.Neutral {
 
     public static final float MAX_HEALTH = 3f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/water_creature/Squid.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/water_creature/Squid.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.water_creature;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class Squid extends Mob {
+public final class Squid extends Mob implements Category.Neutral {
 
     public static final float MAX_HEALTH = 10f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/water_creature/Tadpole.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/water_creature/Tadpole.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.water_creature;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class Tadpole extends Mob {
+public final class Tadpole extends Mob implements Category.Neutral {
 
     public static final float MAX_HEALTH = 6f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/water_creature/TropicalFish.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/water_creature/TropicalFish.java
@@ -1,5 +1,6 @@
 package fr.euphyllia.fidorial.server.entity.mob.water_creature;
 
+import fr.euphyllia.fidorial.server.entity.Category;
 import fr.euphyllia.fidorial.server.entity.EntityTypes;
 import fr.euphyllia.fidorial.server.entity.mob.Mob;
 import fr.fidorial.world.Location;
@@ -7,7 +8,7 @@ import fr.fidorial.world.World;
 
 import java.util.UUID;
 
-public final class TropicalFish extends Mob {
+public final class TropicalFish extends Mob implements Category.Neutral {
 
     public static final float MAX_HEALTH = 3f;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/player/ServerPlayer.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/player/ServerPlayer.java
@@ -281,6 +281,11 @@ public final class ServerPlayer extends AbstractEntity implements Player, Permis
         connection.send(new ClientboundStopSoundPacket(stop.source(), stop.sound()));
     }
 
+    @Override
+    public Sound.Source soundSource() {
+        return Sound.Source.PLAYER;
+    }
+
     private record BossBarEntry(UUID id, BossBar.Listener listener) {
     }
     private final Map<BossBar, BossBarEntry> activeBossBars = new ConcurrentHashMap<>();

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/player/ServerPlayer.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/player/ServerPlayer.java
@@ -272,7 +272,7 @@ public final class ServerPlayer extends AbstractEntity implements Player, Permis
         } else if (emitter instanceof final Entity entity) {
             connection.send(new ClientboundSoundEntityPacket(sound, entity.entityId()));
         } else {
-            playSound(sound);
+            throw new IllegalArgumentException("Sound emitter must be an Entity or self(), but was: " + emitter);
         }
     }
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/player/ServerPlayer.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/player/ServerPlayer.java
@@ -341,7 +341,7 @@ public final class ServerPlayer extends AbstractEntity implements Player, Permis
     }
 
     @Override
-    public void kick(final String reason) {
+    public void kick(final Component reason) {
         connection.disconnect(reason);
     }
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/ClientConnection.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/ClientConnection.java
@@ -16,6 +16,7 @@ import fr.euphyllia.fidorial.server.network.protocol.ProtocolMap;
 import fr.euphyllia.fidorial.server.network.protocol.packet.ClientboundPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.ServerboundPackets;
 import fr.euphyllia.fidorial.server.network.protocol.packet.clientbound.login.ClientboundLoginDisconnectPacket;
+import fr.euphyllia.fidorial.server.network.protocol.packet.clientbound.play.ClientboundDisconnectPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.clientbound.play.ClientboundKeepAlivePacket;
 import fr.euphyllia.fidorial.server.world.ServerWorld;
 import fr.fidorial.entity.PlayerProfile;
@@ -30,6 +31,7 @@ import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.logger.slf4j.ComponentLogger;
 import org.jspecify.annotations.Nullable;
 
@@ -118,12 +120,17 @@ public final class ClientConnection extends SimpleChannelInboundHandler<ByteBuf>
         write(packet).addListener(ChannelFutureListener.CLOSE);
     }
 
-    public void disconnect(final String reason) {
+    public void disconnect(final Component reason) {
         if (state == ConnectionState.LOGIN) {
-            sendAndClose(ClientboundLoginDisconnectPacket.ofText(reason));
+            sendAndClose(ClientboundLoginDisconnectPacket.ofComponent(reason));
         } else {
-            LOGGER.info("Disconnection of {}: {}", username, reason);
-            close();
+            LOGGER.info(
+                    Component.text("Disconnection of ")
+                            .append(Component.text(username == null ? "<unknown>" : username)) // shouldn't ever be null but idea doesn't want to shut up
+                            .append(Component.text(": "))
+                            .append(reason)
+            );
+            sendAndClose(new ClientboundDisconnectPacket(reason));
         }
     }
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/listener/LoginPacketHandler.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/listener/LoginPacketHandler.java
@@ -132,7 +132,7 @@ public final class LoginPacketHandler implements LoginPacketListener {
         try {
             final byte[] token = EncryptionUtils.decryptRsa(server.keyPair().getPrivate(), packet.encryptedToken());
             if (!Arrays.equals(token, verifyToken)) {
-                disconnect("Verify token invalide");
+                disconnect(Component.translatable("disconnect.loginFailedInfo.invalidSession"));
                 return;
             }
             final byte[] sharedSecret = EncryptionUtils.decryptRsa(server.keyPair().getPrivate(), packet.encryptedSecret());
@@ -145,7 +145,7 @@ public final class LoginPacketHandler implements LoginPacketListener {
             Thread.startVirtualThread(() -> authenticate(username, serverHash));
         } catch (final Exception e) {
             LOGGER.warn("Echec du chiffrement pour {}", pendingUsername, e);
-            connection.close();
+            disconnect(Component.translatable("disconnect.packetError"));
         }
     }
 
@@ -154,7 +154,7 @@ public final class LoginPacketHandler implements LoginPacketListener {
             final Optional<GameProfile> profile = server.sessionService().hasJoined(username, serverHash);
             connection.execute(() -> {
                 if (profile.isEmpty()) {
-                    disconnect("Mojang authentication refused");
+                    disconnect(Component.translatable("disconnect.loginFailedInfo.invalidSession"));
                 } else {
                     enableCompression();
                     sendLoginSuccess(profile.get());
@@ -162,7 +162,7 @@ public final class LoginPacketHandler implements LoginPacketListener {
             });
         } catch (final Exception e) {
             LOGGER.warn("Mojang session unreachable for {}", username, e);
-            connection.execute(() -> disconnect("Authentication servers unavailable"));
+            connection.execute(() -> disconnect(Component.translatable("disconnect.loginFailedInfo.serversUnavailable")));
         }
     }
 
@@ -190,7 +190,7 @@ public final class LoginPacketHandler implements LoginPacketListener {
     public void handleLoginAcknowledged(final ServerboundLoginAcknowledgedPacket packet) {
         if (!loginComplete || connection.profile() == null) {
             LOGGER.warn("login_acknowledged refuses for {}: login not completed", pendingUsername);
-            disconnect("Login not completed");
+            disconnect(Component.translatable("disconnect.packetError"));
             return;
 
         }
@@ -199,5 +199,9 @@ public final class LoginPacketHandler implements LoginPacketListener {
 
     private void disconnect(final String reason) {
         connection.sendAndClose(ClientboundLoginDisconnectPacket.ofComponent(Component.text(reason)));
+    }
+
+    private void disconnect(final Component reason) {
+        connection.sendAndClose(ClientboundLoginDisconnectPacket.ofComponent(reason));
     }
 }

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/listener/LoginPacketHandler.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/listener/LoginPacketHandler.java
@@ -6,7 +6,6 @@ import fr.euphyllia.fidorial.server.FidorialServer;
 import fr.euphyllia.fidorial.server.ServerConfig;
 import fr.euphyllia.fidorial.server.network.ClientConnection;
 import fr.euphyllia.fidorial.server.network.ConnectionState;
-import fr.euphyllia.fidorial.server.network.proxy.VelocityForwarding;
 import fr.euphyllia.fidorial.server.network.protocol.ProtocolConstants;
 import fr.euphyllia.fidorial.server.network.protocol.packet.clientbound.login.ClientboundCustomQueryPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.clientbound.login.ClientboundHelloPacket;
@@ -18,7 +17,9 @@ import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.login.Se
 import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.login.ServerboundHelloPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.login.ServerboundKeyPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.login.ServerboundLoginAcknowledgedPacket;
+import fr.euphyllia.fidorial.server.network.proxy.VelocityForwarding;
 import fr.fidorial.entity.PlayerProfile;
+import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.logger.slf4j.ComponentLogger;
 import org.jspecify.annotations.Nullable;
 
@@ -197,6 +198,6 @@ public final class LoginPacketHandler implements LoginPacketListener {
     }
 
     private void disconnect(final String reason) {
-        connection.sendAndClose(ClientboundLoginDisconnectPacket.ofText(reason));
+        connection.sendAndClose(ClientboundLoginDisconnectPacket.ofComponent(Component.text(reason)));
     }
 }

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/listener/PlayPacketHandler.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/listener/PlayPacketHandler.java
@@ -8,7 +8,6 @@ import fr.euphyllia.fidorial.server.entity.player.ServerPlayer;
 import fr.euphyllia.fidorial.server.inventory.ContainerMenu;
 import fr.euphyllia.fidorial.server.inventory.EnderChestMenu;
 import fr.euphyllia.fidorial.server.network.ClientConnection;
-import fr.euphyllia.fidorial.server.network.session.ChunkViewTracker;
 import fr.euphyllia.fidorial.server.network.protocol.packet.clientbound.play.ClientboundBlockChangedAckPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.clientbound.play.ClientboundBlockEventPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.clientbound.play.ClientboundCommandSuggestionsPacket;
@@ -41,6 +40,7 @@ import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.play.Ser
 import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.play.ServerboundSetCarriedItemPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.play.ServerboundSetCreativeModeSlotPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.play.ServerboundUseItemOnPacket;
+import fr.euphyllia.fidorial.server.network.session.ChunkViewTracker;
 import fr.euphyllia.fidorial.server.registry.Registry;
 import fr.euphyllia.fidorial.server.registry.RegistryHolder;
 import fr.euphyllia.fidorial.server.world.ChunkNetworkSerializer;
@@ -120,6 +120,7 @@ public final class PlayPacketHandler implements PlayPacketListener {
     @Override
     public void onDisconnect() {
         if (chunkView != null) {
+            chunkView.close();
             chunkView.world().removeViewer(chunkView);
             chunkView = null;
         }
@@ -568,6 +569,7 @@ public final class PlayPacketHandler implements PlayPacketListener {
             throw new RuntimeException("Attempt to teleport a player who does not exist!");
         }
         if (chunkView != null) {
+            chunkView.close();
             from.removeViewer(chunkView);
             chunkView = null;
         }

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/nbt/ComponentResolver.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/nbt/ComponentResolver.java
@@ -6,7 +6,6 @@ import fr.fidorial.command.CommandSource;
 import fr.fidorial.entity.Entity;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.SelectorComponent;
-import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.format.NamedTextColor;
 
 import java.util.ArrayList;
@@ -59,12 +58,7 @@ public final class ComponentResolver {
         for (int i = 0; i < matches.size(); i++) {
             Entity entity = matches.get(i);
 
-            Component name = entity.displayName()
-                    .hoverEvent(HoverEvent.showEntity(
-                            entity.type().key(),
-                            entity.uuid(),
-                            entity.displayName()
-                    ));
+            Component name = entity.displayName().hoverEvent(entity.asHoverEvent());
 
             if (i != 0) {
                 result = result.append(separator);

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/protocol/packet/clientbound/login/ClientboundLoginDisconnectPacket.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/protocol/packet/clientbound/login/ClientboundLoginDisconnectPacket.java
@@ -3,11 +3,12 @@ package fr.euphyllia.fidorial.server.network.protocol.packet.clientbound.login;
 import fr.euphyllia.fidorial.server.network.PacketBuffer;
 import fr.euphyllia.fidorial.server.network.protocol.catalog.LoginClientboundPackets;
 import fr.euphyllia.fidorial.server.network.protocol.packet.ClientboundPacket;
+import net.kyori.adventure.text.Component;
 
-public record ClientboundLoginDisconnectPacket(String reasonJson) implements ClientboundPacket {
+public record ClientboundLoginDisconnectPacket(Component reason) implements ClientboundPacket {
 
-    public static ClientboundLoginDisconnectPacket ofText(String text) {
-        return new ClientboundLoginDisconnectPacket("{\"text\":\"" + text + "\"}");
+    public static ClientboundLoginDisconnectPacket ofComponent(Component reason) {
+        return new ClientboundLoginDisconnectPacket(reason);
     }
 
     @Override
@@ -17,6 +18,6 @@ public record ClientboundLoginDisconnectPacket(String reasonJson) implements Cli
 
     @Override
     public void write(PacketBuffer buf) {
-        buf.writeString(reasonJson);
+        buf.writeComponent(reason);
     }
 }

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/protocol/packet/clientbound/play/ClientboundDisconnectPacket.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/protocol/packet/clientbound/play/ClientboundDisconnectPacket.java
@@ -1,0 +1,19 @@
+package fr.euphyllia.fidorial.server.network.protocol.packet.clientbound.play;
+
+import fr.euphyllia.fidorial.server.network.PacketBuffer;
+import fr.euphyllia.fidorial.server.network.protocol.catalog.PlayClientboundPackets;
+import fr.euphyllia.fidorial.server.network.protocol.packet.ClientboundPacket;
+import net.kyori.adventure.text.Component;
+
+public record ClientboundDisconnectPacket(Component reason) implements ClientboundPacket {
+
+    @Override
+    public String name() {
+        return PlayClientboundPackets.DISCONNECT;
+    }
+
+    @Override
+    public void write(PacketBuffer buf) {
+        buf.writeComponent(reason);
+    }
+}

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/session/ChunkViewTracker.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/session/ChunkViewTracker.java
@@ -27,6 +27,7 @@ public final class ChunkViewTracker implements ChunkViewSource {
     private final ServerWorld world;
     private final ChunkNetworkSerializer serializer;
     private final int radius;
+    private volatile boolean closed;
 
     private final Object lock = new Object();
     private final Set<Long> sent = new HashSet<>();
@@ -59,6 +60,9 @@ public final class ChunkViewTracker implements ChunkViewSource {
 
     public void init(final ChunkPos center) {
         synchronized (lock) {
+            if (closed) {
+                return;
+            }
             centerX = center.x();
             centerZ = center.z();
         }
@@ -68,6 +72,9 @@ public final class ChunkViewTracker implements ChunkViewSource {
 
     public boolean moveTo(final int chunkX, final int chunkZ) {
         synchronized (lock) {
+            if (closed) {
+                return false;
+            }
             if (chunkX == centerX && chunkZ == centerZ) {
                 return false;
             }
@@ -80,6 +87,11 @@ public final class ChunkViewTracker implements ChunkViewSource {
     }
 
     private void stream(final int centerX, final int centerZ) {
+        synchronized (lock) {
+            if (closed) {
+                return;
+            }
+        }
         forgetOutOfRange(centerX, centerZ);
         requestInRange(centerX, centerZ);
     }
@@ -126,6 +138,11 @@ public final class ChunkViewTracker implements ChunkViewSource {
         final long key = ChunkPos.chunkKey(cx, cz);
         synchronized (lock) {
             pending.remove(key);
+
+            if (closed) {
+                return;
+            }
+
             if (error != null) {
                 LOGGER.error("Unable to load chunk {},{} for {}", cx, cz, connection.username(), error);
                 return;
@@ -135,6 +152,11 @@ public final class ChunkViewTracker implements ChunkViewSource {
                 return;
             }
         }
+
+        if (closed) {
+            return;
+        }
+
         connection.send(new ClientboundLevelChunkWithLightPacket(serializer, column));
     }
 
@@ -155,6 +177,9 @@ public final class ChunkViewTracker implements ChunkViewSource {
     @Override
     public void collectViewedChunks(final LongConsumer keys) {
         synchronized (lock) {
+            if (closed) {
+                return;
+            }
             emit(sent, keys);
             emit(pending, keys);
         }
@@ -163,6 +188,17 @@ public final class ChunkViewTracker implements ChunkViewSource {
     public int sentCount() {
         synchronized (lock) {
             return sent.size();
+        }
+    }
+
+    public void close() {
+        synchronized (lock) {
+            if (closed) {
+                return;
+            }
+            closed = true;
+            pending.clear();
+            sent.clear();
         }
     }
 }

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/registry/Registries.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/registry/Registries.java
@@ -1,8 +1,10 @@
 package fr.euphyllia.fidorial.server.registry;
 
 import fr.euphyllia.fidorial.server.registry.entity.EntityTypeRegistry;
+import fr.euphyllia.fidorial.server.registry.sound.SoundEventRegistry;
 import fr.fidorial.registry.Registry;
 import fr.fidorial.registry.RegistryKey;
+import fr.fidorial.registry.keys.SoundEventKeys;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -29,8 +31,13 @@ public final class Registries {
         final Map<RegistryKey<?>, Registry<?>> registries = new HashMap<>();
 
         final EntityTypeRegistry entityTypes = new EntityTypeRegistry();
+        final SoundEventRegistry soundEvents = new SoundEventRegistry();
+
+        SoundEventKeys.values()
+                .forEach(soundEvents::register);
 
         registries.put(RegistryKey.ENTITY_TYPE, entityTypes);
+        registries.put(RegistryKey.SOUND_EVENT, soundEvents);
 
         return new Registries(RegistryHolder.of(data.dynamic()), RegistryHolder.of(data.frozen()), registries);
     }

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/registry/sound/SoundEventRegistry.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/registry/sound/SoundEventRegistry.java
@@ -1,0 +1,61 @@
+package fr.euphyllia.fidorial.server.registry.sound;
+
+import fr.fidorial.registry.Registry;
+import fr.fidorial.registry.RegistryKey;
+import fr.fidorial.registry.TypedKey;
+import fr.fidorial.registry.data.SoundEvent;
+import net.kyori.adventure.key.Key;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+public final class SoundEventRegistry implements Registry<SoundEvent> {
+
+    private static final SoundEvent EMPTY = new SoundEvent() {};
+
+    private final Map<Key, TypedKey<SoundEvent>> entries = new HashMap<>();
+
+    @Override
+    public RegistryKey<SoundEvent> registryKey() {
+        return RegistryKey.SOUND_EVENT;
+    }
+
+    @Override
+    public SoundEvent get(final TypedKey<SoundEvent> key) {
+        if (!entries.containsKey(key.key())) {
+            throw new IllegalArgumentException("Unknown sound event: " + key);
+        }
+
+        return EMPTY;
+    }
+
+    @Override
+    public Optional<SoundEvent> find(final TypedKey<SoundEvent> key) {
+        return entries.containsKey(key.key())
+                ? Optional.of(EMPTY)
+                : Optional.empty();
+    }
+
+    @Override
+    public TypedKey<SoundEvent> key(final SoundEvent value) {
+        throw new UnsupportedOperationException("SoundEvent has no unique value mapping");
+    }
+
+    @Override
+    public Collection<SoundEvent> values() {
+        return Collections.nCopies(entries.size(), EMPTY);
+    }
+
+    @Override
+    public Stream<SoundEvent> stream() {
+        return values().stream();
+    }
+
+    public void register(final TypedKey<SoundEvent> key) {
+        entries.put(key.key(), key);
+    }
+}

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/ServerWorld.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/ServerWorld.java
@@ -62,7 +62,7 @@ public final class ServerWorld implements World {
     private volatile @Nullable AsyncChunkLoader chunkLoader;
     private volatile @Nullable IntSupplier entityIdSupplier;
     private volatile @Nullable EntitySpawnBridge entityBridge;
-    private @Nullable Iterable<? extends Audience> adventure$audiences;
+    private volatile @Nullable Iterable<? extends Audience> adventure$audiences;
 
     public ServerWorld(
             final Dimension dimension,
@@ -200,12 +200,16 @@ public final class ServerWorld implements World {
 
     public void addEntity(final AbstractEntity entity) {
         entities.add(entity);
-        invalidateAudiences();
+        if (entity instanceof ServerPlayer) {
+            invalidateAudiences();
+        }
     }
 
     public void removeEntity(final AbstractEntity entity) {
         entities.remove(entity);
-        invalidateAudiences();
+        if (entity instanceof ServerPlayer) {
+            invalidateAudiences();
+        }
     }
 
     public ChunkColumn getChunk(final int chunkX, final int chunkZ) throws IOException {
@@ -424,13 +428,15 @@ public final class ServerWorld implements World {
 
     @Override
     public Iterable<? extends Audience> audiences() {
-        if (adventure$audiences == null) {
-            adventure$audiences = this.entities().stream()
+        Iterable<? extends Audience> audiences = adventure$audiences;
+        if (audiences == null) {
+            audiences = this.entities().stream()
                     .filter(ServerPlayer.class::isInstance)
                     .map(ServerPlayer.class::cast)
                     .toList();
+            adventure$audiences = audiences;
         }
-        return adventure$audiences;
+        return audiences;
     }
 
     @Override

--- a/fidorial-server/src/main/resources/languages/en_us.json
+++ b/fidorial-server/src/main/resources/languages/en_us.json
@@ -53,6 +53,8 @@
   "command.summon.unknown" : "Unknown entity type: <arg:0>",
   "command.summon.usage" : "Usage: /<arg:0> <type> [x y z]",
 
+  "commands.stop.stopping": "Stopping the server",
+
   "console.argument.double.low": "Double must not be less than '<arg:0>': found '<arg:1>'",
   "console.argument.double.big": "Double must not be more than '<arg:0>': found '<arg:1>'",
   "console.argument.float.low": "Float must not be less than '<arg:0>': found '<arg:1>'",

--- a/fidorial-server/src/main/resources/languages/fr_fr.json
+++ b/fidorial-server/src/main/resources/languages/fr_fr.json
@@ -52,6 +52,8 @@
   "command.summon.unknown" : "Type d'entité inconnu : <arg:0>",
   "command.summon.usage" : "Utilisation : /<arg:0> <type> [x y z]",
 
+  "commands.stop.stopping": "Arrêt du serveur",
+
   "console.argument.double.low": "Le double ne doit pas être inférieur à <arg:0> (valeur trouvée : <arg:1>)",
   "console.argument.double.big": "Le double ne doit pas être supérieur à <arg:0> (valeur trouvée : <arg:1>)",
   "console.argument.float.low": "Le flottant ne doit pas être inférieur à <arg:0> (valeur trouvée : <arg:1>)",

--- a/fidorial-test-plugin/src/main/java/fr/euphyllia/fidorial/testplugin/command/ApiTestCommand.java
+++ b/fidorial-test-plugin/src/main/java/fr/euphyllia/fidorial/testplugin/command/ApiTestCommand.java
@@ -13,6 +13,9 @@ import fr.fidorial.command.CommandSource;
 import fr.fidorial.command.MessageComponentSerializer;
 import fr.fidorial.command.argument.ArgumentTypes;
 import fr.fidorial.entity.Player;
+import fr.fidorial.registry.RegistryKey;
+import fr.fidorial.registry.TypedKey;
+import fr.fidorial.registry.data.SoundEvent;
 import fr.fidorial.scheduler.RegionTps;
 import fr.fidorial.world.ChunkPos;
 import fr.fidorial.world.Location;
@@ -102,7 +105,7 @@ public final class ApiTestCommand {
                                 .executes(ctx -> unloadWorld(plugin, ctx, ctx.getArgument("name", Key.class)))))
                 .then(literal("sound")
                         .executes(ApiTestCommand::soundDemo)
-                        .then(argument("key", ArgumentTypes.key())
+                        .then(argument("key", ArgumentTypes.resourceKey(RegistryKey.SOUND_EVENT))
                                 .executes(ApiTestCommand::soundDefault)
                                 .then(argument("volume", ArgumentTypes.floatArg())
                                         .executes(ApiTestCommand::soundVolume)
@@ -179,11 +182,12 @@ public final class ApiTestCommand {
             return Command.SINGLE_SUCCESS;
         }
 
-        final Key key = ctx.getArgument("key", Key.class);
+        final TypedKey<SoundEvent> soundTypedKey = ctx.getArgument("key", TypedKey.class);
+        final Key soundKey = soundTypedKey.key();
 
-        player.playSound(Sound.sound(key, Sound.Source.MASTER, volume, pitch));
+        player.playSound(Sound.sound(soundKey, Sound.Source.MASTER, volume, pitch));
 
-        msg(player, "[TestPlugin] Played sound " + key + " (volume=" + volume + ", pitch=" + pitch + ")");
+        msg(player, "[TestPlugin] Played sound " + soundKey + " (volume=" + volume + ", pitch=" + pitch + ")");
 
         return Command.SINGLE_SUCCESS;
     }


### PR DESCRIPTION
This fixes the netty race in console that happens sometimes while stopping the server. Found the culprit by debugging packets inside of `ClientConnection#write`
<img width="1894" height="303" alt="image" src="https://github.com/user-attachments/assets/a00df3d0-1094-48f8-8d47-65bdc58b98da" />

### Additional changes
- Made `Player#kick` accept `Component` as the reason
- Made it so stopping the server kicks all players with a translatable stop message
- Extend `ForwardingAudience` in `Server` and `World`
    - Everything except `audiences()` delegates to individual audiences (such as `ServerPlayer`), so this just cleans up our code
- Fixes entities not being treated as sound sources when they should be, causing issues with emitters (when we implement block classes we should also provide them with a similar `Category.Block` extending `Sound.Source`)