### PR TITLE
Remove polling from scenario test logic

### DIFF
--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/testing/ScenarioTestMain.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/testing/ScenarioTestMain.java
@@ -19,7 +19,6 @@ import java.util.concurrent.CountDownLatch;
 public final class ScenarioTestMain {
 
     private static final ComponentLogger LOGGER = ComponentLogger.logger(ScenarioTestMain.class);
-    private static final long POLL_INTERVAL_MS = 50;
 
     private ScenarioTestMain() {
     }
@@ -40,8 +39,13 @@ public final class ScenarioTestMain {
                 ScenarioTestScanner.scanPackages(collectClassLoaders(server), args);
 
         runner.start(tests, world);
+        final CountDownLatch done = new CountDownLatch(1);
+        runner.onComplete(done::countDown);
+        if (runner.isDone()) {
+            done.countDown();
+        }
         wireIntoWorldTick(server, world, runner);
-        awaitCompletion(runner);
+        done.await();
 
         logResults(runner);
 
@@ -68,22 +72,6 @@ public final class ScenarioTestMain {
                 runner.tick((int) tick);
             }
         });
-    }
-
-    private static void awaitCompletion(final ScenarioTestRunner runner) throws InterruptedException {
-        final CountDownLatch done = new CountDownLatch(1);
-        Thread.ofVirtual().start(() -> {
-            try {
-                while (!runner.isDone()) {
-                    Thread.sleep(POLL_INTERVAL_MS);
-                }
-            } catch (final InterruptedException e) {
-                Thread.currentThread().interrupt();
-                return;
-            }
-            done.countDown();
-        });
-        done.await();
     }
 
     private static void logResults(final ScenarioTestRunner runner) {

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/testing/ScenarioTestRunner.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/testing/ScenarioTestRunner.java
@@ -3,19 +3,27 @@ package fr.euphyllia.fidorial.server.testing;
 import fr.fidorial.testing.ScenarioTestInfo;
 import fr.fidorial.testing.ScenarioTestInstance;
 import fr.fidorial.world.World;
+import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 final class ScenarioTestRunner {
 
     private final List<ScenarioTestInfo> running = new ArrayList<>();
     private final List<ScenarioTestInfo> finished = new ArrayList<>();
+    private final AtomicBoolean doneFired = new AtomicBoolean();
+    private volatile @Nullable Runnable onComplete;
 
     public void start(final List<ScenarioTestInstance> tests, final World world) {
         for (final ScenarioTestInstance test : tests) {
             running.add(new ScenarioTestInfo(test, world));
         }
+    }
+
+    public void onComplete(final Runnable action) {
+        this.onComplete = action;
     }
 
     public void tick(final int currentTick) {
@@ -25,6 +33,10 @@ final class ScenarioTestRunner {
                 running.remove(info);
                 finished.add(info);
             }
+        }
+        if (running.isEmpty() && doneFired.compareAndSet(false, true)) {
+            final Runnable action = onComplete;
+            if (action != null) action.run();
         }
     }
 


### PR DESCRIPTION
We now rely on a dynamic runnable callback which fixes the polling not catching ticks when the tps drops below 20