### PR TITLE
More Adventure fun for items and players

### DIFF
--- a/fidorial-api/src/main/java/fr/fidorial/entity/Player.java
+++ b/fidorial-api/src/main/java/fr/fidorial/entity/Player.java
@@ -9,10 +9,11 @@ import net.kyori.adventure.bossbar.BossBarViewer;
 import net.kyori.adventure.identity.Identified;
 import net.kyori.adventure.identity.Identity;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.object.ObjectContentsLike;
 
 import java.util.UUID;
 
-public interface Player extends LivingEntity, PermissionHolder, CommandSource, CommandSender, Identified, BossBarViewer {
+public interface Player extends LivingEntity, PermissionHolder, CommandSource, CommandSender, Identified, BossBarViewer, ObjectContentsLike {
 
     void refreshCommands();
 

--- a/fidorial-api/src/main/java/fr/fidorial/entity/PlayerProfile.java
+++ b/fidorial-api/src/main/java/fr/fidorial/entity/PlayerProfile.java
@@ -1,11 +1,16 @@
 package fr.fidorial.entity;
 
+import net.kyori.adventure.text.object.ObjectContents;
+import net.kyori.adventure.text.object.ObjectContentsLike;
+import net.kyori.adventure.text.object.PlayerHeadObjectContents;
 import org.jspecify.annotations.Nullable;
 
 import java.util.List;
 import java.util.UUID;
 
-public record PlayerProfile(UUID uuid, String name, List<Property> properties) {
+import static net.kyori.adventure.text.object.PlayerHeadObjectContents.property;
+
+public record PlayerProfile(UUID uuid, String name, List<Property> properties) implements PlayerHeadObjectContents.SkinSource, ObjectContentsLike {
 
     public PlayerProfile {
         properties = List.copyOf(properties);
@@ -17,6 +22,24 @@ public record PlayerProfile(UUID uuid, String name, List<Property> properties) {
 
     public PlayerProfile(PlayerProfileMeta meta) {
         this(meta.id(), meta.name(), List.of());
+    }
+
+    @Override
+    public void applySkinToPlayerHeadContents(final PlayerHeadObjectContents.Builder builder) {
+        if (!this.properties.isEmpty()) {
+            builder.profileProperties(
+                    this.properties.stream()
+                            .map(p -> property(p.name(), p.value(), p.signature()))
+                            .toList()
+            );
+        }
+        builder.id(this.uuid)
+                .name(this.name);
+    }
+
+    @Override
+    public ObjectContents asObjectContents() {
+        return ObjectContents.playerHead(this);
     }
 
     public record Property(

--- a/fidorial-api/src/main/java/fr/fidorial/inventory/ItemStack.java
+++ b/fidorial-api/src/main/java/fr/fidorial/inventory/ItemStack.java
@@ -3,13 +3,17 @@ package fr.fidorial.inventory;
 import fr.fidorial.attribute.AttributeModifier;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.event.HoverEvent;
+import net.kyori.adventure.text.event.HoverEventSource;
+import net.kyori.adventure.translation.Translatable;
 import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.UnaryOperator;
 
-public final class ItemStack {
+public final class ItemStack implements Translatable, HoverEventSource<HoverEvent.ShowItem> {
 
     private static final Key AIR = Key.key("air");
     public static final ItemStack EMPTY = new ItemStack(AIR, 0);
@@ -148,5 +152,15 @@ public final class ItemStack {
                 + (hasLore() ? ", lore=" + lore.size() : "")
                 + (hasAttributeModifiers() ? ", attributes=" + attributeModifiers.size() : "")
                 + "}";
+    }
+
+    @Override
+    public HoverEvent<HoverEvent.ShowItem> asHoverEvent(final UnaryOperator<HoverEvent.ShowItem> op) {
+        return HoverEvent.showItem(op.apply(HoverEvent.ShowItem.showItem(id, count)));
+    }
+
+    @Override
+    public String translationKey() {
+        return "item." + id.asString().replace(":", ".");
     }
 }

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/player/ServerPlayer.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/player/ServerPlayer.java
@@ -44,6 +44,7 @@ import net.kyori.adventure.bossbar.BossBar;
 import net.kyori.adventure.sound.Sound;
 import net.kyori.adventure.sound.SoundStop;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.object.ObjectContents;
 import org.jetbrains.annotations.UnmodifiableView;
 import org.jspecify.annotations.Nullable;
 
@@ -587,6 +588,11 @@ public final class ServerPlayer extends AbstractLivingEntity implements Player, 
         }
         heal(REGENERATION_AMOUNT);
         connection.send(new ClientboundSetHealthPacket(health(), 20, 5.0f));
+    }
+
+    @Override
+    public ObjectContents asObjectContents() {
+        return this.profile().asObjectContents();
     }
 
     private record BossBarEntry(UUID id, BossBar.Listener listener) {

--- a/fidorial-test-plugin/src/main/java/fr/euphyllia/fidorial/testplugin/command/ApiTestCommand.java
+++ b/fidorial-test-plugin/src/main/java/fr/euphyllia/fidorial/testplugin/command/ApiTestCommand.java
@@ -14,6 +14,7 @@ import fr.fidorial.command.CommandSource;
 import fr.fidorial.command.MessageComponentSerializer;
 import fr.fidorial.command.argument.ArgumentTypes;
 import fr.fidorial.entity.Player;
+import fr.fidorial.inventory.ItemStack;
 import fr.fidorial.registry.RegistryKey;
 import fr.fidorial.registry.data.SoundEvent;
 import fr.fidorial.scheduler.RegionTps;
@@ -119,6 +120,8 @@ public final class ApiTestCommand {
                 .then(literal("baguette")
                         .then(argument("type", BaguetteArgument.baguette())
                                 .executes(ApiTestCommand::baguette)))
+                .then(literal("itemhover").executes(ApiTestCommand::itemHover))
+                .then(literal("playerhead").executes(ApiTestCommand::playerHead))
                 // TODO: should become a standalone command in fidorial tbh like vanilla /bossbar, and be expanded to match vanilla args too (with our additional flags)
                 .then(literal("bossbar")
                         .then(literal("show")
@@ -475,6 +478,38 @@ public final class ApiTestCommand {
 
         Component callbackComponent = Component.text("[Click me!]", NamedTextColor.GREEN).clickEvent(ClickEvent.callback(callback, options));
         ctx.getSource().sender().sendMessage(callbackComponent);
+        return Command.SINGLE_SUCCESS;
+    }
+
+    private static int itemHover(final CommandContext<CommandSource> ctx) {
+        final CommandSender sender = ctx.getSource().sender();
+
+        final ItemStack diamond = ItemStack.of(Key.key("diamond"), 64);
+
+        final Component item = Component.translatable(diamond)
+                .color(NamedTextColor.AQUA)
+                .hoverEvent(diamond);
+
+        sender.sendMessage(Component.text("[TestPlugin] Hover me: ").append(item));
+
+        msg(sender, "[TestPlugin] Translation key = " + diamond.translationKey());
+        sender.sendMessage(Component.text("[TestPlugin] Rendered key = ").append(Component.translatable(diamond.translationKey())));
+
+        return Command.SINGLE_SUCCESS;
+    }
+
+    private static int playerHead(final CommandContext<CommandSource> ctx) {
+        final CommandSender sender = ctx.getSource().sender();
+
+        if (!(sender instanceof final Player player)) {
+            msg(sender, "<red>[TestPlugin] Run this command in-game.</red>");
+            return Command.SINGLE_SUCCESS;
+        }
+
+        final Component head = Component.object(player);
+
+        sender.sendMessage(Component.text("[TestPlugin] Your head: ").append(head));
+
         return Command.SINGLE_SUCCESS;
     }
 


### PR DESCRIPTION
### Changes
- `ItemStack` receives two new methods: `ItemStack#asHoverEvent`, `ItemStack#translationKey`
- `Player` and `PlayerProfile` receive a new `Player#asObjectContents` which can be used to display the player's head

PSA: the objects themselves can be passed into adventure APIs like `.hoverEvent(itemStack)` which will auto-delegate to `ItemStack#asHoverEvent`

<img width="542" height="64" alt="image" src="https://github.com/user-attachments/assets/bf88f03d-06af-45e2-93cd-4aa002b2583e" />
<img width="267" height="34" alt="image" src="https://github.com/user-attachments/assets/10439a46-84a4-41f4-ab38-e624fde4d69c" />
