### PR TITLE
Implement resource packs along with API

### DIFF
--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/ServerConfig.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/ServerConfig.java
@@ -2,7 +2,9 @@ package fr.euphyllia.fidorial.server;
 
 import fr.euphyllia.fidorial.server.world.WorldConstants;
 import fr.fidorial.entity.GameMode;
+import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.logger.slf4j.ComponentLogger;
+import net.kyori.adventure.text.minimessage.MiniMessage;
 import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;
@@ -12,6 +14,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Locale;
 import java.util.Properties;
+import java.util.UUID;
 
 public record ServerConfig(
         int port,
@@ -35,7 +38,12 @@ public record ServerConfig(
         boolean pvp,
         ProxyMode proxyMode,
         @Nullable String velocitySecret,
-        boolean useIoUring
+        boolean useIoUring,
+        @Nullable String resourcePackUrl,
+        @Nullable String resourcePackHash,
+        @Nullable String resourcePackId,
+        boolean resourcePackForced,
+        @Nullable Component resourcePackPrompt
 ) {
 
     private static final ComponentLogger LOGGER = ComponentLogger.logger(ServerConfig.class);
@@ -52,6 +60,19 @@ public record ServerConfig(
         if (proxyMode == ProxyMode.VELOCITY && (velocitySecret == null || velocitySecret.isBlank())) {
             throw new IllegalArgumentException(
                     "proxy-mode=velocity requires velocity-secret (the content of the proxy's forwarding.secret file)");
+        }
+        if (resourcePackHash != null && !resourcePackHash.isBlank()
+                && !resourcePackHash.matches("[0-9a-f]{40}")) {
+            throw new IllegalArgumentException(
+                    "resource-pack-hash must be a 40-character lowercase SHA-1 hex string, or empty");
+        }
+        if (resourcePackId != null && !resourcePackId.isBlank()) {
+            try {
+                UUID.fromString(resourcePackId);
+            } catch (final IllegalArgumentException e) {
+                throw new IllegalArgumentException(
+                        "resource-pack-id must be a valid UUID: '" + resourcePackId + "'", e);
+            }
         }
     }
 
@@ -93,7 +114,12 @@ public record ServerConfig(
                 true,
                 ProxyMode.NONE,
                 "",
-        false);
+                false,
+                "",
+                "",
+                "",
+                false,
+                Component.empty());
     }
 
     public static ServerConfig load() throws IOException {
@@ -134,7 +160,12 @@ public record ServerConfig(
                 readBool(props, "pvp", defaults.pvp()),
                 readProxyMode(props, "proxy-mode", defaults.proxyMode()),
                 readString(props, "velocity-secret", "").strip(),
-                readBool(props, "use-io-uring", false));
+                readBool(props, "use-io-uring", false),
+                readString(props, "resource-pack-url", ""),
+                readString(props, "resource-pack-hash", ""),
+                readString(props, "resource-pack-id", ""),
+                readBool(props, "resource-pack-forced", false),
+                readComponent(props, "resource-pack-prompt", Component.empty()));
         LOGGER.info("Configuration loaded from {}", file);
         return config;
     }
@@ -171,6 +202,19 @@ public record ServerConfig(
             return fallback;
         }
         return raw;
+    }
+
+    private static Component readComponent(final Properties props, final String key, final Component fallback) {
+        final String raw = props.getProperty(key);
+        if (raw == null || raw.isBlank()) {
+            return fallback;
+        }
+        try {
+            return MiniMessage.miniMessage().deserialize(raw.strip());
+        } catch (final Exception e) {
+            LOGGER.warn("{} = '{}' could not be parsed as MiniMessage, default value used", key, raw, e);
+            return fallback;
+        }
     }
 
     private static GameMode readGameMode(final Properties props, final String key, final GameMode fallback) {
@@ -228,6 +272,11 @@ public record ServerConfig(
         props.setProperty("proxy-mode", proxyMode.name().toLowerCase(Locale.ROOT));
         props.setProperty("velocity-secret", velocitySecret == null ? "" : velocitySecret);
         props.setProperty("use-io-uring", Boolean.toString(useIoUring));
+        props.setProperty("resource-pack-url", resourcePackUrl == null ? "" : resourcePackUrl);
+        props.setProperty("resource-pack-hash", resourcePackHash == null ? "" : resourcePackHash);
+        props.setProperty("resource-pack-id", resourcePackId == null ? "" : resourcePackId);
+        props.setProperty("resource-pack-forced", Boolean.toString(resourcePackForced));
+        props.setProperty("resource-pack-prompt", resourcePackPrompt == null ? "" : MiniMessage.miniMessage().serialize(resourcePackPrompt));
         try (final OutputStream out = Files.newOutputStream(file)) {
             props.store(out, "Configuration Fidorial");
         }

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/player/ServerPlayer.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/player/ServerPlayer.java
@@ -41,6 +41,7 @@ import fr.fidorial.world.BlockPos;
 import fr.fidorial.world.Location;
 import fr.fidorial.world.World;
 import net.kyori.adventure.bossbar.BossBar;
+import net.kyori.adventure.resource.ResourcePackRequest;
 import net.kyori.adventure.sound.Sound;
 import net.kyori.adventure.sound.SoundStop;
 import net.kyori.adventure.text.Component;
@@ -485,6 +486,21 @@ public final class ServerPlayer extends AbstractLivingEntity implements Player, 
             entry.getKey().removeListener(entry.getValue().listener());
         }
         activeBossBars.clear();
+    }
+
+    @Override
+    public void sendResourcePacks(final ResourcePackRequest request) {
+        connection.sendResourcePacks(request);
+    }
+
+    @Override
+    public void removeResourcePacks(final UUID id, final UUID... others) {
+        connection.removeResourcePacks(id, others);
+    }
+
+    @Override
+    public void clearResourcePacks() {
+        connection.clearResourcePacks();
     }
 
     @Override

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/ClientConnection.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/ClientConnection.java
@@ -13,8 +13,12 @@ import fr.euphyllia.fidorial.server.network.listener.LoginPacketHandler;
 import fr.euphyllia.fidorial.server.network.listener.PlayPacketHandler;
 import fr.euphyllia.fidorial.server.network.listener.StatusPacketHandler;
 import fr.euphyllia.fidorial.server.network.protocol.ProtocolMap;
+import fr.euphyllia.fidorial.server.network.protocol.catalog.ConfigurationClientboundPackets;
+import fr.euphyllia.fidorial.server.network.protocol.catalog.PlayClientboundPackets;
 import fr.euphyllia.fidorial.server.network.protocol.packet.ClientboundPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.ServerboundPackets;
+import fr.euphyllia.fidorial.server.network.protocol.packet.clientbound.common.ClientboundResourcePackPopPacket;
+import fr.euphyllia.fidorial.server.network.protocol.packet.clientbound.common.ClientboundResourcePackPushPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.clientbound.login.ClientboundLoginDisconnectPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.clientbound.play.ClientboundDisconnectPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.clientbound.play.ClientboundKeepAlivePacket;
@@ -32,6 +36,10 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.key.Key;
+import net.kyori.adventure.resource.ResourcePackCallback;
+import net.kyori.adventure.resource.ResourcePackInfo;
+import net.kyori.adventure.resource.ResourcePackRequest;
+import net.kyori.adventure.resource.ResourcePackStatus;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.logger.slf4j.ComponentLogger;
 import org.jspecify.annotations.Nullable;
@@ -41,11 +49,16 @@ import javax.crypto.SecretKey;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.security.GeneralSecurityException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
-// implement resource pack, pointers and dialog methods in the future from audience
+// implement pointers and dialog methods in the future from audience
 public final class ClientConnection extends SimpleChannelInboundHandler<ByteBuf> implements Audience {
 
     private static final ComponentLogger LOGGER = ComponentLogger.logger(ClientConnection.class);
@@ -322,5 +335,83 @@ public final class ClientConnection extends SimpleChannelInboundHandler<ByteBuf>
             return play.teleport(target, location);
         }
         return false;
+    }
+
+    private final Map<UUID, ResourcePackCallback> pendingResourcePacks = new ConcurrentHashMap<>();
+
+    @Override
+    public void sendResourcePacks(final ResourcePackRequest request) {
+        LOGGER.info("ClientConnection.sendResourcePacks called for {} (packs={})", username, request.packs().size());
+        if (state != ConnectionState.CONFIGURATION && state != ConnectionState.PLAY) {
+            return;
+        }
+        final Key pushName = state == ConnectionState.PLAY
+                ? PlayClientboundPackets.RESOURCE_PACK_PUSH
+                : ConfigurationClientboundPackets.RESOURCE_PACK_PUSH;
+
+        final ResourcePackCallback cb = request.callback();
+        request.packs().forEach(pack -> pendingResourcePacks.put(pack.id(), cb));
+
+        for (final ResourcePackInfo pack : request.packs()) {
+            send(new ClientboundResourcePackPushPacket(
+                    pushName,
+                    pack.id(),
+                    pack.uri().toString(),
+                    pack.hash(),
+                    request.required(),
+                    request.prompt()));
+        }
+    }
+
+    @Override
+    public void removeResourcePacks(final UUID id, final UUID... others) {
+        popPack(id);
+        for (final UUID other : others) {
+            popPack(other);
+        }
+    }
+
+    @Override
+    public void clearResourcePacks() {
+        popPack(null);
+    }
+
+    private void popPack(final @Nullable UUID id) {
+        final Key popName = state == ConnectionState.PLAY
+                ? PlayClientboundPackets.RESOURCE_PACK_POP
+                : ConfigurationClientboundPackets.RESOURCE_PACK_POP;
+        send(new ClientboundResourcePackPopPacket(popName, id));
+    }
+
+    public void notifyResourcePackResponse(final UUID id, final ResourcePackStatus status) {
+        final ResourcePackCallback callback = status.intermediate()
+                ? pendingResourcePacks.get(id)
+                : pendingResourcePacks.remove(id);
+        if (callback != null) {
+            callback.packEventReceived(id, status, this.player != null ? this.player : this);
+        }
+    }
+
+    private final List<Component> pendingMessages = new ArrayList<>();
+
+    @Override
+    public void sendMessage(final Component message) {
+        if (state == ConnectionState.PLAY && this.player != null) {
+            this.player.sendMessage(message);
+            return;
+        }
+        // we're too early to send a message so just collect it
+        pendingMessages.add(message);
+    }
+
+    public void flushPendingMessages() {
+        if (pendingMessages.isEmpty()) {
+            return;
+        }
+        final List<Component> queued = List.copyOf(pendingMessages);
+        pendingMessages.clear();
+        for (final Component message : queued) {
+            sendMessage(message);
+        }
     }
 }

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/listener/ConfigurationPacketHandler.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/listener/ConfigurationPacketHandler.java
@@ -5,6 +5,8 @@ import fr.euphyllia.fidorial.server.adventure.ClickCallbackManager;
 import fr.euphyllia.fidorial.server.network.ClientConnection;
 import fr.euphyllia.fidorial.server.network.ConnectionState;
 import fr.euphyllia.fidorial.server.network.protocol.ProtocolConstants;
+import fr.euphyllia.fidorial.server.network.protocol.catalog.ConfigurationClientboundPackets;
+import fr.euphyllia.fidorial.server.network.protocol.packet.clientbound.common.ClientboundResourcePackPushPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.clientbound.configuration.ClientboundBrandPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.clientbound.configuration.ClientboundFinishConfigurationPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.clientbound.configuration.ClientboundRegistryDataPacket;
@@ -12,11 +14,13 @@ import fr.euphyllia.fidorial.server.network.protocol.packet.clientbound.configur
 import fr.euphyllia.fidorial.server.network.protocol.packet.clientbound.configuration.ClientboundUpdateTagsPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.listener.ConfigurationPacketListener;
 import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.common.ServerboundClientInformationPacket;
-import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.common.ServerboundCustomClickActionPacket;
+import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.configuration.ServerboundCustomClickActionPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.configuration.ServerboundFinishConfigurationPacket;
+import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.configuration.ServerboundResourcePackPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.configuration.ServerboundSelectKnownPacksPacket;
 import fr.euphyllia.fidorial.server.registry.Registry;
 import fr.euphyllia.fidorial.server.registry.RegistryHolder;
+import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.logger.slf4j.ComponentLogger;
 
 import java.util.Locale;
@@ -28,6 +32,7 @@ public final class ConfigurationPacketHandler implements ConfigurationPacketList
 
     private final ClientConnection connection;
     private final FidorialServer server;
+    private volatile boolean awaitingResourcePackResponse = false;
 
     public ConfigurationPacketHandler(final ClientConnection connection) {
         this.connection = connection;
@@ -45,8 +50,36 @@ public final class ConfigurationPacketHandler implements ConfigurationPacketList
             return;
         }
         connection.send(new ClientboundBrandPacket("Fidorial"));
-        connection.send(
-                new ClientboundSelectKnownPacksPacket("minecraft", "core", ProtocolConstants.MINECRAFT_VERSION));
+        if (sendResourcePackIfConfigured()) {
+            awaitingResourcePackResponse = true;
+            return;
+        }
+        proceedToKnownPacks();
+    }
+
+    private void proceedToKnownPacks() {
+        connection.send(new ClientboundSelectKnownPacksPacket("minecraft", "core", ProtocolConstants.MINECRAFT_VERSION));
+    }
+
+    @Override
+    public void handleResourcePackResponse(final ServerboundResourcePackPacket packet) {
+        LOGGER.debug("{}: resource pack response {} -> {}", connection.username(), packet.id(), packet.status());
+        connection.notifyResourcePackResponse(packet.id(), packet.status());
+
+        final boolean terminalFailure = switch (packet.status()) {
+            case SUCCESSFULLY_LOADED, ACCEPTED, DOWNLOADED -> false;
+            default -> true;
+        };
+
+        if (terminalFailure && server.config().resourcePackForced()) {
+            connection.close();
+            return;
+        }
+
+        if (awaitingResourcePackResponse) {
+            awaitingResourcePackResponse = false;
+            proceedToKnownPacks();
+        }
     }
 
     @Override
@@ -73,6 +106,24 @@ public final class ConfigurationPacketHandler implements ConfigurationPacketList
 
     private void sendTags() {
         connection.send(new ClientboundUpdateTagsPacket(server.dynamicRegistries()));
+    }
+
+    private boolean sendResourcePackIfConfigured() {
+        final String url = server.config().resourcePackUrl();
+        if (url == null || url.isBlank()) {
+            return false;
+        }
+        final Component prompt = server.config().resourcePackPrompt();
+        final String idRaw = server.config().resourcePackId();
+        final UUID id = (idRaw == null || idRaw.isBlank()) ? UUID.randomUUID() : UUID.fromString(idRaw);
+        connection.send(new ClientboundResourcePackPushPacket(
+                ConfigurationClientboundPackets.RESOURCE_PACK_PUSH,
+                id,
+                url,
+                server.config().resourcePackHash() == null ? "" : server.config().resourcePackHash(),
+                server.config().resourcePackForced(),
+                prompt));
+        return true;
     }
 
     @Override

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/listener/PlayPacketHandler.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/listener/PlayPacketHandler.java
@@ -30,7 +30,6 @@ import fr.euphyllia.fidorial.server.network.protocol.packet.clientbound.play.Cli
 import fr.euphyllia.fidorial.server.network.protocol.packet.clientbound.play.ClientboundSystemChatPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.listener.PlayPacketListener;
 import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.common.ServerboundClientInformationPacket;
-import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.common.ServerboundCustomClickActionPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.play.ServerboundAcceptTeleportationPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.play.ServerboundAttackPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.play.ServerboundChatCommandPacket;
@@ -39,6 +38,7 @@ import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.play.Ser
 import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.play.ServerboundCommandSuggestionPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.play.ServerboundContainerClickPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.play.ServerboundContainerClosePacket;
+import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.play.ServerboundCustomClickActionPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.play.ServerboundInteractPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.play.ServerboundKeepAlivePacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.play.ServerboundMovePlayerPosPacket;
@@ -47,6 +47,7 @@ import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.play.Ser
 import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.play.ServerboundPlayerActionPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.play.ServerboundPlayerInputPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.play.ServerboundPlayerLoadedPacket;
+import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.play.ServerboundResourcePackPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.play.ServerboundSetCarriedItemPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.play.ServerboundSetCreativeModeSlotPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.play.ServerboundSwingPacket;
@@ -123,6 +124,7 @@ public final class PlayPacketHandler implements PlayPacketListener {
         openChunkView(world, dynamic, spawn.chunk());
         spawnPlayer(spawn);
 
+        connection.flushPendingMessages();
         connection.startKeepAlive();
         server.addPlayerConnection(connection);
         for (final ServerPlayer other : server.players()) {
@@ -681,6 +683,12 @@ public final class PlayPacketHandler implements PlayPacketListener {
         }
     }
 
+    @Override
+    public void handleResourcePackResponse(final ServerboundResourcePackPacket packet) {
+        LOGGER.debug("{}: resource pack response {} -> {}",
+                player == null ? connection.username() : player.name(), packet.id(), packet.status());
+        connection.notifyResourcePackResponse(packet.id(), packet.status());
+    }
 
     private void respawn() {
         if (player == null || !player.isAwaitingRespawn()) {

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/protocol/packet/ServerboundPackets.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/protocol/packet/ServerboundPackets.java
@@ -8,8 +8,8 @@ import fr.euphyllia.fidorial.server.network.protocol.catalog.LoginServerboundPac
 import fr.euphyllia.fidorial.server.network.protocol.catalog.PlayServerboundPackets;
 import fr.euphyllia.fidorial.server.network.protocol.catalog.StatusServerboundPackets;
 import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.common.ServerboundClientInformationPacket;
-import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.common.ServerboundCustomClickActionPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.configuration.ServerboundFinishConfigurationPacket;
+import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.configuration.ServerboundResourcePackPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.configuration.ServerboundSelectKnownPacksPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.handshake.ServerboundIntentionPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.login.ServerboundCustomQueryAnswerPacket;
@@ -24,6 +24,7 @@ import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.play.Ser
 import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.play.ServerboundCommandSuggestionPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.play.ServerboundContainerClickPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.play.ServerboundContainerClosePacket;
+import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.play.ServerboundCustomClickActionPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.play.ServerboundInteractPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.play.ServerboundKeepAlivePacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.play.ServerboundMovePlayerPosPacket;
@@ -76,8 +77,12 @@ public class ServerboundPackets {
                 ServerboundClientInformationPacket::read);
         register(
                 ConnectionState.CONFIGURATION,
-                PlayServerboundPackets.CUSTOM_CLICK_ACTION,
-                ServerboundCustomClickActionPacket::read);
+                ConfigurationServerboundPackets.CUSTOM_CLICK_ACTION,
+                fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.configuration.ServerboundCustomClickActionPacket::read);
+        register(
+                ConnectionState.CONFIGURATION,
+                ConfigurationServerboundPackets.RESOURCE_PACK,
+                ServerboundResourcePackPacket::read);
         register(
                 ConnectionState.CONFIGURATION,
                 ConfigurationServerboundPackets.FINISH_CONFIGURATION,
@@ -124,6 +129,8 @@ public class ServerboundPackets {
                 ConnectionState.PLAY,
                 PlayServerboundPackets.CUSTOM_CLICK_ACTION,
                 ServerboundCustomClickActionPacket::read);
+        register(ConnectionState.PLAY, PlayServerboundPackets.RESOURCE_PACK,
+                fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.play.ServerboundResourcePackPacket::read);
 
         register(ConnectionState.PLAY, PlayServerboundPackets.ATTACK, ServerboundAttackPacket::read);
         register(ConnectionState.PLAY, PlayServerboundPackets.INTERACT, ServerboundInteractPacket::read);

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/protocol/packet/clientbound/common/ClientboundResourcePackPopPacket.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/protocol/packet/clientbound/common/ClientboundResourcePackPopPacket.java
@@ -1,0 +1,25 @@
+package fr.euphyllia.fidorial.server.network.protocol.packet.clientbound.common;
+
+import fr.euphyllia.fidorial.server.network.PacketBuffer;
+import fr.euphyllia.fidorial.server.network.protocol.packet.ClientboundPacket;
+import net.kyori.adventure.key.Key;
+import org.jspecify.annotations.Nullable;
+
+import java.util.UUID;
+
+// https://minecraft.wiki/w/Java_Edition_protocol/Packets#Remove_Resource_Pack
+public record ClientboundResourcePackPopPacket(Key packetName, @Nullable UUID id) implements ClientboundPacket {
+
+    @Override
+    public Key name() {
+        return packetName;
+    }
+
+    @Override
+    public void write(final PacketBuffer buf) {
+        buf.writeBoolean(id != null);
+        if (id != null) {
+            buf.writeUuid(id);
+        }
+    }
+}

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/protocol/packet/clientbound/common/ClientboundResourcePackPushPacket.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/protocol/packet/clientbound/common/ClientboundResourcePackPushPacket.java
@@ -1,0 +1,37 @@
+package fr.euphyllia.fidorial.server.network.protocol.packet.clientbound.common;
+
+import fr.euphyllia.fidorial.server.network.PacketBuffer;
+import fr.euphyllia.fidorial.server.network.protocol.packet.ClientboundPacket;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.text.Component;
+import org.jspecify.annotations.Nullable;
+
+import java.util.UUID;
+
+// https://minecraft.wiki/w/Java_Edition_protocol/Packets#Add_Resource_Pack
+public record ClientboundResourcePackPushPacket(
+        Key packetName,
+        UUID id,
+        String url,
+        String hash,
+        boolean forced,
+        @Nullable Component promptMessage
+) implements ClientboundPacket {
+
+    @Override
+    public Key name() {
+        return packetName;
+    }
+
+    @Override
+    public void write(final PacketBuffer buf) {
+        buf.writeUuid(id);
+        buf.writeString(url);
+        buf.writeString(hash);
+        buf.writeBoolean(forced);
+        buf.writeBoolean(promptMessage != null);
+        if (promptMessage != null) {
+            buf.writeComponent(promptMessage);
+        }
+    }
+}

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/protocol/packet/listener/ConfigurationPacketListener.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/protocol/packet/listener/ConfigurationPacketListener.java
@@ -1,8 +1,9 @@
 package fr.euphyllia.fidorial.server.network.protocol.packet.listener;
 
 import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.common.ServerboundClientInformationPacket;
-import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.common.ServerboundCustomClickActionPacket;
+import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.configuration.ServerboundCustomClickActionPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.configuration.ServerboundFinishConfigurationPacket;
+import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.configuration.ServerboundResourcePackPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.configuration.ServerboundSelectKnownPacksPacket;
 import fr.fidorial.protocol.PacketListener;
 
@@ -12,6 +13,8 @@ public interface ConfigurationPacketListener extends PacketListener {
     void handleFinishConfiguration(ServerboundFinishConfigurationPacket packet);
 
     void handleCustomClickAction(ServerboundCustomClickActionPacket packet);
+
+    void handleResourcePackResponse(ServerboundResourcePackPacket packet);
 
     void handleClientInformation(ServerboundClientInformationPacket packet);
 }

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/protocol/packet/listener/PlayPacketListener.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/protocol/packet/listener/PlayPacketListener.java
@@ -1,7 +1,6 @@
 package fr.euphyllia.fidorial.server.network.protocol.packet.listener;
 
 import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.common.ServerboundClientInformationPacket;
-import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.common.ServerboundCustomClickActionPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.play.ServerboundAcceptTeleportationPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.play.ServerboundAttackPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.play.ServerboundChatCommandPacket;
@@ -10,6 +9,7 @@ import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.play.Ser
 import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.play.ServerboundCommandSuggestionPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.play.ServerboundContainerClickPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.play.ServerboundContainerClosePacket;
+import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.play.ServerboundCustomClickActionPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.play.ServerboundInteractPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.play.ServerboundKeepAlivePacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.play.ServerboundMovePlayerPosPacket;
@@ -18,6 +18,7 @@ import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.play.Ser
 import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.play.ServerboundPlayerActionPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.play.ServerboundPlayerInputPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.play.ServerboundPlayerLoadedPacket;
+import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.play.ServerboundResourcePackPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.play.ServerboundSetCarriedItemPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.play.ServerboundSetCreativeModeSlotPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.play.ServerboundSwingPacket;
@@ -66,6 +67,8 @@ public interface PlayPacketListener extends PacketListener {
     void handleSwing(ServerboundSwingPacket packet);
 
     void handleClientCommand(ServerboundClientCommandPacket packet);
+
+    void handleResourcePackResponse(ServerboundResourcePackPacket packet);
 
     void handlePlayerInput(ServerboundPlayerInputPacket packet);
 }

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/protocol/packet/serverbound/configuration/ServerboundCustomClickActionPacket.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/protocol/packet/serverbound/configuration/ServerboundCustomClickActionPacket.java
@@ -1,0 +1,25 @@
+package fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.configuration;
+
+import fr.euphyllia.fidorial.server.network.PacketBuffer;
+import fr.euphyllia.fidorial.server.network.protocol.packet.listener.ConfigurationPacketListener;
+import fr.euphyllia.fidorial.server.world.nbt.Nbt;
+import fr.fidorial.protocol.PacketListener;
+import fr.fidorial.protocol.ServerboundPacket;
+import net.kyori.adventure.key.Key;
+
+// https://minecraft.wiki/w/Java_Edition_protocol/Packets#Custom_Click_Action
+public record ServerboundCustomClickActionPacket(Key id, Nbt payload) implements ServerboundPacket {
+
+    private static final int MAX_PAYLOAD_BYTES = 65536;
+
+    public static ServerboundCustomClickActionPacket read(final PacketBuffer buf) {
+        final Key id = buf.readKey();
+        final Nbt payload = buf.readSizedNbt(MAX_PAYLOAD_BYTES);
+        return new ServerboundCustomClickActionPacket(id, payload);
+    }
+
+    @Override
+    public void handle(final PacketListener listener) {
+        ((ConfigurationPacketListener) listener).handleCustomClickAction(this);
+    }
+}

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/protocol/packet/serverbound/configuration/ServerboundResourcePackPacket.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/protocol/packet/serverbound/configuration/ServerboundResourcePackPacket.java
@@ -1,0 +1,38 @@
+package fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.configuration;
+
+import fr.euphyllia.fidorial.server.network.PacketBuffer;
+import fr.euphyllia.fidorial.server.network.protocol.packet.listener.ConfigurationPacketListener;
+import fr.fidorial.protocol.PacketListener;
+import fr.fidorial.protocol.ServerboundPacket;
+import net.kyori.adventure.resource.ResourcePackStatus;
+
+import java.util.UUID;
+
+// https://minecraft.wiki/w/Java_Edition_protocol/Packets#Resource_Pack_Response
+public record ServerboundResourcePackPacket(UUID id, ResourcePackStatus status) implements ServerboundPacket {
+
+    // look at Result box under the packet
+    private static final ResourcePackStatus[] BY_WIRE_ID = {
+            ResourcePackStatus.SUCCESSFULLY_LOADED,
+            ResourcePackStatus.DECLINED,
+            ResourcePackStatus.FAILED_DOWNLOAD,
+            ResourcePackStatus.ACCEPTED,
+            ResourcePackStatus.DOWNLOADED,
+            ResourcePackStatus.INVALID_URL,
+            ResourcePackStatus.FAILED_RELOAD,
+            ResourcePackStatus.DISCARDED
+    };
+
+    public static ServerboundResourcePackPacket read(final PacketBuffer buf) {
+        final UUID id = buf.readUuid();
+        final int wireId = buf.readVarInt();
+        final ResourcePackStatus status =
+                (wireId >= 0 && wireId < BY_WIRE_ID.length) ? BY_WIRE_ID[wireId] : ResourcePackStatus.DISCARDED;
+        return new ServerboundResourcePackPacket(id, status);
+    }
+
+    @Override
+    public void handle(final PacketListener listener) {
+        ((ConfigurationPacketListener) listener).handleResourcePackResponse(this);
+    }
+}

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/protocol/packet/serverbound/play/ServerboundCustomClickActionPacket.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/protocol/packet/serverbound/play/ServerboundCustomClickActionPacket.java
@@ -1,4 +1,4 @@
-package fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.common;
+package fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.play;
 
 import fr.euphyllia.fidorial.server.network.PacketBuffer;
 import fr.euphyllia.fidorial.server.network.protocol.packet.listener.PlayPacketListener;

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/protocol/packet/serverbound/play/ServerboundResourcePackPacket.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/protocol/packet/serverbound/play/ServerboundResourcePackPacket.java
@@ -1,0 +1,38 @@
+package fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.play;
+
+import fr.euphyllia.fidorial.server.network.PacketBuffer;
+import fr.euphyllia.fidorial.server.network.protocol.packet.listener.PlayPacketListener;
+import fr.fidorial.protocol.PacketListener;
+import fr.fidorial.protocol.ServerboundPacket;
+import net.kyori.adventure.resource.ResourcePackStatus;
+
+import java.util.UUID;
+
+// https://minecraft.wiki/w/Java_Edition_protocol/Packets#Resource_Pack_Response
+public record ServerboundResourcePackPacket(UUID id, ResourcePackStatus status) implements ServerboundPacket {
+
+    // look at Result box under the packet
+    private static final ResourcePackStatus[] BY_WIRE_ID = {
+            ResourcePackStatus.SUCCESSFULLY_LOADED, // 0
+            ResourcePackStatus.DECLINED,             // 1
+            ResourcePackStatus.FAILED_DOWNLOAD,      // 2
+            ResourcePackStatus.ACCEPTED,             // 3
+            ResourcePackStatus.DOWNLOADED,           // 4
+            ResourcePackStatus.INVALID_URL,          // 5
+            ResourcePackStatus.FAILED_RELOAD,        // 6
+            ResourcePackStatus.DISCARDED             // 7
+    };
+
+    public static ServerboundResourcePackPacket read(final PacketBuffer buf) {
+        final UUID id = buf.readUuid();
+        final int wireId = buf.readVarInt();
+        final ResourcePackStatus status =
+                (wireId >= 0 && wireId < BY_WIRE_ID.length) ? BY_WIRE_ID[wireId] : ResourcePackStatus.DISCARDED;
+        return new ServerboundResourcePackPacket(id, status);
+    }
+
+    @Override
+    public void handle(final PacketListener listener) {
+        ((PlayPacketListener) listener).handleResourcePackResponse(this);
+    }
+}

--- a/fidorial-test-plugin/src/main/java/fr/euphyllia/fidorial/testplugin/command/ApiTestCommand.java
+++ b/fidorial-test-plugin/src/main/java/fr/euphyllia/fidorial/testplugin/command/ApiTestCommand.java
@@ -26,13 +26,18 @@ import fr.fidorial.world.generation.WorldGenerator;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.bossbar.BossBar;
 import net.kyori.adventure.key.Key;
+import net.kyori.adventure.resource.ResourcePackCallback;
+import net.kyori.adventure.resource.ResourcePackInfo;
+import net.kyori.adventure.resource.ResourcePackRequest;
 import net.kyori.adventure.sound.Sound;
 import net.kyori.adventure.sound.SoundStop;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.event.ClickCallback;
 import net.kyori.adventure.text.event.ClickEvent;
 import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.minimessage.MiniMessage;
 
+import java.net.URI;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
@@ -122,6 +127,8 @@ public final class ApiTestCommand {
                                 .executes(ApiTestCommand::baguette)))
                 .then(literal("itemhover").executes(ApiTestCommand::itemHover))
                 .then(literal("playerhead").executes(ApiTestCommand::playerHead))
+                .then(literal("resourcepack")
+                        .executes(ApiTestCommand::resourcePackBroadcast))
                 // TODO: should become a standalone command in fidorial tbh like vanilla /bossbar, and be expanded to match vanilla args too (with our additional flags)
                 .then(literal("bossbar")
                         .then(literal("show")
@@ -509,6 +516,31 @@ public final class ApiTestCommand {
         final Component head = Component.object(player);
 
         sender.sendMessage(Component.text("[TestPlugin] Your head: ").append(head));
+
+        return Command.SINGLE_SUCCESS;
+    }
+
+    private static int resourcePackBroadcast(final CommandContext<CommandSource> ctx) {
+        final var server = ctx.getSource().server();
+
+        final ResourcePackInfo pack = ResourcePackInfo.resourcePackInfo(
+                UUID.fromString("2e26aec4-e14c-4947-bdc1-99c391d6d257"),
+                URI.create("https://download.mc-packs.net/pack/e7d205a0f0c8bef05cdd540e08b0437fbdb973d2.zip"),
+                "e7d205a0f0c8bef05cdd540e08b0437fbdb973d2");
+
+        final ResourcePackRequest request = ResourcePackRequest.resourcePackRequest()
+                .packs(pack)
+                .required(false)
+                .prompt(MiniMessage.miniMessage().deserialize(
+                        "<gradient:blue:white:red>[TestPlugin] Try the best custom resource pack!</gradient>"))
+                .callback(ResourcePackCallback.onTerminal(
+                        (id, audience) -> audience.sendMessage(Component.text("Pack loaded, thanks!", NamedTextColor.GREEN)),
+                        (id, audience) -> audience.sendMessage(Component.text("Pack failed or declined.", NamedTextColor.RED))))
+                .build();
+
+        server.sendResourcePacks(request);
+
+        msg(ctx.getSource().sender(), "[TestPlugin] Resource pack request sent to " + server.playerCount() + " player(s).");
 
         return Command.SINGLE_SUCCESS;
     }


### PR DESCRIPTION
This implements resource pack methods along with the relevant Adventure Audience APIs, with MiniMessage formatting for the prompt in `fidorial.properties`

### Notes
- A test resource pack made by me has been bundled into a new `/apitest resourcepack` command which sends it to all players for testing
- Fixed the handling of custom click action configuration-state packet
- Made `ClientConnection` queue all messages sent to the player before it enters the `PLAY` state and then flushes them

<img width="982" height="408" alt="image" src="https://github.com/user-attachments/assets/674ad26d-bfcd-4b20-9f48-275bfe6a54ed" />

<img width="1231" height="330" alt="image" src="https://github.com/user-attachments/assets/ac12bcc1-b151-4601-bc38-e875d605b3f8" />

