### PR TITLE
Optimize saveLoadedEntities by tracking dirty chunks

### DIFF
--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/AbstractEntity.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/AbstractEntity.java
@@ -161,7 +161,7 @@ public abstract class AbstractEntity implements Entity {
 
             if (from == target) {
                 setLocation(location);
-                target.entityManager().moved(this, previous.chunk(), location.chunk());
+                target.entityMoved(this, previous.chunk(), location.chunk());
             } else {
                 if (from instanceof final ServerWorld old) {
                     old.removeEntity(this);

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/EntityManager.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/EntityManager.java
@@ -2,6 +2,7 @@ package fr.euphyllia.fidorial.server.entity;
 
 import fr.euphyllia.fidorial.server.schedulers.ThreadedRegionRegionizer;
 import fr.fidorial.world.ChunkPos;
+import org.jetbrains.annotations.ApiStatus;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -27,49 +28,52 @@ public final class EntityManager {
         return ((long) sectionZ << 32) | (sectionX & 0xFFFFFFFFL);
     }
 
+    @ApiStatus.Internal
     public void add(final AbstractEntity entity) {
         byId.put(entity.entityId(), entity);
         byUuid.put(entity.uuid(), entity);
         final ChunkPos chunk = entity.chunk();
-        byChunk.computeIfAbsent(ChunkPos.chunkKey(chunk), k -> ConcurrentHashMap.newKeySet()).add(entity);
+        byChunk.computeIfAbsent(ChunkPos.chunkKey(chunk), _ -> ConcurrentHashMap.newKeySet()).add(entity);
         bySection
-                .computeIfAbsent(sectionKey(chunk), k -> ConcurrentHashMap.newKeySet())
+                .computeIfAbsent(sectionKey(chunk), _ -> ConcurrentHashMap.newKeySet())
                 .add(entity);
     }
 
+    @ApiStatus.Internal
     public void remove(final AbstractEntity entity) {
         byId.remove(entity.entityId());
         byUuid.remove(entity.uuid());
         final ChunkPos chunk = entity.chunk();
-        byChunk.computeIfPresent(ChunkPos.chunkKey(chunk), (k, set) -> {
+        byChunk.computeIfPresent(ChunkPos.chunkKey(chunk), (_, set) -> {
             set.remove(entity);
             return set.isEmpty() ? null : set;
         });
-        bySection.computeIfPresent(sectionKey(chunk), (k, set) -> {
+        bySection.computeIfPresent(sectionKey(chunk), (_, set) -> {
             set.remove(entity);
             return set.isEmpty() ? null : set;
         });
     }
 
+    @ApiStatus.Internal
     public void moved(final AbstractEntity entity, final ChunkPos from, final ChunkPos to) {
         if (from.equals(to)) {
             return;
         }
-        byChunk.computeIfPresent(ChunkPos.chunkKey(from), (k, set) -> {
+        byChunk.computeIfPresent(ChunkPos.chunkKey(from), (_, set) -> {
             set.remove(entity);
             return set.isEmpty() ? null : set;
         });
-        byChunk.computeIfAbsent(ChunkPos.chunkKey(to), k -> ConcurrentHashMap.newKeySet()).add(entity);
+        byChunk.computeIfAbsent(ChunkPos.chunkKey(to), _ -> ConcurrentHashMap.newKeySet()).add(entity);
 
         final long fromSection = sectionKey(from);
         final long toSection = sectionKey(to);
         if (fromSection != toSection) {
-            bySection.computeIfPresent(fromSection, (k, set) -> {
+            bySection.computeIfPresent(fromSection, (_, set) -> {
                 set.remove(entity);
                 return set.isEmpty() ? null : set;
             });
             bySection
-                    .computeIfAbsent(toSection, k -> ConcurrentHashMap.newKeySet())
+                    .computeIfAbsent(toSection, _ -> ConcurrentHashMap.newKeySet())
                     .add(entity);
         }
     }

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/MovingMob.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/mob/MovingMob.java
@@ -189,7 +189,7 @@ public abstract class MovingMob extends Mob {
         final ChunkPos fromChunk = before.chunk();
         final ChunkPos toChunk = after.chunk();
         if (!fromChunk.equals(toChunk)) {
-            serverWorld().entityManager().moved(this, fromChunk, toChunk);
+            serverWorld().entityMoved(this, fromChunk, toChunk);
             server().regionizer().moveTicket(serverWorld().dimension().id(), fromChunk, toChunk);
         }
     }

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/ServerWorld.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/ServerWorld.java
@@ -21,8 +21,10 @@ import fr.fidorial.world.Chunk;
 import fr.fidorial.world.ChunkPos;
 import fr.fidorial.world.World;
 import fr.fidorial.world.entity.EntitySpawnBridge;
+import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import it.unimi.dsi.fastutil.longs.LongSet;
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.nbt.CompoundBinaryTag;
@@ -59,6 +61,7 @@ public final class ServerWorld implements World {
 
     private final Map<Long, ChunkColumn> loaded = new ConcurrentHashMap<>();
     private final Set<Long> dirty = ConcurrentHashMap.newKeySet();
+    private final Set<Long> entitiesDirty = ConcurrentHashMap.newKeySet();
     private final Set<Long> entitiesLoaded = ConcurrentHashMap.newKeySet();
     private final Set<ChunkViewSource> viewers = ConcurrentHashMap.newKeySet();
     private volatile @Nullable AsyncChunkLoader chunkLoader;
@@ -215,6 +218,7 @@ public final class ServerWorld implements World {
 
     public void addEntity(final AbstractEntity entity) {
         entities.add(entity);
+        markEntitiesDirty(entity.chunk().x(), entity.chunk().z());
         if (entity instanceof ServerPlayer) {
             invalidateAudiences();
         }
@@ -222,6 +226,7 @@ public final class ServerWorld implements World {
 
     public void removeEntity(final AbstractEntity entity) {
         entities.remove(entity);
+        markEntitiesDirty(entity.chunk().x(), entity.chunk().z());
         if (entity instanceof ServerPlayer) {
             invalidateAudiences();
         }
@@ -299,8 +304,7 @@ public final class ServerWorld implements World {
         }
     }
 
-    private void saveChunkEntities(final int chunkX, final int chunkZ) throws IOException {
-        final List<AbstractEntity> inChunk = persistableEntities(chunkX, chunkZ);
+    private void saveChunkEntities(final int chunkX, final int chunkZ, final List<AbstractEntity> inChunk) throws IOException {
         if (inChunk.isEmpty() && !entityStorage.hasChunk(dimension, chunkX, chunkZ)) {
             return;
         }
@@ -318,14 +322,30 @@ public final class ServerWorld implements World {
         return result;
     }
 
+    private Long2ObjectOpenHashMap<List<AbstractEntity>> bucketPersistableEntities() {
+        final Long2ObjectOpenHashMap<List<AbstractEntity>> byChunk = new Long2ObjectOpenHashMap<>();
+        for (final AbstractEntity entity : entities.all()) {
+            if (!AnvilEntitySerializer.isPersistable(entity)) {
+                continue;
+            }
+            final ChunkPos pos = entity.chunk();
+            final long key = ChunkPos.chunkKey(pos.x(), pos.z());
+            byChunk.computeIfAbsent(key, _ -> new ObjectArrayList<>()).add(entity);
+        }
+        return byChunk;
+    }
+
     private void unloadChunkEntities(final int chunkX, final int chunkZ) throws IOException {
         final long k = ChunkPos.chunkKey(chunkX, chunkZ);
         if (!entitiesLoaded.remove(k)) {
             return;
         }
-        saveChunkEntities(chunkX, chunkZ);
+        final List<AbstractEntity> inChunk = persistableEntities(chunkX, chunkZ);
+        saveChunkEntities(chunkX, chunkZ, inChunk);
+        entitiesDirty.remove(k);
+
         final EntitySpawnBridge bridge = this.entityBridge;
-        for (final AbstractEntity entity : persistableEntities(chunkX, chunkZ)) {
+        for (final AbstractEntity entity : inChunk) {
             entities.remove(entity);
 
             if (entity instanceof ServerPlayer) {
@@ -401,12 +421,26 @@ public final class ServerWorld implements World {
         saveLoadedEntities();
     }
 
-    // Todo : It will be very resource-intensive if there are many entities; this method will need to be modified.
+    public void markEntitiesDirty(final int chunkX, final int chunkZ) {
+        entitiesDirty.add(ChunkPos.chunkKey(chunkX, chunkZ));
+    }
+
     private void saveLoadedEntities() throws IOException {
-        for (final long k : Set.copyOf(entitiesLoaded)) {
+        if (entitiesDirty.isEmpty()) {
+            return;
+        }
+        final Long2ObjectOpenHashMap<List<AbstractEntity>> byChunk = bucketPersistableEntities();
+
+        for (final long k : Set.copyOf(entitiesDirty)) {
+            if (!entitiesLoaded.contains(k)) {
+                entitiesDirty.remove(k);
+                continue;
+            }
             final int cx = (int) (k >> 32);
             final int cz = (int) k;
-            saveChunkEntities(cx, cz);
+            final List<AbstractEntity> inChunk = byChunk.getOrDefault(k, List.of());
+            saveChunkEntities(cx, cz, inChunk);
+            entitiesDirty.remove(k);
         }
     }
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/ServerWorld.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/ServerWorld.java
@@ -232,6 +232,14 @@ public final class ServerWorld implements World {
         }
     }
 
+    public void entityMoved(final AbstractEntity entity, final ChunkPos from, final ChunkPos to) {
+        entities.moved(entity, from, to);
+        if (!from.equals(to)) {
+            markEntitiesDirty(from.x(), from.z());
+            markEntitiesDirty(to.x(), to.z());
+        }
+    }
+
     public ChunkColumn getChunk(final int chunkX, final int chunkZ) throws IOException {
         final long k = ChunkPos.chunkKey(chunkX, chunkZ);
         final ChunkColumn cached = loaded.get(k);


### PR DESCRIPTION
Previously, `saveLoadedEntities` iterated over every loaded chunk on each autosave and re-serialized its entities regardless of whether anything had changed since the last save.

This introduces an `entitiesDirty` set, that tracks only the chunks with changes to entities, and made `saveLoadedEntities` iterate over only those chunks.