### PR TITLE
Threaded light engine

### DIFF
--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/FidorialServer.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/FidorialServer.java
@@ -111,10 +111,12 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public final class FidorialServer implements Server {
 
@@ -168,11 +170,13 @@ public final class FidorialServer implements Server {
     private final BossBarRegistry bossBarRegistry = new BossBarRegistry(worldManager.levelData(), this::players);
     private final DayNightThread dayNightEngine = new DayNightThread(worldManager, registries.dynamic());
     private final ChunkNetworkSerializer chunkSerializer = new ChunkNetworkSerializer(blockStateRegistry, registries.biomes());
-    private final ScheduledExecutorService lightWorker = Executors.newSingleThreadScheduledExecutor(
-            r -> Thread.ofPlatform().name("fidorial-light").unstarted(r));
+    private final AtomicInteger lightThreadId = new AtomicInteger();
+    private final ExecutorService lightPool = Executors.newFixedThreadPool(
+            Math.max(1, Runtime.getRuntime().availableProcessors() / 3),
+            r -> Thread.ofPlatform().name("fidorial-light-%d".formatted(lightThreadId.incrementAndGet())).unstarted(r));
 
     private final LightUpdateDispatcher lightDispatcher = new LightUpdateDispatcher(
-            lightWorker, this::broadcast, chunkSerializer, worldManager::world);
+            lightPool, WorldConstants.MIN_Y, WorldConstants.HEIGHT, this::broadcast, chunkSerializer, worldManager::world);
     private final BlockEditService blockEdits = new BlockEditService(
             blockStateRegistry,
             (pos, stateId) -> broadcast(new ClientboundBlockUpdatePacket(pos, stateId)),
@@ -277,7 +281,7 @@ public final class FidorialServer implements Server {
         closeQuietly("bossbars", bossBarRegistry::close);
         closeQuietly("day/night cycle", dayNightEngine::close);
         closeQuietly("network", network::shutdown);
-        closeQuietly("light engine", lightWorker::shutdownNow);
+        closeQuietly("light engine", lightPool::shutdownNow);
         closeQuietly("auto-save", autoSave::shutdownNow);
         closeQuietly("ia", aiWorker::shutdown);
         closeQuietly("regions", regionizer::shutdown);

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/FidorialServer.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/FidorialServer.java
@@ -168,8 +168,11 @@ public final class FidorialServer implements Server {
     private final BossBarRegistry bossBarRegistry = new BossBarRegistry(worldManager.levelData(), this::players);
     private final DayNightThread dayNightEngine = new DayNightThread(worldManager, registries.dynamic());
     private final ChunkNetworkSerializer chunkSerializer = new ChunkNetworkSerializer(blockStateRegistry, registries.biomes());
+    private final ScheduledExecutorService lightWorker = Executors.newSingleThreadScheduledExecutor(
+            r -> Thread.ofPlatform().name("fidorial-light").unstarted(r));
+
     private final LightUpdateDispatcher lightDispatcher = new LightUpdateDispatcher(
-            chunkWorker::execute, this::broadcast, chunkSerializer, worldManager::world);
+            lightWorker, this::broadcast, chunkSerializer, worldManager::world);
     private final BlockEditService blockEdits = new BlockEditService(
             blockStateRegistry,
             (pos, stateId) -> broadcast(new ClientboundBlockUpdatePacket(pos, stateId)),
@@ -274,6 +277,7 @@ public final class FidorialServer implements Server {
         closeQuietly("bossbars", bossBarRegistry::close);
         closeQuietly("day/night cycle", dayNightEngine::close);
         closeQuietly("network", network::shutdown);
+        closeQuietly("light engine", lightWorker::shutdownNow);
         closeQuietly("auto-save", autoSave::shutdownNow);
         closeQuietly("ia", aiWorker::shutdown);
         closeQuietly("regions", regionizer::shutdown);

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/FidorialServer.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/FidorialServer.java
@@ -172,7 +172,7 @@ public final class FidorialServer implements Server {
     private final ChunkNetworkSerializer chunkSerializer = new ChunkNetworkSerializer(blockStateRegistry, registries.biomes());
     private final AtomicInteger lightThreadId = new AtomicInteger();
     private final ExecutorService lightPool = Executors.newFixedThreadPool(
-            Math.max(1, Runtime.getRuntime().availableProcessors() / 3),
+            config.lightWorkers(),
             r -> Thread.ofPlatform().name("fidorial-light-%d".formatted(lightThreadId.incrementAndGet())).unstarted(r));
 
     private final LightUpdateDispatcher lightDispatcher = new LightUpdateDispatcher(

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/ServerConfig.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/ServerConfig.java
@@ -27,6 +27,7 @@ public record ServerConfig(
         int autoSaveSeconds,
         int regionWorkers,
         int chunkWorkers,
+        int lightWorkers,
         int aiWorkers,
         int regionShift,
         GameMode defaultGameMode,
@@ -99,6 +100,7 @@ public record ServerConfig(
                 Math.max(2, cpus / 2),
                 Math.max(2, cpus / 8),
                 Math.max(2, cpus / 8),
+                Math.max(2, cpus / 8),
                 5,
                 GameMode.SURVIVAL,
                 WorldConstants.DEFAULT_SPAWN_X,
@@ -145,6 +147,7 @@ public record ServerConfig(
                 readInt(props, "auto-save-seconds", defaults.autoSaveSeconds()),
                 readInt(props, "region-workers", defaults.regionWorkers()),
                 readInt(props, "chunk-workers", defaults.chunkWorkers()),
+                readInt(props, "light-workers", defaults.lightWorkers()),
                 readInt(props, "ai-workers", defaults.aiWorkers()),
                 readInt(props, "region-section-shift", defaults.regionShift()),
                 readGameMode(props, "default-game-mode", defaults.defaultGameMode()),
@@ -286,6 +289,7 @@ public record ServerConfig(
         props.setProperty("auto-save-seconds", Integer.toString(autoSaveSeconds));
         props.setProperty("region-workers", Integer.toString(regionWorkers));
         props.setProperty("chunk-workers", Integer.toString(chunkWorkers));
+        props.setProperty("light-workers", Integer.toString(lightWorkers));
         props.setProperty("ai-workers", Integer.toString(aiWorkers));
         props.setProperty("region-section-shift", Integer.toString(regionShift));
         props.setProperty("default-game-mode", defaultGameMode.name().toLowerCase(Locale.ROOT));

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/schedulers/ChunkRegionScheduler.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/schedulers/ChunkRegionScheduler.java
@@ -1,9 +1,9 @@
 package fr.euphyllia.fidorial.server.schedulers;
 
 import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.longs.LongIterator;
 import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import it.unimi.dsi.fastutil.longs.LongSet;
-import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -12,7 +12,7 @@ import java.util.concurrent.Executor;
 public final class ChunkRegionScheduler {
 
     private final LongOpenHashSet locked = new LongOpenHashSet();
-    private final Long2ObjectOpenHashMap<@Nullable List<PendingTask>> waitingOn = new Long2ObjectOpenHashMap<>();
+    private final Long2ObjectOpenHashMap<List<PendingTask>> waitingOn = new Long2ObjectOpenHashMap<>();
     private final Executor executor;
 
     public ChunkRegionScheduler(final Executor executor) {
@@ -20,64 +20,87 @@ public final class ChunkRegionScheduler {
     }
 
     public synchronized void submit(final LongSet keys, final Runnable task) {
-        final LongOpenHashSet blockers = overlapping(keys);
-        final PendingTask pending = new PendingTask(keys, task, blockers.size());
-
+        final PendingTask pending = new PendingTask(new LongOpenHashSet(keys), task);
+        final LongOpenHashSet blockers = registerAndCollectBlockers(pending);
         if (blockers.isEmpty()) {
             lockAndRun(pending);
-            return;
-        }
-
-        for (final long k : blockers) {
-            waitingOn.computeIfAbsent(k, _ -> new ArrayList<>()).add(pending);
+        } else {
+            pending.remainingBlockers = blockers.size();
         }
     }
 
-    private void lockAndRun(final PendingTask task) {
-        locked.addAll(task.keys);
+    private LongOpenHashSet registerAndCollectBlockers(final PendingTask pending) {
+        final LongOpenHashSet blockers = new LongOpenHashSet();
+        final LongIterator it = pending.keys.iterator();
+        while (it.hasNext()) {
+            final long k = it.nextLong();
+            if (locked.contains(k)) {
+                blockers.add(k);
+                waitingOn.computeIfAbsent(k, _ -> new ArrayList<>()).add(pending);
+            }
+        }
+        return blockers;
+    }
+
+    private void lockAndRun(final PendingTask pending) {
+        locked.addAll(pending.keys);
         executor.execute(() -> {
             try {
-                task.task.run();
+                pending.task.run();
             } finally {
-                release(task.keys);
+                release(pending);
             }
         });
     }
 
-    private synchronized void release(final LongSet keys) {
-        locked.removeAll(keys);
-        for (final long k : keys) {
-            final List<PendingTask> list = waitingOn.remove(k);
-            if (list == null) {
-                continue;
-            }
-            for (final PendingTask p : list) {
+    private synchronized void release(final PendingTask finished) {
+        locked.removeAll(finished.keys);
+
+        List<PendingTask> ready = null;
+        final LongIterator it = finished.keys.iterator();
+        while (it.hasNext()) {
+            final long k = it.nextLong();
+            final List<PendingTask> waiters = waitingOn.remove(k);
+            if (waiters == null) continue;
+            for (final PendingTask p : waiters) {
                 if (--p.remainingBlockers == 0) {
-                    lockAndRun(p);
+                    if (ready == null) ready = new ArrayList<>();
+                    ready.add(p);
                 }
             }
         }
+        if (ready == null) return;
+
+        for (final PendingTask p : ready) {
+            tryStart(p);
+        }
     }
 
-    private LongOpenHashSet overlapping(final LongSet keys) {
-        final LongOpenHashSet result = new LongOpenHashSet();
-        for (final long k : keys) {
-            if (locked.contains(k)) {
-                result.add(k);
-            }
+    private void tryStart(final PendingTask p) {
+        if (!isBlocked(p.keys)) {
+            lockAndRun(p);
+            return;
         }
-        return result;
+        final LongOpenHashSet blockers = registerAndCollectBlockers(p);
+        p.remainingBlockers = blockers.size();
+    }
+
+    private boolean isBlocked(final LongOpenHashSet keys) {
+        final LongIterator it = keys.iterator();
+        while (it.hasNext()) {
+            if (locked.contains(it.nextLong())) return true;
+        }
+        return false;
     }
 
     private static final class PendingTask {
-        final LongSet keys;
+        final LongOpenHashSet keys;
         final Runnable task;
         int remainingBlockers;
 
-        PendingTask(final LongSet keys, final Runnable task, final int remainingBlockers) {
+        PendingTask(final LongOpenHashSet keys, final Runnable task) {
             this.keys = keys;
             this.task = task;
-            this.remainingBlockers = remainingBlockers;
         }
     }
 }

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/schedulers/ChunkRegionScheduler.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/schedulers/ChunkRegionScheduler.java
@@ -1,0 +1,83 @@
+package fr.euphyllia.fidorial.server.schedulers;
+
+import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
+import it.unimi.dsi.fastutil.longs.LongSet;
+import org.jspecify.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Executor;
+
+public final class ChunkRegionScheduler {
+
+    private final LongOpenHashSet locked = new LongOpenHashSet();
+    private final Long2ObjectOpenHashMap<@Nullable List<PendingTask>> waitingOn = new Long2ObjectOpenHashMap<>();
+    private final Executor executor;
+
+    public ChunkRegionScheduler(final Executor executor) {
+        this.executor = executor;
+    }
+
+    public synchronized void submit(final LongSet keys, final Runnable task) {
+        final LongOpenHashSet blockers = overlapping(keys);
+        final PendingTask pending = new PendingTask(keys, task, blockers.size());
+
+        if (blockers.isEmpty()) {
+            lockAndRun(pending);
+            return;
+        }
+
+        for (final long k : blockers) {
+            waitingOn.computeIfAbsent(k, _ -> new ArrayList<>()).add(pending);
+        }
+    }
+
+    private void lockAndRun(final PendingTask task) {
+        locked.addAll(task.keys);
+        executor.execute(() -> {
+            try {
+                task.task.run();
+            } finally {
+                release(task.keys);
+            }
+        });
+    }
+
+    private synchronized void release(final LongSet keys) {
+        locked.removeAll(keys);
+        for (final long k : keys) {
+            final List<PendingTask> list = waitingOn.remove(k);
+            if (list == null) {
+                continue;
+            }
+            for (final PendingTask p : list) {
+                if (--p.remainingBlockers == 0) {
+                    lockAndRun(p);
+                }
+            }
+        }
+    }
+
+    private LongOpenHashSet overlapping(final LongSet keys) {
+        final LongOpenHashSet result = new LongOpenHashSet();
+        for (final long k : keys) {
+            if (locked.contains(k)) {
+                result.add(k);
+            }
+        }
+        return result;
+    }
+
+    private static final class PendingTask {
+        final LongSet keys;
+        final Runnable task;
+        int remainingBlockers;
+
+        PendingTask(final LongSet keys, final Runnable task, final int remainingBlockers) {
+            this.keys = keys;
+            this.task = task;
+            this.remainingBlockers = remainingBlockers;
+        }
+    }
+}

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/schedulers/LightUpdateDispatcher.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/schedulers/LightUpdateDispatcher.java
@@ -206,15 +206,17 @@ public class LightUpdateDispatcher {
         }
     }
 
-    private static LongSet withNeighborRing(final LongSet chunkKeys) {
-        final LongOpenHashSet ring = new LongOpenHashSet(chunkKeys.size() * 9);
+    private static LongSet withNeighborRing(final LongOpenHashSet chunkKeys) {
+        final LongOpenHashSet ring = new LongOpenHashSet(chunkKeys);
         final LongIterator it = chunkKeys.iterator();
         while (it.hasNext()) {
             final long key = it.nextLong();
             final int cx = (int) (key >> 32), cz = (int) key;
             for (int dx = -1; dx <= 1; dx++)
-                for (int dz = -1; dz <= 1; dz++)
-                    ring.add(ChunkPos.chunkKey(cx + dx, cz + dz));
+                for (int dz = -1; dz <= 1; dz++) {
+                    final long nk = ChunkPos.chunkKey(cx + dx, cz + dz);
+                    if (!chunkKeys.contains(nk)) ring.add(nk);
+                }
         }
         return ring;
     }

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/schedulers/LightUpdateDispatcher.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/schedulers/LightUpdateDispatcher.java
@@ -35,7 +35,7 @@ public class LightUpdateDispatcher {
 
     private static final ComponentLogger LOGGER = ComponentLogger.logger(LightUpdateDispatcher.class);
 
-    private static final int CLUSTER_SHIFT = 3;
+    private static final int CLUSTER_SHIFT = 3; // seems to give the most optimal CPS
 
     private final ExecutorService lightPool;
     private final Consumer<ClientboundPacket> broadcaster;

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/schedulers/LightUpdateDispatcher.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/schedulers/LightUpdateDispatcher.java
@@ -5,16 +5,20 @@ import fr.euphyllia.fidorial.server.network.protocol.packet.clientbound.play.Cli
 import fr.euphyllia.fidorial.server.world.ChunkNetworkSerializer;
 import fr.euphyllia.fidorial.server.world.ServerWorld;
 import fr.euphyllia.fidorial.server.world.chunk.ChunkColumn;
+import fr.euphyllia.fidorial.server.world.light.FloodFillLightEngine;
+import fr.euphyllia.fidorial.server.world.light.LightEnginePool;
 import fr.fidorial.world.BlockPos;
 import fr.fidorial.world.ChunkPos;
 import it.unimi.dsi.fastutil.longs.Long2IntOpenHashMap;
 import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.longs.LongIterator;
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
+import it.unimi.dsi.fastutil.longs.LongSet;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.logger.slf4j.ComponentLogger;
 import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
@@ -22,7 +26,8 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -30,10 +35,14 @@ public class LightUpdateDispatcher {
 
     private static final ComponentLogger LOGGER = ComponentLogger.logger(LightUpdateDispatcher.class);
 
-    private final Executor worker;
+    private static final int CLUSTER_SHIFT = 3;
+
+    private final ExecutorService lightPool;
     private final Consumer<ClientboundPacket> broadcaster;
     private final ChunkNetworkSerializer serializer;
     private final Function<Key, @Nullable ServerWorld> worldLookup;
+    private final LightEnginePool enginePool;
+    private final ChunkRegionScheduler regionScheduler;
 
     private final Map<Key, WorldLightState> states = new ConcurrentHashMap<>();
 
@@ -43,12 +52,16 @@ public class LightUpdateDispatcher {
     private final Set<Key> scheduledChunks = ConcurrentHashMap.newKeySet();
 
     public LightUpdateDispatcher(
-            final Executor worker,
+            final ExecutorService lightPool,
+            final int minY,
+            final int height,
             final Consumer<ClientboundPacket> broadcaster,
             final ChunkNetworkSerializer serializer,
             final Function<Key, @Nullable ServerWorld> worldLookup
     ) {
-        this.worker = worker;
+        this.lightPool = lightPool;
+        this.enginePool = new LightEnginePool(((ThreadPoolExecutor) lightPool).getMaximumPoolSize(), minY, height);
+        this.regionScheduler = new ChunkRegionScheduler(lightPool);
         this.broadcaster = broadcaster;
         this.serializer = serializer;
         this.worldLookup = worldLookup;
@@ -66,20 +79,18 @@ public class LightUpdateDispatcher {
 
     public void queueChunkLoad(final Key world, final int chunkX, final int chunkZ) {
         final Set<Long> set = pendingChunks.computeIfAbsent(world, _ -> ConcurrentHashMap.newKeySet());
-        final long[] added = new long[9];
-        int count = 0;
+        final WorldLightState state = stateFor(world);
 
-        for (int dx = -1; dx <= 1; dx++) {
-            for (int dz = -1; dz <= 1; dz++) {
-                final long key = ChunkPos.chunkKey(chunkX + dx, chunkZ + dz);
-                if (set.add(key)) {
-                    added[count++] = key;
+        synchronized (state) {
+            for (int dx = -1; dx <= 1; dx++) {
+                for (int dz = -1; dz <= 1; dz++) {
+                    final long key = ChunkPos.chunkKey(chunkX + dx, chunkZ + dz);
+                    state.refCounts.addTo(key, 1);
+                    if (!set.add(key)) {
+                        state.refCounts.addTo(key, -1);
+                    }
                 }
             }
-        }
-
-        if (count != 0) {
-            increment(world, added, count);
         }
 
         scheduleChunks(world);
@@ -128,96 +139,157 @@ public class LightUpdateDispatcher {
     }
 
     private void drainBlocks(final Key world) {
-        int processed = 0;
-        try {
-            final Queue<BlockPos> queue = pendingBlocks.get(world);
-            if (queue == null || queue.isEmpty()) {
-                return;
-            }
-            final ServerWorld serverWorld = worldLookup.apply(world);
-            if (serverWorld == null) {
-                BlockPos drained;
-                while ((drained = queue.poll()) != null) {
-                    processed++;
-                    decrementArea(world, drained.x() >> 4, drained.z() >> 4);
-                }
-                return;
-            }
+        final Queue<BlockPos> queue = pendingBlocks.get(world);
+        if (queue == null) {
+            scheduledBlocks.remove(world);
+            return;
+        }
 
-            final Set<Long> dirtyChunks = new HashSet<>();
+        final ServerWorld serverWorld = worldLookup.apply(world);
+        if (!queue.isEmpty() && serverWorld != null) {
+            final Long2ObjectOpenHashMap<List<BlockPos>> byCluster = new Long2ObjectOpenHashMap<>();
+            int processed = 0;
             BlockPos pos;
             while (processed < 4096 && (pos = queue.poll()) != null) {
                 processed++;
-                dirtyChunks.addAll(serverWorld.checkBlockLight(pos.x(), pos.y(), pos.z()));
-                decrementArea(world, pos.x() >> 4, pos.z() >> 4);
+                final int cx = pos.x() >> 4;
+                final int cz = pos.z() >> 4;
+                final long clusterKey = ChunkPos.chunkKey(cx >> CLUSTER_SHIFT, cz >> CLUSTER_SHIFT);
+                byCluster.computeIfAbsent(clusterKey, _ -> new ArrayList<>()).add(pos);
             }
 
-            for (final long key : dirtyChunks) {
-                final ChunkColumn column = serverWorld.loadedColumn((int) (key >> 32), (int) key);
-                if (column != null) {
-                    final ClientboundLightUpdatePacket packet;
-                    synchronized (serverWorld.lightManager()) {
-                        packet = new ClientboundLightUpdatePacket(serializer, column);
-                    }
-                    broadcaster.accept(packet);
+            for (final Long2ObjectOpenHashMap.Entry<List<BlockPos>> entry : byCluster.long2ObjectEntrySet()) {
+                final List<BlockPos> positions = entry.getValue();
+                final LongOpenHashSet chunkKeys = new LongOpenHashSet();
+                for (final BlockPos p : positions) {
+                    chunkKeys.add(ChunkPos.chunkKey(p.x() >> 4, p.z() >> 4));
                 }
+                final LongSet lockKeys = withNeighborRing(chunkKeys);
+
+                regionScheduler.submit(lockKeys, () -> {
+                    FloodFillLightEngine engine = null;
+                    try {
+                        engine = enginePool.acquire();
+                        final LongOpenHashSet dirtyChunks = new LongOpenHashSet();
+                        for (final BlockPos p : positions) {
+                            dirtyChunks.addAll(serverWorld.checkBlockLight(p.x(), p.y(), p.z(), engine));
+                        }
+                        if (!dirtyChunks.isEmpty()) {
+                            final LongSet viewedChunks = serverWorld.collectAllViewedChunks();
+                            final LongIterator dirtyIt = dirtyChunks.iterator();
+                            while (dirtyIt.hasNext()) {
+                                final long key = dirtyIt.nextLong();
+                                if (!viewedChunks.contains(key)) continue;
+                                final ChunkColumn column = serverWorld.loadedColumn((int) (key >> 32), (int) key);
+                                if (column == null) {
+                                    continue;
+                                }
+                                broadcaster.accept(new ClientboundLightUpdatePacket(serializer, column));
+                            }
+                        }
+                    } catch (final InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    } finally {
+                        for (final BlockPos p : positions) {
+                            decrementArea(world, p.x() >> 4, p.z() >> 4);
+                        }
+                        if (engine != null) {
+                            enginePool.release(engine);
+                        }
+                    }
+                });
             }
-        } catch (final Throwable t) {
-            LOGGER.error("Lighting recalculation impossible for world {}", world, t);
-        } finally {
-            scheduledBlocks.remove(world);
         }
-        final Queue<BlockPos> stragglers = pendingBlocks.get(world);
-        if (stragglers != null && !stragglers.isEmpty()) {
+        scheduledBlocks.remove(world);
+        if (!queue.isEmpty()) {
             scheduleBlocks(world);
         }
     }
 
+    private static LongSet withNeighborRing(final LongSet chunkKeys) {
+        final LongOpenHashSet ring = new LongOpenHashSet(chunkKeys.size() * 9);
+        final LongIterator it = chunkKeys.iterator();
+        while (it.hasNext()) {
+            final long key = it.nextLong();
+            final int cx = (int) (key >> 32), cz = (int) key;
+            for (int dx = -1; dx <= 1; dx++)
+                for (int dz = -1; dz <= 1; dz++)
+                    ring.add(ChunkPos.chunkKey(cx + dx, cz + dz));
+        }
+        return ring;
+    }
+
     private void drainChunks(final Key world) {
-        Set<Long> batch = null;
-        try {
-            batch = pendingChunks.remove(world);
-            if (batch != null && !batch.isEmpty()) {
-                final ServerWorld serverWorld = worldLookup.apply(world);
-                if (serverWorld != null) {
-                    final Set<Long> dirty = serverWorld.relightChunks(batch);
-                    for (final long key : dirty) {
-                        final ChunkColumn column = serverWorld.loadedColumn((int) (key >> 32), (int) key);
-                        if (column != null) {
-                            final ClientboundLightUpdatePacket packet;
-                            synchronized (serverWorld.lightManager()) {
-                                packet = new ClientboundLightUpdatePacket(serializer, column);
-                            }
-                            broadcaster.accept(packet);
-                        }
-                    }
-                }
-            }
-        } catch (final Throwable t) {
-            LOGGER.error("Lighting recalculation impossible for world {}", world, t);
-        } finally {
+        final Set<Long> pending = pendingChunks.get(world);
+        if (pending == null) {
             scheduledChunks.remove(world);
-            if (batch != null && !batch.isEmpty()) {
-                final long[] keys = new long[batch.size()];
-                int i = 0;
-                for (final long key : batch) {
-                    keys[i++] = key;
+            return;
+        }
+
+        if (!pending.isEmpty()) {
+            final LongOpenHashSet snapshot = new LongOpenHashSet(pending);
+            pending.removeAll(snapshot);
+
+            final ServerWorld serverWorld = worldLookup.apply(world);
+            if (serverWorld == null) {
+                decrement(world, snapshot.toLongArray());
+            } else if (!snapshot.isEmpty()) {
+                final Long2ObjectOpenHashMap<LongOpenHashSet> clusters = new Long2ObjectOpenHashMap<>();
+                final LongIterator snapIt = snapshot.iterator();
+                while (snapIt.hasNext()) {
+                    final long key = snapIt.nextLong();
+                    final int cx = (int) (key >> 32);
+                    final int cz = (int) key;
+                    final long clusterKey = ChunkPos.chunkKey(cx >> CLUSTER_SHIFT, cz >> CLUSTER_SHIFT);
+                    clusters.computeIfAbsent(clusterKey, _ -> new LongOpenHashSet()).add(key);
                 }
-                decrement(world, keys);
+                for (final LongOpenHashSet subBatch : clusters.values()) {
+                    submitRelightTask(world, serverWorld, subBatch);
+                }
             }
         }
-        final Set<Long> stragglers = pendingChunks.get(world);
-        if (stragglers != null && !stragglers.isEmpty()) {
+
+        scheduledChunks.remove(world);
+        if (!pending.isEmpty()) {
             scheduleChunks(world);
         }
     }
 
+    private void submitRelightTask(final Key world, final ServerWorld serverWorld, final LongOpenHashSet subBatch) {
+        final LongSet lockKeys = withNeighborRing(subBatch);
+        regionScheduler.submit(lockKeys, () -> {
+            FloodFillLightEngine engine = null;
+            try {
+                engine = enginePool.acquire();
+                final Set<Long> dirtyChunks = serverWorld.relightChunks(subBatch, engine);
+                if (!dirtyChunks.isEmpty()) {
+                    final LongSet viewedChunks = serverWorld.collectAllViewedChunks();
+                    for (final long key : dirtyChunks) {
+                        if (!viewedChunks.contains(key)) continue;
+                        final ChunkColumn column = serverWorld.loadedColumn((int) (key >> 32), (int) key);
+                        if (column == null) {
+                            continue;
+                        }
+                        broadcaster.accept(new ClientboundLightUpdatePacket(serializer, column));
+                    }
+                }
+            } catch (final InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } catch (final Throwable t) {
+                LOGGER.error("Lighting recalculation impossible for world {}", world, t);
+            } finally {
+                if (engine != null) enginePool.release(engine);
+                decrement(world, subBatch.toLongArray());
+            }
+        });
+    }
+
     private void scheduleBlocks(final Key world) {
-        if (scheduledBlocks.add(world)) worker.execute(() -> drainBlocks(world));
+        if (scheduledBlocks.add(world)) lightPool.execute(() -> drainBlocks(world));
     }
 
     private void scheduleChunks(final Key world) {
-        if (scheduledChunks.add(world)) worker.execute(() -> drainChunks(world));
+        if (scheduledChunks.add(world)) lightPool.execute(() -> drainChunks(world));
     }
 
     private WorldLightState stateFor(final Key world) {

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/BlockStateRegistry.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/BlockStateRegistry.java
@@ -28,7 +28,7 @@ public record BlockStateRegistry(BlockRegistry registry) {
         if (data == null) {
             return BlockState.AIR;
         }
-        return new BlockState(data.key(), data.propertyMap());
+        return BlockState.of(data.key(), data.propertyMap());
     }
 
     public boolean contains(final BlockState state) {
@@ -36,7 +36,7 @@ public record BlockStateRegistry(BlockRegistry registry) {
     }
 
     public BlockState toBlockState(final BlockData data) {
-        return new BlockState(data.key(), data.propertyMap());
+        return BlockState.of(data.key(), data.propertyMap());
     }
 
     @SuppressWarnings("PatternValidation")
@@ -75,11 +75,11 @@ public record BlockStateRegistry(BlockRegistry registry) {
         }
 
         if (itemId.equals(Key.key("water_bucket"))) {
-            return new BlockState(Key.key("water"), Map.of("level", "0"));
+            return BlockState.of(Key.key("water"), Map.of("level", "0"));
         }
 
         if (itemId.equals(Key.key("lava_bucket"))) {
-            return new BlockState(Key.key("lava"), Map.of("level", "0"));
+            return BlockState.of(Key.key("lava"), Map.of("level", "0"));
         }
 
         final BlockState candidate = BlockState.of(itemId);

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/ChunkMapKey.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/ChunkMapKey.java
@@ -1,0 +1,34 @@
+package fr.euphyllia.fidorial.server.world;
+
+final class ChunkMapKey {
+    final long raw;
+    private final int hash;
+
+    private ChunkMapKey(final long raw) {
+        this.raw = raw;
+        this.hash = mix(raw);
+    }
+
+    static ChunkMapKey of(final long raw) {
+        return new ChunkMapKey(raw);
+    }
+
+    private static int mix(long h) {
+        h ^= (h >>> 33);
+        h *= 0xff51afd7ed558ccdL;
+        h ^= (h >>> 33);
+        h *= 0xc4ceb9fe1a85ec53L;
+        h ^= (h >>> 33);
+        return (int) h;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        return o instanceof ChunkMapKey other && other.raw == this.raw;
+    }
+
+    @Override
+    public int hashCode() {
+        return hash;
+    }
+}

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/ServerWorld.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/ServerWorld.java
@@ -275,10 +275,11 @@ public final class ServerWorld implements World {
             return;
         }
 
-        lightManager.lightChunkIfNeeded(column, chunkX, chunkZ);
         final LightUpdateDispatcher dispatcher = lightDispatcher;
         if (dispatcher != null) {
             dispatcher.queueChunkLoad(dimension.id(), chunkX, chunkZ);
+        } else {
+            lightManager.lightChunkIfNeeded(column, chunkX, chunkZ);
         }
     }
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/ServerWorld.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/ServerWorld.java
@@ -62,7 +62,7 @@ public final class ServerWorld implements World {
     private volatile @Nullable LightUpdateDispatcher lightDispatcher;
     private final FloodFillLightEngine fallbackEngine;
 
-    private final Map<Long, ChunkColumn> loaded = new ConcurrentHashMap<>();
+    private final Map<ChunkMapKey, ChunkColumn> loaded = new ConcurrentHashMap<>();
     private final Set<Long> dirty = ConcurrentHashMap.newKeySet();
     private final Set<Long> entitiesDirty = ConcurrentHashMap.newKeySet();
     private final Set<Long> entitiesLoaded = ConcurrentHashMap.newKeySet();
@@ -134,7 +134,7 @@ public final class ServerWorld implements World {
 
     @Override
     public CompletableFuture<Chunk> getChunkAsync(final int chunkX, final int chunkZ) {
-        final ChunkColumn cached = loaded.get(ChunkPos.chunkKey(chunkX, chunkZ));
+        final ChunkColumn cached = loaded.get(ChunkMapKey.of(ChunkPos.chunkKey(chunkX, chunkZ)));
         if (cached != null) {
             return CompletableFuture.completedFuture(wrap(cached));
         }
@@ -151,7 +151,7 @@ public final class ServerWorld implements World {
 
     @Override
     public Optional<Chunk> getChunkIfLoaded(final int chunkX, final int chunkZ) {
-        final ChunkColumn cached = loaded.get(ChunkPos.chunkKey(chunkX, chunkZ));
+        final ChunkColumn cached = loaded.get(ChunkMapKey.of(ChunkPos.chunkKey(chunkX, chunkZ)));
         return Optional.ofNullable(cached).map(this::wrap);
     }
 
@@ -246,13 +246,14 @@ public final class ServerWorld implements World {
 
     public ChunkColumn getChunk(final int chunkX, final int chunkZ) throws IOException {
         final long k = ChunkPos.chunkKey(chunkX, chunkZ);
-        final ChunkColumn cached = loaded.get(k);
+        final ChunkMapKey mapKey = ChunkMapKey.of(k);
+        final ChunkColumn cached = loaded.get(mapKey);
         if (cached != null) {
             return cached;
         }
         final ChunkColumn column;
         try {
-            column = loaded.computeIfAbsent(k, ignored -> {
+            column = loaded.computeIfAbsent(mapKey, ignored -> {
                 try {
                     final ChunkColumn fromDisk = storage.load(dimension, chunkX, chunkZ);
                     if (fromDisk != null) {
@@ -416,7 +417,7 @@ public final class ServerWorld implements World {
     public void saveDirty() throws IOException {
         lightFlushFuture(dirty).join();
         for (final long k : Set.copyOf(dirty)) {
-            final ChunkColumn chunk = loaded.get(k);
+            final ChunkColumn chunk = loaded.get(ChunkMapKey.of(k));
             if (chunk != null) {
                 storage.save(dimension, chunk);
             }
@@ -426,7 +427,11 @@ public final class ServerWorld implements World {
     }
 
     public void saveAll() throws IOException {
-        lightFlushFuture(loaded.keySet()).join();
+        final LongSet keys = new LongOpenHashSet(loaded.size());
+        for (final ChunkMapKey key : loaded.keySet()) {
+            keys.add(key.raw);
+        }
+        lightFlushFuture(keys).join();
         for (final ChunkColumn chunk : loaded.values()) {
             storage.save(dimension, chunk);
         }
@@ -475,7 +480,8 @@ public final class ServerWorld implements World {
         }
 
         final LongSet toUnload = new LongOpenHashSet();
-        for (final long k : loaded.keySet()) {
+        for (final ChunkMapKey mapKey : loaded.keySet()) {
+            final long k = mapKey.raw;
             if (!wanted.contains(k) && !dirty.contains(k)) {
                 toUnload.add(k);
             }
@@ -487,7 +493,7 @@ public final class ServerWorld implements World {
 
         int unloaded = 0;
         for (final long k : toUnload) {
-            if (loaded.remove(k) != null) {
+            if (loaded.remove(ChunkMapKey.of(k)) != null) {
                 unloaded++;
                 final int cx = (int) (k >> 32);
                 final int cz = (int) k;
@@ -507,18 +513,15 @@ public final class ServerWorld implements World {
             lightFlushFuture(LongSet.of(ChunkPos.chunkKey(chunkX, chunkZ))).join();
         }
         final long k = ChunkPos.chunkKey(chunkX, chunkZ);
+        final ChunkMapKey mapKey = ChunkMapKey.of(k);
         if (dirty.remove(k)) {
-            final ChunkColumn chunk = loaded.get(k);
+            final ChunkColumn chunk = loaded.get(mapKey);
             if (chunk != null) {
                 storage.save(dimension, chunk);
             }
         }
         unloadChunkEntities(chunkX, chunkZ);
-        loaded.remove(k);
-    }
-
-    public int loadedCount() {
-        return loaded.size();
+        loaded.remove(mapKey);
     }
 
     private void invalidateAudiences() {
@@ -541,7 +544,8 @@ public final class ServerWorld implements World {
     @Override
     public CompletableFuture<Boolean> unloadChunkAsync(final int chunkX, final int chunkZ) {
         final long k = ChunkPos.chunkKey(chunkX, chunkZ);
-        if (!loaded.containsKey(k)) {
+        final ChunkMapKey mapKey = ChunkMapKey.of(k);
+        if (!loaded.containsKey(mapKey)) {
             return CompletableFuture.completedFuture(false);
         }
 
@@ -572,7 +576,7 @@ public final class ServerWorld implements World {
     }
 
     public @Nullable ChunkColumn loadedColumn(final int chunkX, final int chunkZ) {
-        return loaded.get(ChunkPos.chunkKey(chunkX, chunkZ));
+        return loaded.get(ChunkMapKey.of(ChunkPos.chunkKey(chunkX, chunkZ)));
     }
 
     public WorldLightManager lightManager() {

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/ServerWorld.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/ServerWorld.java
@@ -8,7 +8,9 @@ import fr.euphyllia.fidorial.server.world.chunk.BlockState;
 import fr.euphyllia.fidorial.server.world.chunk.ChunkColumn;
 import fr.euphyllia.fidorial.server.world.entity.AnvilEntitySerializer;
 import fr.euphyllia.fidorial.server.world.light.ChunkLightData;
+import fr.euphyllia.fidorial.server.world.light.FloodFillLightEngine;
 import fr.euphyllia.fidorial.server.world.light.LightAccess;
+import fr.euphyllia.fidorial.server.world.light.LightEngine;
 import fr.euphyllia.fidorial.server.world.light.WorldLightManager;
 import fr.euphyllia.fidorial.server.world.storage.ChunkStorage;
 import fr.euphyllia.fidorial.server.world.storage.Dimension;
@@ -58,6 +60,7 @@ public final class ServerWorld implements World {
     private final int height;
     private final WorldLightManager lightManager;
     private volatile @Nullable LightUpdateDispatcher lightDispatcher;
+    private final FloodFillLightEngine fallbackEngine;
 
     private final Map<Long, ChunkColumn> loaded = new ConcurrentHashMap<>();
     private final Set<Long> dirty = ConcurrentHashMap.newKeySet();
@@ -88,7 +91,8 @@ public final class ServerWorld implements World {
         this.dayNightCycle = new WorldTimeEngine(WorldClocks.forDimension(dimension));
         this.minY = minY;
         this.height = height;
-        this.lightManager = new WorldLightManager(minY, height, new WorldLightAccess());
+        this.lightManager = new WorldLightManager(new WorldLightAccess());
+        this.fallbackEngine = new FloodFillLightEngine(minY, height);
     }
 
     public void setEntityBridge(final IntSupplier entityIdSupplier, final EntitySpawnBridge entityBridge) {
@@ -279,7 +283,7 @@ public final class ServerWorld implements World {
         if (dispatcher != null) {
             dispatcher.queueChunkLoad(dimension.id(), chunkX, chunkZ);
         } else {
-            lightManager.lightChunkIfNeeded(column, chunkX, chunkZ);
+            lightManager.lightChunkIfNeeded(column, chunkX, chunkZ, fallbackEngine);
         }
     }
 
@@ -410,7 +414,7 @@ public final class ServerWorld implements World {
     }
 
     public void saveDirty() throws IOException {
-        awaitLightFlush(dirty);
+        lightFlushFuture(dirty).join();
         for (final long k : Set.copyOf(dirty)) {
             final ChunkColumn chunk = loaded.get(k);
             if (chunk != null) {
@@ -422,7 +426,7 @@ public final class ServerWorld implements World {
     }
 
     public void saveAll() throws IOException {
-        awaitLightFlush(loaded.keySet());
+        lightFlushFuture(loaded.keySet()).join();
         for (final ChunkColumn chunk : loaded.values()) {
             storage.save(dimension, chunk);
         }
@@ -479,7 +483,7 @@ public final class ServerWorld implements World {
         if (toUnload.isEmpty()) {
             return 0;
         }
-        awaitLightFlush(toUnload);
+        lightFlushFuture(toUnload).join();
 
         int unloaded = 0;
         for (final long k : toUnload) {
@@ -498,8 +502,10 @@ public final class ServerWorld implements World {
         return unloaded;
     }
 
-    public void unloadChunk(final int chunkX, final int chunkZ) throws IOException {
-        awaitLightFlush(LongSet.of(ChunkPos.chunkKey(chunkX, chunkZ)));
+    public void unloadChunk(final int chunkX, final int chunkZ, boolean flushLight) throws IOException {
+        if (flushLight) {
+            lightFlushFuture(LongSet.of(ChunkPos.chunkKey(chunkX, chunkZ))).join();
+        }
         final long k = ChunkPos.chunkKey(chunkX, chunkZ);
         if (dirty.remove(k)) {
             final ChunkColumn chunk = loaded.get(k);
@@ -547,14 +553,22 @@ public final class ServerWorld implements World {
             return CompletableFuture.completedFuture(false);
         }
 
-        return CompletableFuture.supplyAsync(() -> {
+        return lightFlushFuture(LongSet.of(k)).thenApplyAsync(_ -> {
             try {
-                unloadChunk(chunkX, chunkZ);
+                unloadChunk(chunkX, chunkZ, false);
                 return true;
             } catch (final IOException e) {
                 throw new UncheckedIOException(e);
             }
         });
+    }
+
+    public LongSet collectAllViewedChunks() {
+        final LongSet wanted = new LongOpenHashSet();
+        for (final ChunkViewSource viewer : viewers) {
+            viewer.collectViewedChunks(wanted::add);
+        }
+        return wanted;
     }
 
     public @Nullable ChunkColumn loadedColumn(final int chunkX, final int chunkZ) {
@@ -569,20 +583,20 @@ public final class ServerWorld implements World {
         this.lightDispatcher = dispatcher;
     }
 
-    private void awaitLightFlush(final Iterable<Long> chunkKeys) {
+    private CompletableFuture<Void> lightFlushFuture(final Iterable<Long> chunkKeys) {
         final LightUpdateDispatcher dispatcher = lightDispatcher;
-        if (dispatcher != null) {
-            dispatcher.flush(dimension.id(), chunkKeys).join();
-        }
+        return dispatcher == null
+                ? CompletableFuture.completedFuture(null)
+                : dispatcher.flush(dimension.id(), chunkKeys);
     }
 
-    public Set<Long> checkBlockLight(final int x, final int y, final int z) {
-        final Set<Long> dirtyChunks = lightManager.checkBlock(x, y, z);
+    public Set<Long> checkBlockLight(final int x, final int y, final int z, final LightEngine engine) {
+        final Set<Long> dirtyChunks = lightManager.checkBlock(x, y, z, engine);
         dirty.addAll(dirtyChunks);
         return dirtyChunks;
     }
 
-    public Set<Long> relightChunks(final Set<Long> chunkKeys) {
+    public Set<Long> relightChunks(final Set<Long> chunkKeys, final LightEngine engine) {
         final LongSet needsFullRelight = new LongOpenHashSet();
         final LongSet needsEdgeCheck = new LongOpenHashSet();
 
@@ -597,7 +611,7 @@ public final class ServerWorld implements World {
         final LongSet dirty = new LongOpenHashSet();
 
         if (!needsFullRelight.isEmpty()) {
-            dirty.addAll(lightManager.relightChunks(needsFullRelight));
+            dirty.addAll(lightManager.relightChunks(needsFullRelight, engine));
             for (final long key : needsFullRelight) {
                 final ChunkColumn column = loadedColumn((int) (key >> 32), (int) key);
                 if (column != null) {
@@ -607,7 +621,7 @@ public final class ServerWorld implements World {
         }
 
         if (!needsEdgeCheck.isEmpty()) {
-            dirty.addAll(lightManager.checkChunkEdges(needsEdgeCheck));
+            dirty.addAll(lightManager.checkChunkEdges(needsEdgeCheck, engine));
         }
 
         this.dirty.addAll(dirty);

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/block/blockentity/BlockEntityTypes.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/block/blockentity/BlockEntityTypes.java
@@ -8,6 +8,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Resolves which {@code minecraft:block_entity_type} a block carries.
@@ -39,6 +40,17 @@ public final class BlockEntityTypes {
      */
     private static final Set<Key> SUFFIX_EXCLUSIONS = Set.of(Key.key("piston_head"));
 
+    /**
+     * Sentinel stored in {@link #CACHE} for blocks resolved to carry no block
+     * entity.
+     */
+    private static final Key NONE = Key.key("fidorial", "none");
+
+    /**
+     * Memorizes {@link #computeResolution(Key)} per block identifier.
+     */
+    private static final Map<Key, Key> CACHE = new ConcurrentHashMap<>();
+
     private BlockEntityTypes() {
         throw new UnsupportedOperationException();
     }
@@ -52,22 +64,8 @@ public final class BlockEntityTypes {
      *         the block has no block entity
      */
     public static Optional<Key> typeIdentifier(final Key blockIdentifier) {
-        final Key exact = EXACT_BLOCKS.get(blockIdentifier);
-        if (exact != null) {
-            return Optional.of(exact);
-        }
-
-        if (SUFFIX_EXCLUSIONS.contains(blockIdentifier)) {
-            return Optional.empty();
-        }
-
-        for (final Map.Entry<String, Key> rule : SUFFIX_RULES.entrySet()) {
-            if (blockIdentifier.value().endsWith(rule.getKey())) {
-                return Optional.of(rule.getValue());
-            }
-        }
-
-        return Optional.empty();
+        final Key resolved = resolve(blockIdentifier);
+        return resolved == NONE ? Optional.empty() : Optional.of(resolved);
     }
 
     /**
@@ -80,10 +78,8 @@ public final class BlockEntityTypes {
      *         from the current registry
      */
     public static int protocolId(final Key blockIdentifier) {
-
-        return typeIdentifier(blockIdentifier)
-                .map(BlockEntityTypeIds::id)
-                .orElse(BlockEntityTypeIds.UNKNOWN);
+        final Key resolved = resolve(blockIdentifier);
+        return resolved == NONE ? BlockEntityTypeIds.UNKNOWN : BlockEntityTypeIds.id(resolved);
     }
 
     /**
@@ -95,6 +91,43 @@ public final class BlockEntityTypes {
      */
     public static boolean hasBlockEntity(final Key blockIdentifier) {
         return protocolId(blockIdentifier) != BlockEntityTypeIds.UNKNOWN;
+    }
+
+    /**
+     * Resolves and caches the block entity type identifier for a block, or
+     * {@link #NONE} when it carries none.
+     */
+    private static Key resolve(final Key blockIdentifier) {
+        final Key cached = CACHE.get(blockIdentifier);
+        if (cached != null) {
+            return cached;
+        }
+        final Key computed = computeResolution(blockIdentifier);
+        CACHE.put(blockIdentifier, computed);
+        return computed;
+    }
+
+    /**
+     * Performs the actual resolution uncached.
+     */
+    private static Key computeResolution(final Key blockIdentifier) {
+        final Key exact = EXACT_BLOCKS.get(blockIdentifier);
+        if (exact != null) {
+            return exact;
+        }
+
+        if (SUFFIX_EXCLUSIONS.contains(blockIdentifier)) {
+            return NONE;
+        }
+
+        final String value = blockIdentifier.value();
+        for (final Map.Entry<String, Key> rule : SUFFIX_RULES.entrySet()) {
+            if (value.endsWith(rule.getKey())) {
+                return rule.getValue();
+            }
+        }
+
+        return NONE;
     }
 
     private static Map<String, Key> suffixRules() {

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/chunk/AnvilChunkSerializer.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/chunk/AnvilChunkSerializer.java
@@ -259,6 +259,6 @@ public class AnvilChunkSerializer {
                 map.put(key, st.value());
             }
         }
-        return new BlockState(Key.key(name), map);
+        return BlockState.of(Key.key(name), map);
     }
 }

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/chunk/BlockState.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/chunk/BlockState.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 import java.util.TreeMap;
+import java.util.concurrent.ConcurrentHashMap;
 
 // To be generated
 @SuppressWarnings("unused")
@@ -36,8 +37,9 @@ public final class BlockState {
     private final boolean fluid;
 
     private volatile LightProperties lightProperties;
+    private static final ConcurrentHashMap<BlockState, BlockState> INTERN = new ConcurrentHashMap<>();
 
-    public BlockState(final Key name, final Map<String, String> properties) {
+    private BlockState(final Key name, final Map<String, String> properties) {
         this.name = name;
         this.properties = properties.isEmpty()
                 ? Collections.emptyMap()
@@ -49,6 +51,12 @@ public final class BlockState {
 
     public static BlockState of(final Key name) {
         return new BlockState(name, Collections.emptyMap());
+    }
+
+    public static BlockState of(final Key name, final Map<String, String> properties) {
+        final BlockState candidate = new BlockState(name, properties);
+        final BlockState existing = INTERN.putIfAbsent(candidate, candidate);
+        return existing != null ? existing : candidate;
     }
 
     public Key name() {

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/chunk/ChunkColumn.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/chunk/ChunkColumn.java
@@ -170,6 +170,9 @@ public final class ChunkColumn {
     }
 
     public @Nullable BlockEntity removeBlockEntity(final int localX, final int worldY, final int localZ) {
+        if (blockEntities.isEmpty()) {
+            return null;
+        }
         return blockEntities.remove(BlockEntity.positionKey(localX, worldY, localZ));
     }
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/chunk/PalettedContainer.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/chunk/PalettedContainer.java
@@ -15,6 +15,8 @@ public final class PalettedContainer<T> {
     private final Object2IntOpenHashMap<T> lookup = new Object2IntOpenHashMap<>();
     private final int[] data;
     private final int minBits;
+    private @Nullable T lastValue = null;
+    private int lastIndex = -1;
 
     private final StampedLock lock = new StampedLock();
 
@@ -41,12 +43,21 @@ public final class PalettedContainer<T> {
     }
 
     private int indexOf(final T value) {
+        if (value == lastValue) {
+            return lastIndex;
+        }
         final int i = lookup.getInt(value);
-        if (i != -1) return i;
+        if (i != -1) {
+            lastValue = value;
+            lastIndex = i;
+            return i;
+        }
         final int next = palette.size();
         palette.add(value);
         lookup.put(value, next);
         paletteArray = palette.toArray();
+        lastValue = value;
+        lastIndex = next;
         return next;
     }
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/fluid/FluidBlockCodec.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/fluid/FluidBlockCodec.java
@@ -42,7 +42,7 @@ public class FluidBlockCodec {
             return BlockState.AIR;
         }
         final int level = state.falling() ? FALLING_OFFSET : clamp(state.level());
-        return new BlockState(state.type().blockKey(), Map.of(LEVEL, String.valueOf(level)));
+        return BlockState.of(state.type().blockKey(), Map.of(LEVEL, String.valueOf(level)));
     }
 
     private static int clamp(final int level) {

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/light/BlockLightProperties.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/light/BlockLightProperties.java
@@ -37,27 +37,28 @@ public class BlockLightProperties {
             state.setLightProperties(AIR_PROPS);
             return AIR_PROPS;
         }
-        final Resolved resolved = resolve(state);
-        if (resolved == null) {
-            // unknown so don't cache
+
+        final BlockRegistry registry;
+        try {
+            registry = Blocks.registry();
+        } catch (final IllegalStateException _) {
+            // registry not bootstrapped yet
             return UNKNOWN_PROPS;
         }
-        final LightProperties props = new LightProperties(
+
+        final Resolved resolved = resolve(registry, state);
+        final LightProperties props = resolved == null
+                ? UNKNOWN_PROPS
+                : new LightProperties(
                 resolved.behaviour().lightOpacity(resolved.data()),
-                resolved.behaviour().lightEmission(resolved.data())
-        );
+                resolved.behaviour().lightEmission(resolved.data()));
+
         state.setLightProperties(props);
         return props;
     }
 
     @SuppressWarnings("PatternValidation")
-    private static @Nullable Resolved resolve(final BlockState state) {
-        final BlockRegistry registry;
-        try {
-            registry = Blocks.registry();
-        } catch (final IllegalStateException notBootstrapped) {
-            return null;
-        }
+    private static @Nullable Resolved resolve(final BlockRegistry registry, final BlockState state) {
         final BlockBehaviour behaviour = registry.behaviour(state.name()).orElse(null);
         if (behaviour == null) {
             return null;

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/light/FloodFillLightEngine.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/light/FloodFillLightEngine.java
@@ -6,6 +6,8 @@ import fr.fidorial.world.light.LightType;
 import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import it.unimi.dsi.fastutil.longs.LongSet;
 
+import java.util.Arrays;
+
 public class FloodFillLightEngine implements LightEngine {
 
     private static final int MAX_LEVEL = 15;
@@ -17,6 +19,10 @@ public class FloodFillLightEngine implements LightEngine {
 
     private final int minY;
     private final int maxY;
+
+    private final LongIntQueue scratchDecrease = new LongIntQueue();
+    private final LongIntQueue scratchIncrease = new LongIntQueue();
+    private final LongQueue scratchLongQueue = new LongQueue();
 
     public FloodFillLightEngine(final int minY, final int height) {
         this.minY = minY;
@@ -61,8 +67,10 @@ public class FloodFillLightEngine implements LightEngine {
         final int oldTop = data.topOpaqueY(x & 15, z & 15);
         final boolean occludesNow = BlockLightProperties.occludes(access.blockAt(x, y, z));
         if (occludesNow && y > oldTop) {
-            final LongIntQueue decrease = new LongIntQueue();
-            final LongIntQueue increase = new LongIntQueue();
+            final LongIntQueue decrease = scratchDecrease;
+            final LongIntQueue increase = scratchIncrease;
+            decrease.reset();
+            increase.reset();
             final long chunkKey = ChunkPos.chunkKey(x >> 4, z >> 4);
 
             final int oldLevel = data.get(LightType.SKY, x, y, z);
@@ -96,7 +104,8 @@ public class FloodFillLightEngine implements LightEngine {
 
             data.setTopOpaqueY(x & 15, z & 15, newTop);
 
-            final LongIntQueue increase = new LongIntQueue();
+            final LongIntQueue increase = scratchIncrease;
+            increase.reset();
             final long chunkKey = ChunkPos.chunkKey(x >> 4, z >> 4);
             for (int cy = y; cy > newTop; cy--) {
                 data.set(LightType.SKY, x, cy, z, MAX_LEVEL);
@@ -121,8 +130,10 @@ public class FloodFillLightEngine implements LightEngine {
             return;
         }
 
-        final LongIntQueue decrease = new LongIntQueue();
-        final LongIntQueue increase = new LongIntQueue();
+        final LongIntQueue decrease = scratchDecrease;
+        final LongIntQueue increase = scratchIncrease;
+        decrease.reset();
+        increase.reset();
 
         final int oldLevel = data.get(type, x, y, z);
         if (oldLevel > 0) {
@@ -328,7 +339,8 @@ public class FloodFillLightEngine implements LightEngine {
     }
 
     private void computeSky(final LongSet chunks, final LightAccess access) {
-        final LongQueue queue = new LongQueue();
+        final LongQueue queue = scratchLongQueue;
+        queue.reset();
 
         for (final long key : chunks) {
             final int chunkX = (int) (key >> 32);
@@ -377,7 +389,8 @@ public class FloodFillLightEngine implements LightEngine {
     }
 
     private void computeBlock(final LongSet chunks, final LightAccess access) {
-        final LongQueue queue = new LongQueue();
+        final LongQueue queue = scratchLongQueue;
+        queue.reset();
 
         for (final long key : chunks) {
             final int chunkX = (int) (key >> 32);
@@ -580,6 +593,11 @@ public class FloodFillLightEngine implements LightEngine {
         private int tail;
         private int lastDir;
 
+        void reset() {
+            head = 0;
+            tail = 0;
+        }
+
         void add(final long value, final int skipDir) {
             if (tail == data.length) grow();
             data[tail] = value;
@@ -609,8 +627,8 @@ public class FloodFillLightEngine implements LightEngine {
                 tail = size;
                 if (tail < data.length) return;
             }
-            data = java.util.Arrays.copyOf(data, data.length * 2);
-            dirs = java.util.Arrays.copyOf(dirs, dirs.length * 2);
+            data = Arrays.copyOf(data, data.length * 2);
+            dirs = Arrays.copyOf(dirs, dirs.length * 2);
         }
     }
 }

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/light/LightEnginePool.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/light/LightEnginePool.java
@@ -1,0 +1,26 @@
+package fr.euphyllia.fidorial.server.world.light;
+
+import java.util.concurrent.ArrayBlockingQueue;
+
+public final class LightEnginePool {
+    private final ArrayBlockingQueue<FloodFillLightEngine> pool;
+    private final int minY;
+    private final int height;
+
+    public LightEnginePool(final int parallelism, final int minY, final int height) {
+        this.minY = minY;
+        this.height = height;
+        this.pool = new ArrayBlockingQueue<>(parallelism);
+        for (int i = 0; i < parallelism; i++) {
+            pool.add(new FloodFillLightEngine(minY, height));
+        }
+    }
+
+    public FloodFillLightEngine acquire() throws InterruptedException {
+        return pool.take();
+    }
+
+    public void release(final FloodFillLightEngine engine) {
+        pool.offer(engine);
+    }
+}

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/light/LongIntQueue.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/light/LongIntQueue.java
@@ -23,6 +23,11 @@ final class LongIntQueue {
         levels = new int[cap];
     }
 
+    void reset() {
+        head = 0;
+        tail = 0;
+    }
+
     void push(final int x, final int y, final int z, final int level) {
         if (tail == xs.length) {
             grow();

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/light/WorldLightManager.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/light/WorldLightManager.java
@@ -11,18 +11,12 @@ import java.util.Set;
 public class WorldLightManager {
 
     private final LightAccess access;
-    private final LightEngine engine;
 
-    public WorldLightManager(final int minY, final int height, final LightAccess access) {
-        this(access, new FloodFillLightEngine(minY, height));
-    }
-
-    public WorldLightManager(final LightAccess access, final LightEngine engine) {
+    public WorldLightManager(final LightAccess access) {
         this.access = access;
-        this.engine = engine;
     }
 
-    public synchronized boolean lightChunkIfNeeded(final ChunkColumn column, final int chunkX, final int chunkZ) {
+    public boolean lightChunkIfNeeded(final ChunkColumn column, final int chunkX, final int chunkZ, final LightEngine engine) {
         if (access.lightAt(chunkX, chunkZ) == null) {
             return false;
         }
@@ -31,11 +25,11 @@ public class WorldLightManager {
         return true;
     }
 
-    public synchronized Set<Long> checkBlock(final int x, final int y, final int z) {
+    public Set<Long> checkBlock(final int x, final int y, final int z, final LightEngine engine) {
         return engine.checkBlock(x, y, z, access);
     }
 
-    public synchronized Set<Long> checkChunkEdges(final Set<Long> chunkKeys) {
+    public Set<Long> checkChunkEdges(final Set<Long> chunkKeys, final LightEngine engine) {
         final LongSet dirty = new LongOpenHashSet();
         final LongSet processedPairs = new LongOpenHashSet();
 
@@ -71,7 +65,7 @@ public class WorldLightManager {
         return lo * 0x9E3779B97F4A7C15L ^ hi;
     }
 
-    public synchronized Set<Long> relightChunks(final Set<Long> chunkKeys) {
+    public Set<Long> relightChunks(final Set<Long> chunkKeys, final LightEngine engine) {
         final LongSet loaded = new LongOpenHashSet();
         for (final long key : chunkKeys) {
             if (access.lightAt((int) (key >> 32), (int) key) != null) {

--- a/fidorial-server/src/main/resources/fidorial.properties
+++ b/fidorial-server/src/main/resources/fidorial.properties
@@ -16,6 +16,7 @@ auto-save-seconds=5
 region-workers=4
 chunk-workers=4
 ai-workers=4
+light-workers=4
 region-section-shift=5
 # gamemode given to players joining for the first time: survival, creative, adventure, spectator
 default-game-mode=creative

--- a/fidorial-test-plugin/src/main/java/fr/euphyllia/fidorial/testplugin/pregen/PregenTask.java
+++ b/fidorial-test-plugin/src/main/java/fr/euphyllia/fidorial/testplugin/pregen/PregenTask.java
@@ -144,8 +144,8 @@ public class PregenTask {
         }
 
         return world.getChunkAsync(chunkX, chunkZ)
-                .thenCompose(c -> world.unloadChunkAsync(chunkX, chunkZ).thenApply(x -> c))
-                .whenComplete((ignored, error) -> {
+                .thenCompose(c -> world.unloadChunkAsync(chunkX, chunkZ).thenApply(_ -> c))
+                .whenComplete((_, error) -> {
                     inFlight.release();
                     if (error != null) {
                         failed.incrementAndGet();

--- a/fidorial-test-plugin/src/main/java/fr/euphyllia/fidorial/testplugin/pregen/PregenTask.java
+++ b/fidorial-test-plugin/src/main/java/fr/euphyllia/fidorial/testplugin/pregen/PregenTask.java
@@ -101,7 +101,7 @@ public class PregenTask {
                     if (cancelled) {
                         break outer;
                     }
-                    submit(this.world, centerX + dx, centerZ + dz).get();
+                    submit(this.world, centerX + dx, centerZ + dz);
 
                     if (System.currentTimeMillis() >= nextReport) {
                         nextReport = System.currentTimeMillis() + REPORT_PERIOD_MS;


### PR DESCRIPTION
Rewrites `LightUpdateDispatcher` to batch work and submit batches to their own light-engine threads, using a configurable fixed thread pool with a default of `available threads / 8`.

### Some benchmarks
#### Spark
https://spark.lucko.me/6vnl5DBaWd

#### Pregen command
<img width="1080" height="332" alt="image" src="https://github.com/user-attachments/assets/e4ea7d95-dbe3-48a9-9475-92a42b1c9f85" />

