### PR TITLE
Enable proper syntax checking for fillbiome/worldgen commands

### DIFF
--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/defaults/FillBiomeCommand.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/defaults/FillBiomeCommand.java
@@ -14,7 +14,6 @@ import fr.fidorial.command.argument.ArgumentTypes;
 import fr.fidorial.command.argument.resolvers.BlockPosResolver;
 import fr.fidorial.entity.Entity;
 import fr.fidorial.registry.RegistryKey;
-import fr.fidorial.registry.TypedKey;
 import fr.fidorial.registry.data.Biome;
 import fr.fidorial.world.BlockPos;
 import fr.fidorial.world.ChunkPos;
@@ -45,13 +44,13 @@ public class FillBiomeCommand {
                 .requires(source -> source.sender().hasPermission(PERMISSION))
                 .then(argument("from", ArgumentTypes.blockPosition())
                         .then(argument("to", ArgumentTypes.blockPosition())
-                                .then(argument("biome", ArgumentTypes.resourceKey(RegistryKey.BIOME))
+                                .then(argument("biome", ArgumentTypes.resource(RegistryKey.BIOME))
                                         .executes(context -> fill(context, null))
                                         .then(literal("replace")
-                                                .then(argument("filter", ArgumentTypes.resourceKey(RegistryKey.BIOME))
+                                                .then(argument("filter", ArgumentTypes.resource(RegistryKey.BIOME))
                                                         .executes(context -> fill(
                                                                 context,
-                                                                context.getArgument("filter", TypedKey.class).key())))))))
+                                                                context.getArgument("filter", Biome.class).key())))))))
                 .build();
     }
 
@@ -64,14 +63,8 @@ public class FillBiomeCommand {
         final BiomeRegistry biomes = server.biomes();
 
         @SuppressWarnings("unchecked")
-        final TypedKey<Biome> target = context.getArgument("biome", TypedKey.class);
+        final Biome target = context.getArgument("biome", Biome.class);
         final Key biome = target.key();
-
-        if (!biomes.contains(biome)) {
-            context.getSource().sender().sendMessage(
-                    Component.translatable("command.fillbiome.unknown", Component.text(biome.asString())));
-            return 0;
-        }
 
         if (filter != null && !biomes.contains(filter)) {
             context.getSource().sender().sendMessage(

--- a/fidorial-test-plugin/src/main/java/fr/euphyllia/fidorial/testplugin/command/WorldgenCommand.java
+++ b/fidorial-test-plugin/src/main/java/fr/euphyllia/fidorial/testplugin/command/WorldgenCommand.java
@@ -11,6 +11,8 @@ import fr.fidorial.command.CommandSender;
 import fr.fidorial.command.CommandSource;
 import fr.fidorial.command.argument.ArgumentTypes;
 import fr.fidorial.entity.Player;
+import fr.fidorial.registry.RegistryKey;
+import fr.fidorial.registry.data.Biome;
 import fr.fidorial.world.Location;
 import net.kyori.adventure.key.Key;
 
@@ -33,12 +35,12 @@ public final class WorldgenCommand {
                 .then(literal("info").executes(this::info))
                 .then(literal("spawn").executes(this::spawn))
                 .then(literal("locate")
-                        .then(argument("biome", ArgumentTypes.key())
-                                .executes(ctx -> locate(ctx, ctx.getArgument("biome", Key.class), DEFAULT_RADIUS))
+                        .then(argument("biome", ArgumentTypes.resource(RegistryKey.BIOME))
+                                .executes(ctx -> locate(ctx, ctx.getArgument("biome", Biome.class).key(), DEFAULT_RADIUS))
                                 .then(argument("radius", IntegerArgumentType.integer(16, 30000))
                                         .executes(ctx -> locate(
                                                 ctx,
-                                                ctx.getArgument("biome", Key.class),
+                                                ctx.getArgument("biome", Biome.class).key(),
                                                 IntegerArgumentType.getInteger(ctx, "radius"))))))
                 .build();
     }


### PR DESCRIPTION
<img width="790" height="70" alt="image" src="https://github.com/user-attachments/assets/4d4602ee-1ae8-4b65-93d5-b71119be6290" />
<img width="482" height="57" alt="image" src="https://github.com/user-attachments/assets/b981e140-28af-4ac4-ba3c-df0b6e20b740" />

Also has the benefit of being able to remove the biome existence check in command logic and exceptions being translated using the client's language files without needing us to provide translations for this case