### PR TITLE
chore: remove unused EXAMPLES fields in Brigadier arguments.

### DIFF
--- a/fidorial-api/src/main/java/fr/fidorial/command/CommandRegistry.java
+++ b/fidorial-api/src/main/java/fr/fidorial/command/CommandRegistry.java
@@ -11,6 +11,8 @@ import java.util.function.Predicate;
 
 /**
  * Handles the registration and execution of commands.
+ *
+ * @since 0.1.0
  */
 public interface CommandRegistry {
 

--- a/fidorial-api/src/main/java/fr/fidorial/command/CommandSource.java
+++ b/fidorial-api/src/main/java/fr/fidorial/command/CommandSource.java
@@ -18,8 +18,8 @@ public interface CommandSource {
     Location location();
 
     /**
-     * Gets the command sender that executed this command.
-     * The sender of a command source stack is the one that initiated/triggered the execution of a command.
+     * Gets the {@link CommandSender} that executed this command.
+     * The sender of a command is the one that triggered the execution of a command.
      * It differs to {@link #executor()} as the executor can be changed by a command, e.g. {@literal /execute}.
      *
      * @return the command sender instance

--- a/fidorial-api/src/main/java/fr/fidorial/command/argument/ArgumentProvider.java
+++ b/fidorial-api/src/main/java/fr/fidorial/command/argument/ArgumentProvider.java
@@ -29,7 +29,6 @@ import net.kyori.adventure.text.format.TextColor;
 import org.jetbrains.annotations.ApiStatus;
 
 import java.time.Duration;
-import java.util.Collection;
 import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.UUID;
@@ -264,11 +263,6 @@ public interface ArgumentProvider {
      * @since 0.1.0
      */
     <N, T> ArgumentType<T> map(ArgumentType<N> nativeType, ArgumentMapper<N, T> mapper, SuggestionProvider<CommandSource> suggestions);
-
-    /**
-     * @since 0.1.0
-     */
-    <N, T> ArgumentType<T> map(ArgumentType<N> nativeType, ArgumentMapper<N, T> mapper, SuggestionProvider<CommandSource> suggestions, Collection<String> examples);
 
     /**
      * @since 0.1.0

--- a/fidorial-api/src/main/java/fr/fidorial/command/argument/ArgumentTypes.java
+++ b/fidorial-api/src/main/java/fr/fidorial/command/argument/ArgumentTypes.java
@@ -29,7 +29,6 @@ import net.kyori.adventure.text.format.Style;
 import net.kyori.adventure.text.format.TextColor;
 
 import java.time.Duration;
-import java.util.Collection;
 import java.util.UUID;
 import java.util.function.Predicate;
 
@@ -600,32 +599,6 @@ public final class ArgumentTypes {
             final SuggestionProvider<CommandSource> suggestions
     ) {
         return provider().map(nativeType, mapper, suggestions);
-    }
-
-    /**
-     * Reuses {@code nativeType}'s client-side grammar and highlighting, converting
-     * the parsed value into a custom result type, replacing the native type's
-     * suggestions with {@code suggestions}, and replacing its examples with
-     * {@code examples} — useful when the native type's own examples (e.g. arbitrary
-     * words) don't reflect the mapped domain's actual valid values.
-     *
-     * @param nativeType the native type providing grammar and highlighting
-     * @param mapper converts a parsed native value into the result type
-     * @param suggestions replaces the native type's client-side suggestions
-     * @param examples replaces the native type's client-side examples
-     * @return argument
-     * @param <N> the native value type
-     * @param <T> the mapped result type
-     * @see #map(ArgumentType, ArgumentMapper, SuggestionProvider)
-     * @since 0.1.0
-     */
-    public static <N, T> ArgumentType<T> map(
-            final ArgumentType<N> nativeType,
-            final ArgumentMapper<N, T> mapper,
-            final SuggestionProvider<CommandSource> suggestions,
-            final Collection<String> examples
-    ) {
-        return provider().map(nativeType, mapper, suggestions, examples);
     }
 
     /**

--- a/fidorial-api/src/main/java/fr/fidorial/entity/PlayerProfile.java
+++ b/fidorial-api/src/main/java/fr/fidorial/entity/PlayerProfile.java
@@ -25,6 +25,7 @@ public record PlayerProfile(UUID uuid, String name, List<Property> properties) i
     }
 
     @Override
+    @SuppressWarnings("UnstableApiUsage") // we are permitted to override
     public void applySkinToPlayerHeadContents(final PlayerHeadObjectContents.Builder builder) {
         if (!this.properties.isEmpty()) {
             builder.profileProperties(

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/FidorialServer.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/FidorialServer.java
@@ -113,12 +113,10 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 
 public final class FidorialServer implements Server {
 
@@ -172,13 +170,8 @@ public final class FidorialServer implements Server {
     private final BossBarRegistry bossBarRegistry = new BossBarRegistry(worldManager.levelData(), this::players);
     private final DayNightThread dayNightEngine = new DayNightThread(worldManager, registries.dynamic());
     private final ChunkNetworkSerializer chunkSerializer = new ChunkNetworkSerializer(blockStateRegistry, registries.biomes());
-    private final AtomicInteger lightThreadId = new AtomicInteger();
-    private final ExecutorService lightPool = Executors.newFixedThreadPool(
-            config.lightWorkers(),
-            r -> Thread.ofPlatform().name("fidorial-light-%d".formatted(lightThreadId.incrementAndGet())).unstarted(r));
-
     private final LightUpdateDispatcher lightDispatcher = new LightUpdateDispatcher(
-            lightPool, WorldConstants.MIN_Y, WorldConstants.HEIGHT, this::broadcast, chunkSerializer, worldManager::world);
+            config.lightWorkers(), WorldConstants.MIN_Y, WorldConstants.HEIGHT, this::broadcast, chunkSerializer, worldManager::world);
     private final BlockEditService blockEdits = new BlockEditService(
             blockStateRegistry,
             (pos, stateId) -> broadcast(new ClientboundBlockUpdatePacket(pos, stateId)),
@@ -284,13 +277,13 @@ public final class FidorialServer implements Server {
         closeQuietly("bossbars", bossBarRegistry::close);
         closeQuietly("day/night cycle", dayNightEngine::close);
         closeQuietly("network", network::shutdown);
-        closeQuietly("light engine", lightPool::shutdownNow);
+        closeQuietly("light engine", lightDispatcher::shutdown);
         closeQuietly("auto-save", autoSave::shutdownNow);
-        closeQuietly("ia", aiWorker::shutdown);
+        closeQuietly("ai", aiWorker::shutdown);
         closeQuietly("regions", regionizer::shutdown);
         closeQuietly("chunks", chunkWorker::shutdown);
         closeQuietly("weather", weatherEngine::close);
-        closeQuietly("profils", offlinePlayers::close);
+        closeQuietly("profiles", offlinePlayers::close);
         closeQuietly("worlds", worldManager::close);
         closeQuietly("metrics", metrics::shutdown);
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/adventure/providers/ClickCallbackProviderImpl.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/adventure/providers/ClickCallbackProviderImpl.java
@@ -5,7 +5,7 @@ import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.text.event.ClickCallback;
 import net.kyori.adventure.text.event.ClickEvent;
 
-@SuppressWarnings("UnstableApiUsage")
+@SuppressWarnings("UnstableApiUsage") // we are permitted
 public class ClickCallbackProviderImpl implements ClickCallback.Provider {
     @Override
     public ClickEvent<?> create(ClickCallback<Audience> callback, ClickCallback.Options options) {

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/adventure/providers/ComponentLoggerProviderImpl.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/adventure/providers/ComponentLoggerProviderImpl.java
@@ -9,6 +9,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Locale;
 
+@SuppressWarnings("UnstableApiUsage") // we are permitted
 public class ComponentLoggerProviderImpl implements ComponentLoggerProvider {
     @Override
     public ComponentLogger logger(final ComponentLoggerProvider.LoggerHelper helper, final String name) {

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/ArgumentProviderImpl.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/ArgumentProviderImpl.java
@@ -31,8 +31,8 @@ import fr.euphyllia.fidorial.server.command.brigadier.argument.location.Dimensio
 import fr.euphyllia.fidorial.server.command.brigadier.argument.location.Vec3Argument;
 import fr.euphyllia.fidorial.server.command.brigadier.argument.player.GameModeArgument;
 import fr.euphyllia.fidorial.server.command.brigadier.argument.player.PlayerProfileArgument;
-import fr.euphyllia.fidorial.server.command.brigadier.argument.range.MinMaxBounds;
 import fr.euphyllia.fidorial.server.command.brigadier.argument.range.RangeArgument;
+import fr.euphyllia.fidorial.server.command.brigadier.argument.range.RangeBounds;
 import fr.euphyllia.fidorial.server.command.brigadier.argument.resource.KeyArgument;
 import fr.euphyllia.fidorial.server.command.brigadier.argument.resource.ResourceArgument;
 import fr.euphyllia.fidorial.server.command.brigadier.argument.resource.ResourceKeyArgument;
@@ -65,7 +65,6 @@ import net.kyori.adventure.text.format.Style;
 import net.kyori.adventure.text.format.TextColor;
 
 import java.time.Duration;
-import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 import java.util.function.Function;
@@ -232,7 +231,7 @@ public class ArgumentProviderImpl implements ArgumentProvider {
     }
 
     private static <N extends Number & Comparable<N>, R extends RangeProvider<N>> R toRange(
-            final MinMaxBounds<N> bounds,
+            final RangeBounds<N> bounds,
             final Function<Range<N>, R> factory
     ) {
         final var min = bounds.min();
@@ -320,16 +319,6 @@ public class ArgumentProviderImpl implements ArgumentProvider {
     @Override
     public <N, T> ArgumentType<T> map(final ArgumentType<N> nativeType, final ArgumentMapper<N, T> mapper, final SuggestionProvider<CommandSource> suggestions) {
         return new MappedArgumentType<>(nativeType, mapper, suggestions);
-    }
-
-    @Override
-    public <N, T> ArgumentType<T> map(
-            final ArgumentType<N> nativeType,
-            final ArgumentMapper<N, T> mapper,
-            final SuggestionProvider<CommandSource> suggestions,
-            final Collection<String> examples
-    ) {
-        return new MappedArgumentType<>(nativeType, mapper, suggestions, examples);
     }
 
     @Override

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/bossbar/BossBarColorArgument.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/bossbar/BossBarColorArgument.java
@@ -12,7 +12,6 @@ import fr.fidorial.command.argument.ArgumentTypes;
 import net.kyori.adventure.bossbar.BossBar;
 import net.kyori.adventure.text.Component;
 
-import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.CompletableFuture;
 
@@ -28,10 +27,8 @@ public final class BossBarColorArgument {
     }
 
     public static ArgumentType<BossBar.Color> bossBarColor() {
-        return ArgumentTypes.map(StringArgumentType.word(), BossBarColorArgument::parse, BossBarColorArgument::suggest, EXAMPLES);
+        return ArgumentTypes.map(StringArgumentType.word(), BossBarColorArgument::parse, BossBarColorArgument::suggest);
     }
-
-    private static final List<String> EXAMPLES = List.of("red", "blue");
 
     private static BossBar.Color parse(final String value, final StringReader reader) throws CommandSyntaxException {
         for (final BossBar.Color color : BossBar.Color.values()) {

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/bossbar/BossBarFlagArgument.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/bossbar/BossBarFlagArgument.java
@@ -12,7 +12,6 @@ import fr.fidorial.command.argument.ArgumentTypes;
 import net.kyori.adventure.bossbar.BossBar;
 import net.kyori.adventure.text.Component;
 
-import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.CompletableFuture;
 
@@ -28,10 +27,8 @@ public final class BossBarFlagArgument {
     }
 
     public static ArgumentType<BossBar.Flag> bossBarFlag() {
-        return ArgumentTypes.map(StringArgumentType.word(), BossBarFlagArgument::parse, BossBarFlagArgument::suggest, EXAMPLES);
+        return ArgumentTypes.map(StringArgumentType.word(), BossBarFlagArgument::parse, BossBarFlagArgument::suggest);
     }
-
-    private static final List<String> EXAMPLES = List.of("progress", "notched_10");
 
     private static BossBar.Flag parse(final String value, final StringReader reader) throws CommandSyntaxException {
         for (final BossBar.Flag flag : BossBar.Flag.values()) {

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/bossbar/BossBarOverlayArgument.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/bossbar/BossBarOverlayArgument.java
@@ -12,7 +12,6 @@ import fr.fidorial.command.argument.ArgumentTypes;
 import net.kyori.adventure.bossbar.BossBar;
 import net.kyori.adventure.text.Component;
 
-import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.CompletableFuture;
 
@@ -28,10 +27,8 @@ public final class BossBarOverlayArgument {
     }
 
     public static ArgumentType<BossBar.Overlay> bossBarOverlay() {
-        return ArgumentTypes.map(StringArgumentType.word(), BossBarOverlayArgument::parse, BossBarOverlayArgument::suggest, EXAMPLES);
+        return ArgumentTypes.map(StringArgumentType.word(), BossBarOverlayArgument::parse, BossBarOverlayArgument::suggest);
     }
-
-    private static final List<String> EXAMPLES = List.of("darken_screen", "play_boss_music");
 
     private static BossBar.Overlay parse(final String value, final StringReader reader) throws CommandSyntaxException {
         for (final BossBar.Overlay overlay : BossBar.Overlay.values()) {

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/chat/ComponentArgument.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/chat/ComponentArgument.java
@@ -19,16 +19,12 @@ import net.kyori.adventure.text.SelectorComponent;
 import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
 import static fr.euphyllia.fidorial.server.adventure.brigadier.BrigadierAdventureHelper.MSG_SERIALIZER;
 
 public final class ComponentArgument implements ArgumentType<Component> {
-
-    private static final Collection<String> EXAMPLES =
-            Arrays.asList("\"hello world\"", "'hello world'", "\"\"", "{\"text\":\"hello world\"}");
 
     public static final DynamicCommandExceptionType ERROR_INVALID_COMPONENT = new DynamicCommandExceptionType(
             message -> MSG_SERIALIZER.serialize(
@@ -103,11 +99,6 @@ public final class ComponentArgument implements ArgumentType<Component> {
             return Component.text(player.name());
         }
         return Component.text(entity.type().key().value());
-    }
-
-    @Override
-    public Collection<String> getExamples() {
-        return EXAMPLES;
     }
 
     public static final class Info implements ArgumentTypeRegistrar<ComponentArgument, Info.Spec> {

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/chat/HexColorArgument.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/chat/HexColorArgument.java
@@ -12,16 +12,12 @@ import fr.euphyllia.fidorial.server.command.brigadier.packet.registry.ArgumentTy
 import fr.euphyllia.fidorial.server.network.PacketBuffer;
 import net.kyori.adventure.text.Component;
 
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
 import static fr.euphyllia.fidorial.server.adventure.brigadier.BrigadierAdventureHelper.MSG_SERIALIZER;
 
 public final class HexColorArgument<T> implements ArgumentType<T> {
-
-    private static final Collection<String> EXAMPLES = Arrays.asList("F00", "FF0000");
 
     public static final DynamicCommandExceptionType ERROR_INVALID_HEX =
             new DynamicCommandExceptionType(value -> MSG_SERIALIZER.serialize(
@@ -79,15 +75,9 @@ public final class HexColorArgument<T> implements ArgumentType<T> {
             final CommandContext<S> context,
             final SuggestionsBuilder builder
     ) {
-        for (final String example : EXAMPLES) {
-            builder.suggest(example);
-        }
+        builder.suggest("FFFFFF");
+        builder.suggest("D6BCFB");
         return builder.buildFuture();
-    }
-
-    @Override
-    public Collection<String> getExamples() {
-        return EXAMPLES;
     }
 
     public static final class Info implements ArgumentTypeRegistrar<HexColorArgument<?>, Info.Spec> {

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/chat/NamedColorArgument.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/chat/NamedColorArgument.java
@@ -13,15 +13,11 @@ import fr.euphyllia.fidorial.server.network.PacketBuffer;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 
 import static fr.euphyllia.fidorial.server.adventure.brigadier.BrigadierAdventureHelper.MSG_SERIALIZER;
 
 public final class NamedColorArgument implements ArgumentType<NamedTextColor> {
-
-    private static final Collection<String> EXAMPLES = Arrays.asList("red", "green");
 
     public static final DynamicCommandExceptionType ERROR_INVALID_VALUE =
             new DynamicCommandExceptionType(value -> MSG_SERIALIZER.serialize(
@@ -47,11 +43,6 @@ public final class NamedColorArgument implements ArgumentType<NamedTextColor> {
             builder.suggest(NamedTextColor.NAMES.key(color));
         }
         return builder.buildFuture();
-    }
-
-    @Override
-    public Collection<String> getExamples() {
-        return EXAMPLES;
     }
 
     public static final class Info implements ArgumentTypeRegistrar<NamedColorArgument, Info.Spec> {

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/chat/StyleArgument.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/chat/StyleArgument.java
@@ -16,15 +16,12 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.Style;
 import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
 
-import java.util.Collection;
-import java.util.List;
 import java.util.Set;
 
 import static fr.euphyllia.fidorial.server.adventure.brigadier.BrigadierAdventureHelper.MSG_SERIALIZER;
 
 public final class StyleArgument implements ArgumentType<Style> {
 
-    private static final Collection<String> EXAMPLES = List.of("{\"bold\":true}", "{\"color\":\"red\"}", "{}");
     private static final Set<String> CONTENT_KEYS = Set.of("text", "translate", "selector", "score", "keybind", "nbt");
 
     public static final DynamicCommandExceptionType ERROR_INVALID_STYLE = new DynamicCommandExceptionType(
@@ -69,11 +66,6 @@ public final class StyleArgument implements ArgumentType<Style> {
 
     public static Style getStyle(final CommandContext<CommandSource> context, final String name) {
         return context.getArgument(name, Style.class);
-    }
-
-    @Override
-    public Collection<String> getExamples() {
-        return EXAMPLES;
     }
 
     public static final class Info implements ArgumentTypeRegistrar<StyleArgument, Info.Spec> {

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/custom/ForcedSuggestionsArgumentType.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/custom/ForcedSuggestionsArgumentType.java
@@ -13,7 +13,6 @@ import fr.euphyllia.fidorial.server.command.brigadier.packet.registry.ArgumentTy
 import fr.euphyllia.fidorial.server.network.PacketBuffer;
 import fr.fidorial.command.CommandSource;
 
-import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 
 public final class ForcedSuggestionsArgumentType<T> implements ArgumentType<T>, ForceServerSuggestions {
@@ -34,11 +33,6 @@ public final class ForcedSuggestionsArgumentType<T> implements ArgumentType<T>, 
     @Override
     public <S> CompletableFuture<Suggestions> listSuggestions(final CommandContext<S> context, final SuggestionsBuilder builder) {
         return delegate.listSuggestions(context, builder);
-    }
-
-    @Override
-    public Collection<String> getExamples() {
-        return delegate.getExamples();
     }
 
     @Override

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/custom/MappedArgumentType.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/custom/MappedArgumentType.java
@@ -12,7 +12,6 @@ import fr.fidorial.command.argument.custom.ArgumentMapper;
 import net.kyori.adventure.text.logger.slf4j.ComponentLogger;
 import org.jspecify.annotations.Nullable;
 
-import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 
 public final class MappedArgumentType<N, T> implements ArgumentType<T>, ForceServerSuggestions {
@@ -22,10 +21,9 @@ public final class MappedArgumentType<N, T> implements ArgumentType<T>, ForceSer
     private final ArgumentType<N> nativeType;
     private final ArgumentMapper<N, T> mapper;
     private final @Nullable SuggestionProvider<CommandSource> customSuggestions;
-    private final @Nullable Collection<String> customExamples;
 
     public MappedArgumentType(final ArgumentType<N> nativeType, final ArgumentMapper<N, T> mapper) {
-        this(nativeType, mapper, null, null);
+        this(nativeType, mapper, null);
     }
 
     public MappedArgumentType(
@@ -33,19 +31,9 @@ public final class MappedArgumentType<N, T> implements ArgumentType<T>, ForceSer
             final ArgumentMapper<N, T> mapper,
             final @Nullable SuggestionProvider<CommandSource> customSuggestions
     ) {
-        this(nativeType, mapper, customSuggestions, null);
-    }
-
-    public MappedArgumentType(
-            final ArgumentType<N> nativeType,
-            final ArgumentMapper<N, T> mapper,
-            final @Nullable SuggestionProvider<CommandSource> customSuggestions,
-            final @Nullable Collection<String> customExamples
-    ) {
         this.nativeType = nativeType;
         this.mapper = mapper;
         this.customSuggestions = customSuggestions;
-        this.customExamples = customExamples;
     }
 
     public ArgumentType<N> nativeType() { return nativeType; }
@@ -67,11 +55,6 @@ public final class MappedArgumentType<N, T> implements ArgumentType<T>, ForceSer
             }
         }
         return nativeType.listSuggestions(context, builder);
-    }
-
-    @Override
-    public Collection<String> getExamples() {
-        return customExamples != null ? customExamples : nativeType.getExamples();
     }
 
     @Override

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/entity/EntityArgument.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/entity/EntityArgument.java
@@ -17,7 +17,6 @@ import fr.fidorial.entity.Player;
 import net.kyori.adventure.text.Component;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
@@ -26,9 +25,6 @@ import java.util.function.Predicate;
 import static fr.euphyllia.fidorial.server.adventure.brigadier.BrigadierAdventureHelper.MSG_SERIALIZER;
 
 public final class EntityArgument<T> implements ArgumentType<T> {
-
-    private static final Collection<String> EXAMPLES =
-            List.of("Player", "0123", "@e", "@e[type=zombie]", "dd12be42-52a9-4a91-a8a1-11c01849e498");
 
     public static final SimpleCommandExceptionType ERROR_NOT_SINGLE_ENTITY =
             new SimpleCommandExceptionType(MSG_SERIALIZER.serialize(Component.translatable("argument.entity.toomany")));
@@ -200,11 +196,6 @@ public final class EntityArgument<T> implements ArgumentType<T> {
                 }
             }
         });
-    }
-
-    @Override
-    public Collection<String> getExamples() {
-        return EXAMPLES;
     }
 
     public static final class Info implements ArgumentTypeRegistrar<EntityArgument<?>, Info.Spec> {

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/entity/UuidArgument.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/entity/UuidArgument.java
@@ -11,8 +11,6 @@ import fr.euphyllia.fidorial.server.network.PacketBuffer;
 import fr.fidorial.command.CommandSource;
 import net.kyori.adventure.text.Component;
 
-import java.util.Collection;
-import java.util.List;
 import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -20,8 +18,6 @@ import java.util.regex.Pattern;
 import static fr.euphyllia.fidorial.server.adventure.brigadier.BrigadierAdventureHelper.MSG_SERIALIZER;
 
 public final class UuidArgument implements ArgumentType<UUID> {
-
-    private static final Collection<String> EXAMPLES = List.of("dd12be42-52a9-4a91-a8a1-11c01849e498");
 
     private static final Pattern ALLOWED_CHARACTERS = Pattern.compile("^([-A-Fa-f0-9]+)");
 
@@ -57,11 +53,6 @@ public final class UuidArgument implements ArgumentType<UUID> {
         }
 
         throw ERROR_INVALID_UUID.createWithContext(reader);
-    }
-
-    @Override
-    public Collection<String> getExamples() {
-        return EXAMPLES;
     }
 
     public static final class Info implements ArgumentTypeRegistrar<UuidArgument, Info.Spec> {

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/generic/DurationArgument.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/generic/DurationArgument.java
@@ -58,10 +58,8 @@ public final class DurationArgument {
     }
 
     public static ArgumentType<Duration> duration() {
-        return ArgumentTypes.map(StringArgumentType.word(), DurationArgument::parse, SUGGESTIONS, EXAMPLES);
+        return ArgumentTypes.map(StringArgumentType.word(), DurationArgument::parse, SUGGESTIONS);
     }
-
-    private static final List<String> EXAMPLES = List.of("30m", "12h", "7d", "1w12h");
 
     public static Duration getDuration(final CommandContext<CommandSource> context, final String name) {
         return context.getArgument(name, Duration.class);

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/generic/TimeArgument.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/generic/TimeArgument.java
@@ -13,8 +13,6 @@ import fr.euphyllia.fidorial.server.command.brigadier.packet.registry.ArgumentTy
 import fr.euphyllia.fidorial.server.network.PacketBuffer;
 import net.kyori.adventure.text.Component;
 
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -22,8 +20,6 @@ import java.util.concurrent.CompletableFuture;
 import static fr.euphyllia.fidorial.server.adventure.brigadier.BrigadierAdventureHelper.MSG_SERIALIZER;
 
 public record TimeArgument(int minimum) implements ArgumentType<Integer> {
-
-    private static final Collection<String> EXAMPLES = Arrays.asList("0d", "0s", "0t", "0");
 
     private static final SimpleCommandExceptionType ERROR_INVALID_UNIT = new SimpleCommandExceptionType(
             MSG_SERIALIZER.serialize(Component.translatable("argument.time.invalid_unit")));
@@ -90,11 +86,6 @@ public record TimeArgument(int minimum) implements ArgumentType<Integer> {
         }
 
         return offset.buildFuture();
-    }
-
-    @Override
-    public Collection<String> getExamples() {
-        return EXAMPLES;
     }
 
     public static final class Info implements ArgumentTypeRegistrar<TimeArgument, Info.Spec> {

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/item/ItemArgument.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/item/ItemArgument.java
@@ -17,8 +17,6 @@ import fr.fidorial.registry.keys.ItemKeys;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Locale;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
@@ -26,8 +24,6 @@ import java.util.function.Function;
 import static fr.euphyllia.fidorial.server.adventure.brigadier.BrigadierAdventureHelper.MSG_SERIALIZER;
 
 public final class ItemArgument<T> implements ArgumentType<T> {
-
-    private static final Collection<String> EXAMPLES = Arrays.asList("stick", "minecraft:stick");
 
     public static final DynamicCommandExceptionType ERROR_UNKNOWN_ITEM =
             new DynamicCommandExceptionType(id -> MSG_SERIALIZER.serialize(
@@ -85,11 +81,6 @@ public final class ItemArgument<T> implements ArgumentType<T> {
                 .filter(id -> id.contains(remaining))
                 .forEach(builder::suggest);
         return builder.buildFuture();
-    }
-
-    @Override
-    public Collection<String> getExamples() {
-        return EXAMPLES;
     }
 
     public record ItemInput(Key id) {

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/item/ItemPredicateArgument.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/item/ItemPredicateArgument.java
@@ -18,8 +18,6 @@ import fr.fidorial.registry.keys.ItemKeys;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Locale;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
@@ -28,8 +26,6 @@ import java.util.function.Predicate;
 import static fr.euphyllia.fidorial.server.adventure.brigadier.BrigadierAdventureHelper.MSG_SERIALIZER;
 
 public final class ItemPredicateArgument<T> implements ArgumentType<T> {
-
-    private static final Collection<String> EXAMPLES = Arrays.asList("stick", "minecraft:stick");
 
     public static final DynamicCommandExceptionType ERROR_UNKNOWN_ITEM =
             new DynamicCommandExceptionType(id -> MSG_SERIALIZER.serialize(
@@ -97,11 +93,6 @@ public final class ItemPredicateArgument<T> implements ArgumentType<T> {
                 .filter(id -> id.contains(remaining))
                 .forEach(builder::suggest);
         return builder.buildFuture();
-    }
-
-    @Override
-    public Collection<String> getExamples() {
-        return EXAMPLES;
     }
 
     public static final class Info implements ArgumentTypeRegistrar<ItemPredicateArgument<?>, Info.Spec> {

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/location/AngleArgument.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/location/AngleArgument.java
@@ -10,14 +10,9 @@ import fr.euphyllia.fidorial.server.network.PacketBuffer;
 import fr.fidorial.command.argument.resolvers.AngleResolver;
 import net.kyori.adventure.text.Component;
 
-import java.util.Arrays;
-import java.util.Collection;
-
 import static fr.euphyllia.fidorial.server.adventure.brigadier.BrigadierAdventureHelper.MSG_SERIALIZER;
 
 public final class AngleArgument implements ArgumentType<AngleResolver> {
-
-    private static final Collection<String> EXAMPLES = Arrays.asList("0", "~", "~-5");
 
     public static final SimpleCommandExceptionType ERROR_NOT_COMPLETE = new SimpleCommandExceptionType(
             MSG_SERIALIZER.serialize(Component.translatable("argument.angle.incomplete")));
@@ -56,11 +51,6 @@ public final class AngleArgument implements ArgumentType<AngleResolver> {
             }
             return result;
         };
-    }
-
-    @Override
-    public Collection<String> getExamples() {
-        return EXAMPLES;
     }
 
     public static final class Info implements ArgumentTypeRegistrar<AngleArgument, Info.Spec> {

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/location/BlockPositionArgument.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/location/BlockPositionArgument.java
@@ -15,13 +15,9 @@ import fr.fidorial.command.argument.resolvers.BlockPosResolver;
 import fr.fidorial.world.BlockPos;
 import fr.fidorial.world.Location;
 
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 
 public final class BlockPositionArgument implements ArgumentType<BlockPosResolver> {
-
-    private static final Collection<String> EXAMPLES = Arrays.asList("0 0 0", "~ ~ ~", "~1 ~ ~-5");
 
     public static BlockPositionArgument blockPosition() {
         return new BlockPositionArgument();
@@ -85,11 +81,6 @@ public final class BlockPositionArgument implements ArgumentType<BlockPosResolve
                     (int) Math.floor(pz)
             );
         };
-    }
-
-    @Override
-    public Collection<String> getExamples() {
-        return EXAMPLES;
     }
 
     private record Coordinate(double value, boolean relative) {

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/location/DimensionArgument.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/location/DimensionArgument.java
@@ -17,16 +17,12 @@ import fr.fidorial.world.World;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
 import static fr.euphyllia.fidorial.server.adventure.brigadier.BrigadierAdventureHelper.MSG_SERIALIZER;
 
 public final class DimensionArgument<T> implements ArgumentType<T> {
-
-    private static final Collection<String> EXAMPLES = Arrays.asList("minecraft:overworld", "minecraft:the_nether");
 
     public static final DynamicCommandExceptionType ERROR_INVALID_VALUE =
             new DynamicCommandExceptionType(value -> MSG_SERIALIZER.serialize(
@@ -76,11 +72,6 @@ public final class DimensionArgument<T> implements ArgumentType<T> {
             builder.suggest(world.key().asString());
         }
         return builder.buildFuture();
-    }
-
-    @Override
-    public Collection<String> getExamples() {
-        return EXAMPLES;
     }
 
     public static final class Info implements ArgumentTypeRegistrar<DimensionArgument<?>, Info.Spec> {

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/location/Vec3Argument.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/location/Vec3Argument.java
@@ -14,13 +14,9 @@ import fr.fidorial.command.CommandSource;
 import fr.fidorial.command.argument.resolvers.PositionResolver;
 import fr.fidorial.world.Location;
 
-import java.util.Collection;
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 public final class Vec3Argument implements ArgumentType<PositionResolver> {
-
-    private static final Collection<String> EXAMPLES = List.of("0 0 0", "~ ~ ~", "~1 ~ ~-5");
 
     private final boolean centerCorrect;
 
@@ -83,11 +79,6 @@ public final class Vec3Argument implements ArgumentType<PositionResolver> {
                 String.format("%.2f", loc.y()),
                 String.format("%.2f", loc.z())
         );
-    }
-
-    @Override
-    public Collection<String> getExamples() {
-        return EXAMPLES;
     }
 
     private record Coordinate(double value, boolean relative) {

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/player/GameModeArgument.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/player/GameModeArgument.java
@@ -13,18 +13,11 @@ import fr.euphyllia.fidorial.server.network.PacketBuffer;
 import fr.fidorial.entity.GameMode;
 import net.kyori.adventure.text.Component;
 
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 
 import static fr.euphyllia.fidorial.server.adventure.brigadier.BrigadierAdventureHelper.MSG_SERIALIZER;
 
 public final class GameModeArgument implements ArgumentType<GameMode> {
-
-    private static final Collection<String> EXAMPLES = Arrays.stream(GameMode.values())
-            .map(GameMode::name)
-            .map(String::toLowerCase)
-            .toList();
 
     private static final DynamicCommandExceptionType ERROR_INVALID =
             new DynamicCommandExceptionType(value -> MSG_SERIALIZER.serialize(
@@ -61,11 +54,6 @@ public final class GameModeArgument implements ArgumentType<GameMode> {
         }
 
         return builder.buildFuture();
-    }
-
-    @Override
-    public Collection<String> getExamples() {
-        return EXAMPLES;
     }
 
     public static final class Info implements ArgumentTypeRegistrar<GameModeArgument, Info.Spec> {

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/player/PlayerProfileArgument.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/player/PlayerProfileArgument.java
@@ -34,9 +34,6 @@ public class PlayerProfileArgument<T> implements ArgumentType<T> {
     public static final SimpleCommandExceptionType ERROR_UNKNOWN_PLAYER =
             new SimpleCommandExceptionType(MSG_SERIALIZER.serialize(Component.translatable("argument.player.unknown")));
 
-    private static final Collection<String> EXAMPLES =
-            List.of("Player", "0123", "dd12be42-52a9-4a91-a8a1-11c01849e498", "@a");
-
     private static final Predicate<Player> ALL = _ -> true;
 
     private final Predicate<Player> filter;
@@ -126,11 +123,6 @@ public class PlayerProfileArgument<T> implements ArgumentType<T> {
                 .forEach(builder::suggest);
 
         return builder.buildFuture();
-    }
-
-    @Override
-    public Collection<String> getExamples() {
-        return EXAMPLES;
     }
 
     @FunctionalInterface

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/range/RangeArgument.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/range/RangeArgument.java
@@ -9,49 +9,40 @@ import fr.euphyllia.fidorial.server.command.brigadier.packet.registry.ArgumentTy
 import fr.euphyllia.fidorial.server.network.PacketBuffer;
 import fr.fidorial.command.CommandSource;
 
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.function.Function;
 
 public interface RangeArgument {
 
-    static RangeArgument.Ints<MinMaxBounds.Ints> intRange() {
+    static RangeArgument.Ints<RangeBounds.Ints> intRange() {
         return intRange(Function.identity());
     }
 
-    static <R> RangeArgument.Ints<R> intRange(final Function<MinMaxBounds.Ints, R> converter) {
+    static <R> RangeArgument.Ints<R> intRange(final Function<RangeBounds.Ints, R> converter) {
         return new RangeArgument.Ints<>(converter);
     }
 
-    static RangeArgument.Floats<MinMaxBounds.Doubles> floatRange() {
+    static RangeArgument.Floats<RangeBounds.Doubles> floatRange() {
         return floatRange(Function.identity());
     }
 
-    static <R> RangeArgument.Floats<R> floatRange(final Function<MinMaxBounds.Doubles, R> converter) {
+    static <R> RangeArgument.Floats<R> floatRange(final Function<RangeBounds.Doubles, R> converter) {
         return new RangeArgument.Floats<>(converter);
     }
 
     final class Floats<R> implements ArgumentType<R> {
-        private static final Collection<String> EXAMPLES = Arrays.asList("0..5.2", "0", "-5.4", "-100.76..", "..100");
+        private final Function<RangeBounds.Doubles, R> converter;
 
-        private final Function<MinMaxBounds.Doubles, R> converter;
-
-        public Floats(final Function<MinMaxBounds.Doubles, R> converter) {
+        public Floats(final Function<RangeBounds.Doubles, R> converter) {
             this.converter = converter;
         }
 
-        public static MinMaxBounds.Doubles getRange(final CommandContext<CommandSource> context, final String name) {
-            return context.getArgument(name, MinMaxBounds.Doubles.class);
+        public static RangeBounds.Doubles getRange(final CommandContext<CommandSource> context, final String name) {
+            return context.getArgument(name, RangeBounds.Doubles.class);
         }
 
         @Override
         public R parse(final StringReader reader) throws CommandSyntaxException {
-            return converter.apply(MinMaxBounds.Doubles.fromReader(reader));
-        }
-
-        @Override
-        public Collection<String> getExamples() {
-            return EXAMPLES;
+            return converter.apply(RangeBounds.Doubles.fromReader(reader));
         }
 
         public static final class Info implements ArgumentTypeRegistrar<Floats<?>, Info.Spec> {
@@ -90,26 +81,19 @@ public interface RangeArgument {
     }
 
     final class Ints<R> implements ArgumentType<R> {
-        private static final Collection<String> EXAMPLES = Arrays.asList("0..5", "0", "-5", "-100..", "..100");
+        private final Function<RangeBounds.Ints, R> converter;
 
-        private final Function<MinMaxBounds.Ints, R> converter;
-
-        public Ints(final Function<MinMaxBounds.Ints, R> converter) {
+        public Ints(final Function<RangeBounds.Ints, R> converter) {
             this.converter = converter;
         }
 
-        public static MinMaxBounds.Ints getRange(final CommandContext<CommandSource> context, final String name) {
-            return context.getArgument(name, MinMaxBounds.Ints.class);
+        public static RangeBounds.Ints getRange(final CommandContext<CommandSource> context, final String name) {
+            return context.getArgument(name, RangeBounds.Ints.class);
         }
 
         @Override
         public R parse(final StringReader reader) throws CommandSyntaxException {
-            return converter.apply(MinMaxBounds.Ints.fromReader(reader));
-        }
-
-        @Override
-        public Collection<String> getExamples() {
-            return EXAMPLES;
+            return converter.apply(RangeBounds.Ints.fromReader(reader));
         }
 
         public static final class Info implements ArgumentTypeRegistrar<Ints<?>, Info.Spec> {

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/range/RangeBounds.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/range/RangeBounds.java
@@ -12,7 +12,7 @@ import java.util.function.Supplier;
 
 import static fr.euphyllia.fidorial.server.adventure.brigadier.BrigadierAdventureHelper.MSG_SERIALIZER;
 
-public interface MinMaxBounds<T extends Number & Comparable<T>> {
+public interface RangeBounds<T extends Number & Comparable<T>> {
 
     SimpleCommandExceptionType ERROR_EMPTY = new SimpleCommandExceptionType(
             MSG_SERIALIZER.serialize(Component.translatable("argument.range.empty")));
@@ -138,7 +138,7 @@ public interface MinMaxBounds<T extends Number & Comparable<T>> {
         }
     }
 
-    record Doubles(Bounds<Double> bounds, Bounds<Double> boundsSqr) implements MinMaxBounds<Double> {
+    record Doubles(Bounds<Double> bounds, Bounds<Double> boundsSqr) implements RangeBounds<Double> {
 
         public static final Doubles ANY = new Doubles(Bounds.any());
 
@@ -186,7 +186,7 @@ public interface MinMaxBounds<T extends Number & Comparable<T>> {
         }
     }
 
-    record Ints(Bounds<Integer> bounds, Bounds<Long> boundsSqr) implements MinMaxBounds<Integer> {
+    record Ints(Bounds<Integer> bounds, Bounds<Long> boundsSqr) implements RangeBounds<Integer> {
 
         public static final Ints ANY = new Ints(Bounds.any());
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/resource/KeyArgument.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/resource/KeyArgument.java
@@ -11,14 +11,9 @@ import fr.euphyllia.fidorial.server.network.PacketBuffer;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 
-import java.util.Arrays;
-import java.util.Collection;
-
 import static fr.euphyllia.fidorial.server.adventure.brigadier.BrigadierAdventureHelper.MSG_SERIALIZER;
 
 public final class KeyArgument implements ArgumentType<Key> {
-
-    private static final Collection<String> EXAMPLES = Arrays.asList("foo", "foo:bar", "012");
 
     public static final SimpleCommandExceptionType ERROR_INVALID_KEY =
             new SimpleCommandExceptionType(MSG_SERIALIZER.serialize(Component.translatable("argument.id.invalid")));
@@ -39,11 +34,6 @@ public final class KeyArgument implements ArgumentType<Key> {
         }
 
         return Key.key(input);
-    }
-
-    @Override
-    public Collection<String> getExamples() {
-        return EXAMPLES;
     }
 
     public static final class Info implements ArgumentTypeRegistrar<KeyArgument, Info.Spec> {

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/resource/ResourceArgument.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/resource/ResourceArgument.java
@@ -19,16 +19,12 @@ import fr.fidorial.registry.TypedKey;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 
-import java.util.Collection;
-import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.CompletableFuture;
 
 import static fr.euphyllia.fidorial.server.adventure.brigadier.BrigadierAdventureHelper.MSG_SERIALIZER;
 
 public final class ResourceArgument<T> implements ArgumentType<T> {
-
-    private static final Collection<String> EXAMPLES = List.of("minecraft:zombie", "zombie", "foo:bar");
 
     public static final Dynamic2CommandExceptionType ERROR_UNKNOWN_RESOURCE =
             new Dynamic2CommandExceptionType((id, registry) -> MSG_SERIALIZER.serialize(Component.translatable(
@@ -84,11 +80,6 @@ public final class ResourceArgument<T> implements ArgumentType<T> {
         }
 
         return builder.buildFuture();
-    }
-
-    @Override
-    public Collection<String> getExamples() {
-        return EXAMPLES;
     }
 
     public RegistryKey<T> registryKey() {

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/resource/ResourceKeyArgument.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/resource/ResourceKeyArgument.java
@@ -16,14 +16,10 @@ import fr.fidorial.registry.RegistryKey;
 import fr.fidorial.registry.TypedKey;
 import net.kyori.adventure.key.Key;
 
-import java.util.Collection;
-import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.CompletableFuture;
 
 public final class ResourceKeyArgument<T> implements ArgumentType<TypedKey<T>> {
-
-    private static final Collection<String> EXAMPLES = List.of("minecraft:zombie", "zombie", "foo:bar");
 
     private final RegistryKey<T> registryKey;
 
@@ -100,11 +96,6 @@ public final class ResourceKeyArgument<T> implements ArgumentType<TypedKey<T>> {
 
     private Registry<T> registry() {
         return FidorialServer.getInstance().registries().registry(registryKey);
-    }
-
-    @Override
-    public Collection<String> getExamples() {
-        return EXAMPLES;
     }
 
     public RegistryKey<T> registryKey() {

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/selector/DoubleRange.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/selector/DoubleRange.java
@@ -4,10 +4,11 @@ import com.mojang.brigadier.StringReader;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
 import net.kyori.adventure.text.Component;
+import org.jspecify.annotations.Nullable;
 
 import static fr.euphyllia.fidorial.server.adventure.brigadier.BrigadierAdventureHelper.MSG_SERIALIZER;
 
-public record DoubleRange(Double min, Double max) {
+public record DoubleRange(@Nullable Double min, @Nullable Double max) {
 
     public static final SimpleCommandExceptionType ERROR_EMPTY = new SimpleCommandExceptionType(
             MSG_SERIALIZER.serialize(Component.translatable("argument.range.empty")));

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/selector/options/EntitySelectorOptions.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/selector/options/EntitySelectorOptions.java
@@ -21,7 +21,6 @@ import static fr.euphyllia.fidorial.server.adventure.brigadier.BrigadierAdventur
 public final class EntitySelectorOptions {
 
     private static final Map<String, Option> OPTIONS = new HashMap<>();
-    private static final Predicate<EntitySelectorParser> ALWAYS_AVAILABLE = p -> true;
 
     public static final SimpleCommandExceptionType ERROR_RANGE_NEGATIVE = new SimpleCommandExceptionType(
             MSG_SERIALIZER.serialize(Component.translatable("argument.entity.options.distance.negative")));

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/packet/registry/NetworkArgumentIds.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/packet/registry/NetworkArgumentIds.java
@@ -1,36 +1,37 @@
 package fr.euphyllia.fidorial.server.command.brigadier.packet.registry;
 
 import com.mojang.brigadier.arguments.ArgumentType;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 
-import java.util.HashMap;
-import java.util.Map;
 
 public final class NetworkArgumentIds {
 
-    private static final Map<Integer, ArgumentTypeRegistrar<?, ?>> BY_ID = new HashMap<>();
-    private static final Map<ArgumentTypeRegistrar<?, ?>, Integer> IDS = new HashMap<>();
+    private static final Int2ObjectOpenHashMap<ArgumentTypeRegistrar<?, ?>> BY_ID = new Int2ObjectOpenHashMap<>();
+    private static final Object2IntOpenHashMap<ArgumentTypeRegistrar<?, ?>> IDS = new Object2IntOpenHashMap<>();
+
+    static {
+        IDS.defaultReturnValue(-1);
+    }
 
     private NetworkArgumentIds() {
     }
 
     public static void register(final int id, final ArgumentTypeRegistrar<?, ?> registrar) {
-        if (BY_ID.put(id, registrar) != null) {
+        if (BY_ID.containsKey(id)) {
             throw new IllegalStateException("Duplicate network id: " + id);
         }
-
-        if (IDS.put(registrar, id) != null) {
+        BY_ID.put(id, registrar);
+        if (IDS.put(registrar, id) != IDS.defaultReturnValue()) {
             throw new IllegalStateException("Registrar already registered: " + registrar);
         }
     }
 
     public static int getId(final ArgumentTypeRegistrar<?, ?> registrar) {
-        final Integer id = IDS.get(registrar);
-
-        if (id == null) {
-            throw new IllegalArgumentException(
-                    "Unknown registrar: " + registrar.getClass().getName());
+        final int id = IDS.getInt(registrar);
+        if (id == -1) {
+            throw new IllegalArgumentException("Unknown registrar: " + registrar.getClass().getName());
         }
-
         return id;
     }
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/ai/AStarPathfinder.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/ai/AStarPathfinder.java
@@ -3,12 +3,11 @@ package fr.euphyllia.fidorial.server.entity.ai;
 import fr.euphyllia.fidorial.server.world.ServerWorld;
 import fr.fidorial.entity.ai.Path;
 import fr.fidorial.world.BlockPos;
+import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.PriorityQueue;
 
 public class AStarPathfinder {
@@ -37,7 +36,7 @@ public class AStarPathfinder {
             return null;
         }
 
-        final Map<Long, Node> nodes = new HashMap<>();
+        final Long2ObjectOpenHashMap<Node> nodes = new Long2ObjectOpenHashMap<>();
         final PriorityQueue<Node> open = new PriorityQueue<>();
 
         final Node startNode = new Node(from.x(), from.y(), from.z(), null, 0.0, heuristic(from, to));

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/schedulers/AiWorker.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/schedulers/AiWorker.java
@@ -45,7 +45,7 @@ public class AiWorker {
             if (!workers.awaitTermination(5, TimeUnit.SECONDS)) {
                 workers.shutdownNow();
             }
-        } catch (final InterruptedException e) {
+        } catch (final InterruptedException _) {
             Thread.currentThread().interrupt();
             workers.shutdownNow();
         }

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/schedulers/LightUpdateDispatcher.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/schedulers/LightUpdateDispatcher.java
@@ -27,7 +27,9 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -38,6 +40,7 @@ public class LightUpdateDispatcher {
     private static final int CLUSTER_SHIFT = 3; // seems to give the most optimal CPS
 
     private final ExecutorService lightPool;
+    private final AtomicInteger lightThreadId = new AtomicInteger(0);
     private final Consumer<ClientboundPacket> broadcaster;
     private final ChunkNetworkSerializer serializer;
     private final Function<Key, @Nullable ServerWorld> worldLookup;
@@ -52,19 +55,25 @@ public class LightUpdateDispatcher {
     private final Set<Key> scheduledChunks = ConcurrentHashMap.newKeySet();
 
     public LightUpdateDispatcher(
-            final ExecutorService lightPool,
+            final int lightWorkers,
             final int minY,
             final int height,
             final Consumer<ClientboundPacket> broadcaster,
             final ChunkNetworkSerializer serializer,
             final Function<Key, @Nullable ServerWorld> worldLookup
     ) {
-        this.lightPool = lightPool;
-        this.enginePool = new LightEnginePool(((ThreadPoolExecutor) lightPool).getMaximumPoolSize(), minY, height);
+        this.lightPool = Executors.newFixedThreadPool(
+                lightWorkers,
+                r -> Thread.ofPlatform()
+                        .name("fidorial-light-worker-" + lightThreadId.incrementAndGet())
+                        .unstarted(r)
+        );
+        this.enginePool = new LightEnginePool(lightWorkers, minY, height);
         this.regionScheduler = new ChunkRegionScheduler(lightPool);
         this.broadcaster = broadcaster;
         this.serializer = serializer;
         this.worldLookup = worldLookup;
+        LOGGER.info("Light pool started with {} workers", lightWorkers);
     }
 
     public void queueBlockChange(final Key world, final int x, final int y, final int z) {
@@ -341,6 +350,19 @@ public class LightUpdateDispatcher {
         return futures.isEmpty()
                 ? CompletableFuture.completedFuture(null)
                 : CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
+    }
+
+    public void shutdown() {
+        lightPool.shutdown();
+        try {
+            if (!lightPool.awaitTermination(5, TimeUnit.SECONDS)) {
+                lightPool.shutdownNow();
+            }
+        } catch (final InterruptedException _) {
+            Thread.currentThread().interrupt();
+            lightPool.shutdownNow();
+        }
+        LOGGER.info("Light workers stopped");
     }
 
     private static final class WorldLightState {

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/schedulers/ThreadedChunkWorker.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/schedulers/ThreadedChunkWorker.java
@@ -75,7 +75,7 @@ public class ThreadedChunkWorker implements AsyncChunkLoader {
             if (!workers.awaitTermination(5, TimeUnit.SECONDS)) {
                 workers.shutdownNow();
             }
-        } catch (final InterruptedException e) {
+        } catch (final InterruptedException _) {
             workers.shutdownNow();
             Thread.currentThread().interrupt();
         }

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/schedulers/ThreadedRegionRegionizer.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/schedulers/ThreadedRegionRegionizer.java
@@ -141,7 +141,7 @@ public final class ThreadedRegionRegionizer implements RegionizedScheduler {
         workers.shutdown();
         try {
             if (!workers.awaitTermination(5, TimeUnit.SECONDS)) workers.shutdownNow();
-        } catch (final InterruptedException e) {
+        } catch (final InterruptedException _) {
             Thread.currentThread().interrupt();
             workers.shutdownNow();
         }

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/BlockStateRegistry.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/BlockStateRegistry.java
@@ -9,11 +9,12 @@ import fr.fidorial.world.block.BlockGetter;
 import fr.fidorial.world.block.BlockPlaceContext;
 import fr.fidorial.world.block.BlockRegistry;
 import fr.fidorial.world.block.BlockType;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import net.kyori.adventure.key.Key;
 import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 
 public final class BlockStateRegistry {
@@ -23,13 +24,13 @@ public final class BlockStateRegistry {
     private static final Key LAVA_BUCKET = Key.key("lava_bucket");
 
     private final BlockRegistry registry;
-    private final Map<BlockState, BlockData> dataByState;
-    private final Map<Integer, BlockState> stateByNetworkId;
+    private final Object2ObjectOpenHashMap<BlockState, BlockData> dataByState;
+    private final Int2ObjectOpenHashMap<BlockState> stateByNetworkId;
 
     public BlockStateRegistry(final BlockRegistry registry) {
         this.registry = registry;
-        this.dataByState = new HashMap<>();
-        this.stateByNetworkId = new HashMap<>();
+        this.dataByState = new Object2ObjectOpenHashMap<>();
+        this.stateByNetworkId = new Int2ObjectOpenHashMap<>();
         indexGeneratedStates();
     }
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/ServerWorld.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/ServerWorld.java
@@ -37,7 +37,6 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -254,7 +253,7 @@ public final class ServerWorld implements World {
         }
         final ChunkColumn column;
         try {
-            column = loaded.computeIfAbsent(mapKey, ignored -> {
+            column = loaded.computeIfAbsent(mapKey, _ -> {
                 try {
                     final ChunkColumn fromDisk = storage.load(dimension, chunkX, chunkZ);
                     if (fromDisk != null) {
@@ -550,7 +549,7 @@ public final class ServerWorld implements World {
             return CompletableFuture.completedFuture(false);
         }
 
-        final Set<Long> wanted = new HashSet<>();
+        final LongSet wanted = new LongOpenHashSet();
         for (final ChunkViewSource viewer : viewers) {
             viewer.collectViewedChunks(wanted::add);
         }

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/light/LightEnginePool.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/light/LightEnginePool.java
@@ -4,12 +4,8 @@ import java.util.concurrent.ArrayBlockingQueue;
 
 public final class LightEnginePool {
     private final ArrayBlockingQueue<FloodFillLightEngine> pool;
-    private final int minY;
-    private final int height;
 
     public LightEnginePool(final int parallelism, final int minY, final int height) {
-        this.minY = minY;
-        this.height = height;
         this.pool = new ArrayBlockingQueue<>(parallelism);
         for (int i = 0; i < parallelism; i++) {
             pool.add(new FloodFillLightEngine(minY, height));

--- a/fidorial-test-plugin/src/main/java/fr/euphyllia/fidorial/testplugin/command/argument/BaguetteArgument.java
+++ b/fidorial-test-plugin/src/main/java/fr/euphyllia/fidorial/testplugin/command/argument/BaguetteArgument.java
@@ -12,7 +12,6 @@ import fr.fidorial.command.MessageComponentSerializer;
 import fr.fidorial.command.argument.ArgumentTypes;
 import net.kyori.adventure.text.Component;
 
-import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.CompletableFuture;
 
@@ -26,8 +25,6 @@ public final class BaguetteArgument {
         RETRODOR,
         MOULEE
     }
-
-    private static final List<String> EXAMPLES = List.of("tradition", "epi");
 
     private static final DynamicCommandExceptionType ERROR_INVALID_VALUE =
             new DynamicCommandExceptionType(
@@ -43,7 +40,7 @@ public final class BaguetteArgument {
     }
 
     public static ArgumentType<Baguette> baguette() {
-        return ArgumentTypes.map(StringArgumentType.word(), BaguetteArgument::parse, BaguetteArgument::suggest, EXAMPLES);
+        return ArgumentTypes.map(StringArgumentType.word(), BaguetteArgument::parse, BaguetteArgument::suggest);
     }
 
     private static Baguette parse(final String value, final StringReader reader) throws CommandSyntaxException {


### PR DESCRIPTION
They aren't serialized in any way nor used in code so no point in having them. Also replaced a couple of maps with fastutil equivalents where applicable.