### PR TITLE
Add NBT Component support

### DIFF
--- a/fidorial-api/src/main/java/fr/fidorial/command/argument/ArgumentProvider.java
+++ b/fidorial-api/src/main/java/fr/fidorial/command/argument/ArgumentProvider.java
@@ -9,6 +9,7 @@ import fr.fidorial.command.argument.range.DoubleRangeProvider;
 import fr.fidorial.command.argument.range.IntegerRangeProvider;
 import fr.fidorial.command.argument.resolvers.AngleResolver;
 import fr.fidorial.command.argument.resolvers.BlockPosResolver;
+import fr.fidorial.command.argument.resolvers.NbtPathResolver;
 import fr.fidorial.command.argument.resolvers.PlayerProfileListResolver;
 import fr.fidorial.command.argument.resolvers.PositionResolver;
 import fr.fidorial.command.argument.resolvers.selector.EntitySelectorArgumentResolver;
@@ -273,4 +274,9 @@ public interface ArgumentProvider {
      * @since 0.1.0
      */
     <T> ArgumentType<T> withServerSuggestions(ArgumentType<T> type);
+
+    /**
+     * @since 0.1.0
+     */
+    ArgumentType<NbtPathResolver> nbtPath();
 }

--- a/fidorial-api/src/main/java/fr/fidorial/command/argument/ArgumentTypes.java
+++ b/fidorial-api/src/main/java/fr/fidorial/command/argument/ArgumentTypes.java
@@ -9,6 +9,7 @@ import fr.fidorial.command.argument.range.DoubleRangeProvider;
 import fr.fidorial.command.argument.range.IntegerRangeProvider;
 import fr.fidorial.command.argument.resolvers.AngleResolver;
 import fr.fidorial.command.argument.resolvers.BlockPosResolver;
+import fr.fidorial.command.argument.resolvers.NbtPathResolver;
 import fr.fidorial.command.argument.resolvers.PlayerProfileListResolver;
 import fr.fidorial.command.argument.resolvers.PositionResolver;
 import fr.fidorial.command.argument.resolvers.selector.EntitySelectorArgumentResolver;
@@ -23,6 +24,7 @@ import fr.fidorial.registry.TypedKey;
 import fr.fidorial.world.World;
 import net.kyori.adventure.bossbar.BossBar;
 import net.kyori.adventure.key.Key;
+import net.kyori.adventure.nbt.BinaryTag;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.Style;
@@ -630,5 +632,15 @@ public final class ArgumentTypes {
      */
     public static <T> ArgumentType<T> withServerSuggestions(final ArgumentType<T> type) {
         return provider().withServerSuggestions(type);
+    }
+
+    /**
+     * An NBT path argument, resolvable against any root {@link BinaryTag}.
+     *
+     * @return argument
+     * @since 0.1.0
+     */
+    public static ArgumentType<NbtPathResolver> nbtPath() {
+        return provider().nbtPath();
     }
 }

--- a/fidorial-api/src/main/java/fr/fidorial/command/argument/resolvers/NbtPathResolver.java
+++ b/fidorial-api/src/main/java/fr/fidorial/command/argument/resolvers/NbtPathResolver.java
@@ -1,0 +1,31 @@
+package fr.fidorial.command.argument.resolvers;
+
+import net.kyori.adventure.nbt.BinaryTag;
+import org.jetbrains.annotations.ApiStatus;
+
+import java.util.List;
+
+/**
+ * A parsed NBT path, resolvable against any root {@link BinaryTag}.
+ *
+ * @since 0.1.0
+ */
+@ApiStatus.NonExtendable
+public interface NbtPathResolver {
+
+    /**
+     * Resolves this path against the given root tag.
+     *
+     * @param root the tag to resolve against
+     * @return the matched tags, or an empty list if any path segment matched nothing
+     * @since 0.1.0
+     */
+    List<BinaryTag> resolve(BinaryTag root);
+
+    /**
+     * Returns a parseable string representation of this path.
+     *
+     * @since 0.1.0
+     */
+    String asString();
+}

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/adventure/brigadier/BrigadierAdventureHelper.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/adventure/brigadier/BrigadierAdventureHelper.java
@@ -1,14 +1,11 @@
 package fr.euphyllia.fidorial.server.adventure.brigadier;
 
 import com.mojang.brigadier.Message;
-import fr.fidorial.command.MessageComponentSerializer;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.ComponentLike;
 import net.kyori.adventure.text.TranslatableComponent;
 
 public final class BrigadierAdventureHelper {
-
-    public static final MessageComponentSerializer MSG_SERIALIZER = MessageComponentSerializer.message();
 
     private BrigadierAdventureHelper() {
     }

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/ArgumentProviderImpl.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/ArgumentProviderImpl.java
@@ -29,6 +29,7 @@ import fr.euphyllia.fidorial.server.command.brigadier.argument.location.AngleArg
 import fr.euphyllia.fidorial.server.command.brigadier.argument.location.BlockPositionArgument;
 import fr.euphyllia.fidorial.server.command.brigadier.argument.location.DimensionArgument;
 import fr.euphyllia.fidorial.server.command.brigadier.argument.location.Vec3Argument;
+import fr.euphyllia.fidorial.server.command.brigadier.argument.nbt.NbtDataArgument;
 import fr.euphyllia.fidorial.server.command.brigadier.argument.player.GameModeArgument;
 import fr.euphyllia.fidorial.server.command.brigadier.argument.player.PlayerProfileArgument;
 import fr.euphyllia.fidorial.server.command.brigadier.argument.range.RangeArgument;
@@ -45,6 +46,7 @@ import fr.fidorial.command.argument.range.IntegerRangeProvider;
 import fr.fidorial.command.argument.range.RangeProvider;
 import fr.fidorial.command.argument.resolvers.AngleResolver;
 import fr.fidorial.command.argument.resolvers.BlockPosResolver;
+import fr.fidorial.command.argument.resolvers.NbtPathResolver;
 import fr.fidorial.command.argument.resolvers.PlayerProfileListResolver;
 import fr.fidorial.command.argument.resolvers.PositionResolver;
 import fr.fidorial.command.argument.resolvers.selector.EntitySelectorArgumentResolver;
@@ -336,5 +338,10 @@ public class ArgumentProviderImpl implements ArgumentProvider {
                 registryLookup.find(typedKey)
                         .orElseThrow(() -> ResourceArgument.ERROR_UNKNOWN_RESOURCE
                                 .createWithContext(reader, typedKey.key().asString(), registryKey.key().asString()))));
+    }
+
+    @Override
+    public ArgumentType<NbtPathResolver> nbtPath() {
+        return NbtDataArgument.nbtPath();
     }
 }

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/bossbar/BossBarColorArgument.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/bossbar/BossBarColorArgument.java
@@ -8,20 +8,16 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.exceptions.DynamicCommandExceptionType;
 import com.mojang.brigadier.suggestion.Suggestions;
 import com.mojang.brigadier.suggestion.SuggestionsBuilder;
+import fr.euphyllia.fidorial.server.command.brigadier.argument.util.ExceptionFactory;
 import fr.fidorial.command.argument.ArgumentTypes;
 import net.kyori.adventure.bossbar.BossBar;
-import net.kyori.adventure.text.Component;
 
 import java.util.Locale;
 import java.util.concurrent.CompletableFuture;
 
-import static fr.euphyllia.fidorial.server.adventure.brigadier.BrigadierAdventureHelper.MSG_SERIALIZER;
-
 public final class BossBarColorArgument {
 
-    private static final DynamicCommandExceptionType ERROR_INVALID_VALUE =
-            new DynamicCommandExceptionType(value -> MSG_SERIALIZER.serialize(
-                    Component.translatable("argument.enum.invalid", Component.text(String.valueOf(value)))));
+    private static final DynamicCommandExceptionType ERROR_INVALID_VALUE = ExceptionFactory.dynamic("argument.enum.invalid");
 
     private BossBarColorArgument() {
     }

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/bossbar/BossBarFlagArgument.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/bossbar/BossBarFlagArgument.java
@@ -8,20 +8,16 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.exceptions.DynamicCommandExceptionType;
 import com.mojang.brigadier.suggestion.Suggestions;
 import com.mojang.brigadier.suggestion.SuggestionsBuilder;
+import fr.euphyllia.fidorial.server.command.brigadier.argument.util.ExceptionFactory;
 import fr.fidorial.command.argument.ArgumentTypes;
 import net.kyori.adventure.bossbar.BossBar;
-import net.kyori.adventure.text.Component;
 
 import java.util.Locale;
 import java.util.concurrent.CompletableFuture;
 
-import static fr.euphyllia.fidorial.server.adventure.brigadier.BrigadierAdventureHelper.MSG_SERIALIZER;
-
 public final class BossBarFlagArgument {
 
-    private static final DynamicCommandExceptionType ERROR_INVALID_VALUE =
-            new DynamicCommandExceptionType(value -> MSG_SERIALIZER.serialize(
-                    Component.translatable("argument.enum.invalid", Component.text(String.valueOf(value)))));
+    private static final DynamicCommandExceptionType ERROR_INVALID_VALUE = ExceptionFactory.dynamic("argument.enum.invalid");
 
     private BossBarFlagArgument() {
     }

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/bossbar/BossBarOverlayArgument.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/bossbar/BossBarOverlayArgument.java
@@ -8,20 +8,16 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.exceptions.DynamicCommandExceptionType;
 import com.mojang.brigadier.suggestion.Suggestions;
 import com.mojang.brigadier.suggestion.SuggestionsBuilder;
+import fr.euphyllia.fidorial.server.command.brigadier.argument.util.ExceptionFactory;
 import fr.fidorial.command.argument.ArgumentTypes;
 import net.kyori.adventure.bossbar.BossBar;
-import net.kyori.adventure.text.Component;
 
 import java.util.Locale;
 import java.util.concurrent.CompletableFuture;
 
-import static fr.euphyllia.fidorial.server.adventure.brigadier.BrigadierAdventureHelper.MSG_SERIALIZER;
-
 public final class BossBarOverlayArgument {
 
-    private static final DynamicCommandExceptionType ERROR_INVALID_VALUE =
-            new DynamicCommandExceptionType(value -> MSG_SERIALIZER.serialize(
-                    Component.translatable("argument.enum.invalid", Component.text(String.valueOf(value)))));
+    private static final DynamicCommandExceptionType ERROR_INVALID_VALUE = ExceptionFactory.dynamic("argument.enum.invalid");
 
     private BossBarOverlayArgument() {
     }

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/chat/ComponentArgument.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/chat/ComponentArgument.java
@@ -9,6 +9,7 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.exceptions.DynamicCommandExceptionType;
 import fr.euphyllia.fidorial.server.command.brigadier.argument.entity.EntitySelector;
 import fr.euphyllia.fidorial.server.command.brigadier.argument.selector.EntitySelectorParser;
+import fr.euphyllia.fidorial.server.command.brigadier.argument.util.ExceptionFactory;
 import fr.euphyllia.fidorial.server.command.brigadier.packet.registry.ArgumentTypeRegistrar;
 import fr.euphyllia.fidorial.server.network.PacketBuffer;
 import fr.fidorial.command.CommandSource;
@@ -22,15 +23,9 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import static fr.euphyllia.fidorial.server.adventure.brigadier.BrigadierAdventureHelper.MSG_SERIALIZER;
-
 public final class ComponentArgument implements ArgumentType<Component> {
 
-    public static final DynamicCommandExceptionType ERROR_INVALID_COMPONENT = new DynamicCommandExceptionType(
-            message -> MSG_SERIALIZER.serialize(
-                    net.kyori.adventure.text.Component.translatable(
-                            "argument.component.invalid",
-                            net.kyori.adventure.text.Component.text(message.toString()))));
+    public static final DynamicCommandExceptionType ERROR_INVALID_COMPONENT = ExceptionFactory.dynamic("argument.component.invalid");
 
     private ComponentArgument() {
     }

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/chat/HexColorArgument.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/chat/HexColorArgument.java
@@ -8,20 +8,16 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.exceptions.DynamicCommandExceptionType;
 import com.mojang.brigadier.suggestion.Suggestions;
 import com.mojang.brigadier.suggestion.SuggestionsBuilder;
+import fr.euphyllia.fidorial.server.command.brigadier.argument.util.ExceptionFactory;
 import fr.euphyllia.fidorial.server.command.brigadier.packet.registry.ArgumentTypeRegistrar;
 import fr.euphyllia.fidorial.server.network.PacketBuffer;
-import net.kyori.adventure.text.Component;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
-import static fr.euphyllia.fidorial.server.adventure.brigadier.BrigadierAdventureHelper.MSG_SERIALIZER;
-
 public final class HexColorArgument<T> implements ArgumentType<T> {
 
-    public static final DynamicCommandExceptionType ERROR_INVALID_HEX =
-            new DynamicCommandExceptionType(value -> MSG_SERIALIZER.serialize(
-                    Component.translatable("argument.hexcolor.invalid", Component.text(String.valueOf(value)))));
+    public static final DynamicCommandExceptionType ERROR_INVALID_HEX = ExceptionFactory.dynamic("argument.hexcolor.invalid");
 
     private final Function<Integer, T> converter;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/chat/NamedColorArgument.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/chat/NamedColorArgument.java
@@ -8,20 +8,16 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.exceptions.DynamicCommandExceptionType;
 import com.mojang.brigadier.suggestion.Suggestions;
 import com.mojang.brigadier.suggestion.SuggestionsBuilder;
+import fr.euphyllia.fidorial.server.command.brigadier.argument.util.ExceptionFactory;
 import fr.euphyllia.fidorial.server.command.brigadier.packet.registry.ArgumentTypeRegistrar;
 import fr.euphyllia.fidorial.server.network.PacketBuffer;
-import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 
 import java.util.concurrent.CompletableFuture;
 
-import static fr.euphyllia.fidorial.server.adventure.brigadier.BrigadierAdventureHelper.MSG_SERIALIZER;
-
 public final class NamedColorArgument implements ArgumentType<NamedTextColor> {
 
-    public static final DynamicCommandExceptionType ERROR_INVALID_VALUE =
-            new DynamicCommandExceptionType(value -> MSG_SERIALIZER.serialize(
-                    Component.translatable("argument.color.invalid", Component.text(String.valueOf(value)))));
+    public static final DynamicCommandExceptionType ERROR_INVALID_VALUE = ExceptionFactory.dynamic("argument.color.invalid");
 
     public static NamedColorArgument namedColor() {
         return new NamedColorArgument();

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/chat/StyleArgument.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/chat/StyleArgument.java
@@ -9,6 +9,7 @@ import com.mojang.brigadier.arguments.ArgumentType;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.exceptions.DynamicCommandExceptionType;
+import fr.euphyllia.fidorial.server.command.brigadier.argument.util.ExceptionFactory;
 import fr.euphyllia.fidorial.server.command.brigadier.packet.registry.ArgumentTypeRegistrar;
 import fr.euphyllia.fidorial.server.network.PacketBuffer;
 import fr.fidorial.command.CommandSource;
@@ -18,16 +19,11 @@ import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
 
 import java.util.Set;
 
-import static fr.euphyllia.fidorial.server.adventure.brigadier.BrigadierAdventureHelper.MSG_SERIALIZER;
-
 public final class StyleArgument implements ArgumentType<Style> {
 
     private static final Set<String> CONTENT_KEYS = Set.of("text", "translate", "selector", "score", "keybind", "nbt");
 
-    public static final DynamicCommandExceptionType ERROR_INVALID_STYLE = new DynamicCommandExceptionType(
-            message -> MSG_SERIALIZER.serialize(
-                    Component.translatable("argument.style.invalid")
-                            .append(Component.text(message.toString()))));
+    public static final DynamicCommandExceptionType ERROR_INVALID_STYLE = ExceptionFactory.dynamic("argument.style.invalid");
 
     private StyleArgument() {
     }

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/entity/EntityArgument.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/entity/EntityArgument.java
@@ -9,12 +9,12 @@ import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
 import com.mojang.brigadier.suggestion.Suggestions;
 import com.mojang.brigadier.suggestion.SuggestionsBuilder;
 import fr.euphyllia.fidorial.server.command.brigadier.argument.selector.EntitySelectorParser;
+import fr.euphyllia.fidorial.server.command.brigadier.argument.util.ExceptionFactory;
 import fr.euphyllia.fidorial.server.command.brigadier.packet.registry.ArgumentTypeRegistrar;
 import fr.euphyllia.fidorial.server.network.PacketBuffer;
 import fr.fidorial.command.CommandSource;
 import fr.fidorial.entity.Entity;
 import fr.fidorial.entity.Player;
-import net.kyori.adventure.text.Component;
 
 import java.util.Collection;
 import java.util.Locale;
@@ -22,27 +22,14 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
-import static fr.euphyllia.fidorial.server.adventure.brigadier.BrigadierAdventureHelper.MSG_SERIALIZER;
-
 public final class EntityArgument<T> implements ArgumentType<T> {
 
-    public static final SimpleCommandExceptionType ERROR_NOT_SINGLE_ENTITY =
-            new SimpleCommandExceptionType(MSG_SERIALIZER.serialize(Component.translatable("argument.entity.toomany")));
-
-    public static final SimpleCommandExceptionType ERROR_NOT_SINGLE_PLAYER =
-            new SimpleCommandExceptionType(MSG_SERIALIZER.serialize(Component.translatable("argument.player.toomany")));
-
-    public static final SimpleCommandExceptionType ERROR_ONLY_PLAYERS_ALLOWED = new SimpleCommandExceptionType(
-            MSG_SERIALIZER.serialize(Component.translatable("argument.player.entities")));
-
-    public static final SimpleCommandExceptionType NO_ENTITIES_FOUND = new SimpleCommandExceptionType(
-            MSG_SERIALIZER.serialize(Component.translatable("argument.entity.notfound.entity")));
-
-    public static final SimpleCommandExceptionType NO_PLAYERS_FOUND = new SimpleCommandExceptionType(
-            MSG_SERIALIZER.serialize(Component.translatable("argument.entity.notfound.player")));
-
-    public static final SimpleCommandExceptionType SELECTORS_NOT_PERMITTED = new SimpleCommandExceptionType(
-            MSG_SERIALIZER.serialize(Component.translatable("argument.entity.selector.not_allowed")));
+    public static final SimpleCommandExceptionType ERROR_NOT_SINGLE_ENTITY = ExceptionFactory.simple("argument.entity.toomany");
+    public static final SimpleCommandExceptionType ERROR_NOT_SINGLE_PLAYER = ExceptionFactory.simple("argument.player.toomany");
+    public static final SimpleCommandExceptionType ERROR_ONLY_PLAYERS_ALLOWED = ExceptionFactory.simple("argument.player.entities");
+    public static final SimpleCommandExceptionType NO_ENTITIES_FOUND = ExceptionFactory.simple("argument.entity.notfound.entity");
+    public static final SimpleCommandExceptionType NO_PLAYERS_FOUND = ExceptionFactory.simple("argument.entity.notfound.player");
+    public static final SimpleCommandExceptionType SELECTORS_NOT_PERMITTED = ExceptionFactory.simple("argument.entity.selector.not_allowed");
 
     private final boolean single;
     private final boolean playersOnly;

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/entity/UuidArgument.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/entity/UuidArgument.java
@@ -6,23 +6,20 @@ import com.mojang.brigadier.arguments.ArgumentType;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
+import fr.euphyllia.fidorial.server.command.brigadier.argument.util.ExceptionFactory;
 import fr.euphyllia.fidorial.server.command.brigadier.packet.registry.ArgumentTypeRegistrar;
 import fr.euphyllia.fidorial.server.network.PacketBuffer;
 import fr.fidorial.command.CommandSource;
-import net.kyori.adventure.text.Component;
 
 import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static fr.euphyllia.fidorial.server.adventure.brigadier.BrigadierAdventureHelper.MSG_SERIALIZER;
-
 public final class UuidArgument implements ArgumentType<UUID> {
 
     private static final Pattern ALLOWED_CHARACTERS = Pattern.compile("^([-A-Fa-f0-9]+)");
 
-    private static final SimpleCommandExceptionType ERROR_INVALID_UUID =
-            new SimpleCommandExceptionType(MSG_SERIALIZER.serialize(Component.translatable("argument.uuid.invalid")));
+    private static final SimpleCommandExceptionType ERROR_INVALID_UUID = ExceptionFactory.simple("argument.uuid.invalid");
 
     public static UuidArgument uuid() {
         return new UuidArgument();

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/generic/DurationArgument.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/generic/DurationArgument.java
@@ -9,9 +9,9 @@ import com.mojang.brigadier.exceptions.DynamicCommandExceptionType;
 import com.mojang.brigadier.suggestion.SuggestionProvider;
 import com.mojang.brigadier.suggestion.Suggestions;
 import com.mojang.brigadier.suggestion.SuggestionsBuilder;
+import fr.euphyllia.fidorial.server.command.brigadier.argument.util.ExceptionFactory;
 import fr.fidorial.command.CommandSource;
 import fr.fidorial.command.argument.ArgumentTypes;
-import net.kyori.adventure.text.Component;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -20,8 +20,6 @@ import java.util.Locale;
 import java.util.concurrent.CompletableFuture;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import static fr.euphyllia.fidorial.server.adventure.brigadier.BrigadierAdventureHelper.MSG_SERIALIZER;
 
 /**
  * Reads a positive amount of time written as a chain of amount/unit pairs, such as
@@ -44,13 +42,8 @@ public final class DurationArgument {
 
     private static final Pattern UNITS = Pattern.compile("(\\d{1,9})([wdhms])", Pattern.CASE_INSENSITIVE);
 
-    private static final DynamicCommandExceptionType ERROR_INVALID =
-            new DynamicCommandExceptionType(value -> MSG_SERIALIZER.serialize(
-                    Component.translatable("argument.duration.invalid", Component.text(String.valueOf(value)))));
-
-    private static final DynamicCommandExceptionType ERROR_TOO_LONG =
-            new DynamicCommandExceptionType(value -> MSG_SERIALIZER.serialize(
-                    Component.translatable("argument.duration.too_long", Component.text(String.valueOf(value)))));
+    private static final DynamicCommandExceptionType ERROR_INVALID = ExceptionFactory.dynamic("argument.duration.invalid");
+    private static final DynamicCommandExceptionType ERROR_TOO_LONG = ExceptionFactory.dynamic("argument.duration.too_long");
 
     public static final SuggestionProvider<CommandSource> SUGGESTIONS = DurationArgument::suggest;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/generic/TimeArgument.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/generic/TimeArgument.java
@@ -9,26 +9,18 @@ import com.mojang.brigadier.exceptions.Dynamic2CommandExceptionType;
 import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
 import com.mojang.brigadier.suggestion.Suggestions;
 import com.mojang.brigadier.suggestion.SuggestionsBuilder;
+import fr.euphyllia.fidorial.server.command.brigadier.argument.util.ExceptionFactory;
 import fr.euphyllia.fidorial.server.command.brigadier.packet.registry.ArgumentTypeRegistrar;
 import fr.euphyllia.fidorial.server.network.PacketBuffer;
-import net.kyori.adventure.text.Component;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
-import static fr.euphyllia.fidorial.server.adventure.brigadier.BrigadierAdventureHelper.MSG_SERIALIZER;
-
 public record TimeArgument(int minimum) implements ArgumentType<Integer> {
 
-    private static final SimpleCommandExceptionType ERROR_INVALID_UNIT = new SimpleCommandExceptionType(
-            MSG_SERIALIZER.serialize(Component.translatable("argument.time.invalid_unit")));
-
-    private static final Dynamic2CommandExceptionType ERROR_TICK_COUNT_TOO_LOW =
-            new Dynamic2CommandExceptionType((value, limit) -> MSG_SERIALIZER.serialize(Component.translatable(
-                    "argument.time.tick_count_too_low",
-                    Component.text(limit.toString()),
-                    Component.text(value.toString()))));
+    private static final SimpleCommandExceptionType ERROR_INVALID_UNIT = ExceptionFactory.simple("argument.time.invalid_unit");
+    private static final Dynamic2CommandExceptionType ERROR_TICK_COUNT_TOO_LOW = ExceptionFactory.dynamic2Reversed("argument.time.tick_count_too_low");
 
     private static final Map<String, Integer> UNITS = new LinkedHashMap<>();
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/item/ItemArgument.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/item/ItemArgument.java
@@ -8,6 +8,7 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.exceptions.DynamicCommandExceptionType;
 import com.mojang.brigadier.suggestion.Suggestions;
 import com.mojang.brigadier.suggestion.SuggestionsBuilder;
+import fr.euphyllia.fidorial.server.command.brigadier.argument.util.ExceptionFactory;
 import fr.euphyllia.fidorial.server.command.brigadier.argument.util.KeyReader;
 import fr.euphyllia.fidorial.server.command.brigadier.packet.registry.ArgumentTypeRegistrar;
 import fr.euphyllia.fidorial.server.network.PacketBuffer;
@@ -15,19 +16,14 @@ import fr.fidorial.inventory.ItemStack;
 import fr.fidorial.registry.TypedKey;
 import fr.fidorial.registry.keys.ItemKeys;
 import net.kyori.adventure.key.Key;
-import net.kyori.adventure.text.Component;
 
 import java.util.Locale;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
-import static fr.euphyllia.fidorial.server.adventure.brigadier.BrigadierAdventureHelper.MSG_SERIALIZER;
-
 public final class ItemArgument<T> implements ArgumentType<T> {
 
-    public static final DynamicCommandExceptionType ERROR_UNKNOWN_ITEM =
-            new DynamicCommandExceptionType(id -> MSG_SERIALIZER.serialize(
-                    Component.translatable("argument.item.id.invalid", Component.text(String.valueOf(id)))));
+    public static final DynamicCommandExceptionType ERROR_UNKNOWN_ITEM = ExceptionFactory.dynamic("argument.item.id.invalid");
 
     private final Function<ItemInput, T> converter;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/item/ItemPredicateArgument.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/item/ItemPredicateArgument.java
@@ -9,6 +9,7 @@ import com.mojang.brigadier.exceptions.DynamicCommandExceptionType;
 import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
 import com.mojang.brigadier.suggestion.Suggestions;
 import com.mojang.brigadier.suggestion.SuggestionsBuilder;
+import fr.euphyllia.fidorial.server.command.brigadier.argument.util.ExceptionFactory;
 import fr.euphyllia.fidorial.server.command.brigadier.argument.util.KeyReader;
 import fr.euphyllia.fidorial.server.command.brigadier.packet.registry.ArgumentTypeRegistrar;
 import fr.euphyllia.fidorial.server.network.PacketBuffer;
@@ -16,23 +17,17 @@ import fr.fidorial.inventory.ItemStack;
 import fr.fidorial.registry.TypedKey;
 import fr.fidorial.registry.keys.ItemKeys;
 import net.kyori.adventure.key.Key;
-import net.kyori.adventure.text.Component;
 
 import java.util.Locale;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
-import static fr.euphyllia.fidorial.server.adventure.brigadier.BrigadierAdventureHelper.MSG_SERIALIZER;
-
 public final class ItemPredicateArgument<T> implements ArgumentType<T> {
 
-    public static final DynamicCommandExceptionType ERROR_UNKNOWN_ITEM =
-            new DynamicCommandExceptionType(id -> MSG_SERIALIZER.serialize(
-                    Component.translatable("argument.item.id.invalid", Component.text(String.valueOf(id)))));
+    public static final DynamicCommandExceptionType ERROR_UNKNOWN_ITEM = ExceptionFactory.dynamic("argument.item.id.invalid");
 
-    public static final SimpleCommandExceptionType ERROR_TAGS_UNSUPPORTED =
-            new SimpleCommandExceptionType(MSG_SERIALIZER.serialize(Component.text("Item tags are not yet supported")));
+    public static final SimpleCommandExceptionType ERROR_TAGS_UNSUPPORTED = ExceptionFactory.simple("Item tags are not yet supported");
 
     private final Function<Predicate<ItemStack>, T> converter;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/location/AngleArgument.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/location/AngleArgument.java
@@ -5,19 +5,15 @@ import com.mojang.brigadier.StringReader;
 import com.mojang.brigadier.arguments.ArgumentType;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
+import fr.euphyllia.fidorial.server.command.brigadier.argument.util.ExceptionFactory;
 import fr.euphyllia.fidorial.server.command.brigadier.packet.registry.ArgumentTypeRegistrar;
 import fr.euphyllia.fidorial.server.network.PacketBuffer;
 import fr.fidorial.command.argument.resolvers.AngleResolver;
-import net.kyori.adventure.text.Component;
-
-import static fr.euphyllia.fidorial.server.adventure.brigadier.BrigadierAdventureHelper.MSG_SERIALIZER;
 
 public final class AngleArgument implements ArgumentType<AngleResolver> {
 
-    public static final SimpleCommandExceptionType ERROR_NOT_COMPLETE = new SimpleCommandExceptionType(
-            MSG_SERIALIZER.serialize(Component.translatable("argument.angle.incomplete")));
-    public static final SimpleCommandExceptionType ERROR_INVALID_ANGLE =
-            new SimpleCommandExceptionType(MSG_SERIALIZER.serialize(Component.translatable("argument.angle.invalid")));
+    public static final SimpleCommandExceptionType ERROR_NOT_COMPLETE = ExceptionFactory.simple("argument.angle.incomplete");
+    public static final SimpleCommandExceptionType ERROR_INVALID_ANGLE = ExceptionFactory.simple("argument.angle.invalid");
 
     public static AngleArgument angle() {
         return new AngleArgument();

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/location/DimensionArgument.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/location/DimensionArgument.java
@@ -9,24 +9,20 @@ import com.mojang.brigadier.exceptions.DynamicCommandExceptionType;
 import com.mojang.brigadier.suggestion.Suggestions;
 import com.mojang.brigadier.suggestion.SuggestionsBuilder;
 import fr.euphyllia.fidorial.server.FidorialServer;
+import fr.euphyllia.fidorial.server.command.brigadier.argument.util.ExceptionFactory;
 import fr.euphyllia.fidorial.server.command.brigadier.argument.util.KeyReader;
 import fr.euphyllia.fidorial.server.command.brigadier.argument.util.KeyReader.ParsedKey;
 import fr.euphyllia.fidorial.server.command.brigadier.packet.registry.ArgumentTypeRegistrar;
 import fr.euphyllia.fidorial.server.network.PacketBuffer;
 import fr.fidorial.world.World;
 import net.kyori.adventure.key.Key;
-import net.kyori.adventure.text.Component;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
-import static fr.euphyllia.fidorial.server.adventure.brigadier.BrigadierAdventureHelper.MSG_SERIALIZER;
-
 public final class DimensionArgument<T> implements ArgumentType<T> {
 
-    public static final DynamicCommandExceptionType ERROR_INVALID_VALUE =
-            new DynamicCommandExceptionType(value -> MSG_SERIALIZER.serialize(
-                    Component.translatable("argument.dimension.invalid", Component.text(value.toString()))));
+    public static final DynamicCommandExceptionType ERROR_INVALID_VALUE = ExceptionFactory.dynamic("argument.dimension.invalid");
 
     private final Function<Key, T> converter;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/nbt/NbtDataArgument.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/nbt/NbtDataArgument.java
@@ -1,0 +1,284 @@
+package fr.euphyllia.fidorial.server.command.brigadier.argument.nbt;
+
+import com.google.gson.JsonObject;
+import com.mojang.brigadier.StringReader;
+import com.mojang.brigadier.arguments.ArgumentType;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.brigadier.exceptions.DynamicCommandExceptionType;
+import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
+import fr.euphyllia.fidorial.server.command.brigadier.argument.util.ExceptionFactory;
+import fr.euphyllia.fidorial.server.command.brigadier.packet.registry.ArgumentTypeRegistrar;
+import fr.euphyllia.fidorial.server.network.PacketBuffer;
+import fr.fidorial.command.argument.resolvers.NbtPathResolver;
+import net.kyori.adventure.nbt.BinaryTag;
+import net.kyori.adventure.nbt.CompoundBinaryTag;
+import net.kyori.adventure.nbt.ListBinaryTag;
+import net.kyori.adventure.nbt.TagStringIO;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
+
+public final class NbtDataArgument implements ArgumentType<NbtPathResolver> {
+
+    public static final SimpleCommandExceptionType ERROR_INVALID_NODE = ExceptionFactory.simple("arguments.nbtpath.node.invalid");
+    public static final DynamicCommandExceptionType ERROR_NOTHING_FOUND = ExceptionFactory.dynamic("arguments.nbtpath.nothing_found");
+
+    public static NbtDataArgument nbtPath() {
+        return new NbtDataArgument();
+    }
+
+    public static List<BinaryTag> getOrThrow(final NbtPathResolver path, final BinaryTag root) throws CommandSyntaxException {
+        final List<BinaryTag> result = path.resolve(root);
+        if (result.isEmpty()) {
+            throw ERROR_NOTHING_FOUND.create(path.asString());
+        }
+        return result;
+    }
+
+    @Override
+    public NbtPathResolver parse(final StringReader reader) throws CommandSyntaxException {
+        final int start = reader.getCursor();
+        final List<Function<List<BinaryTag>, List<BinaryTag>>> chain = new ArrayList<>();
+        boolean atStart = true;
+
+        while (reader.canRead() && reader.peek() != ' ') {
+            chain.add(parseStep(reader, atStart));
+            atStart = false;
+            if (reader.canRead()) {
+                final char next = reader.peek();
+                if (next != ' ' && next != '[' && next != '{') {
+                    reader.expect('.');
+                }
+            }
+        }
+
+        final String text = reader.getString().substring(start, reader.getCursor());
+        return new ChainPath(text, List.copyOf(chain));
+    }
+
+    private static Function<List<BinaryTag>, List<BinaryTag>> parseStep(final StringReader reader, final boolean atStart) throws CommandSyntaxException {
+        return switch (reader.peek()) {
+            case '"', '\'' -> keyStep(reader, reader.readString());
+            case '[' -> {
+                reader.skip();
+                if (reader.canRead() && reader.peek() == '{') {
+                    final CompoundBinaryTag pattern = readPattern(reader);
+                    reader.expect(']');
+                    yield fanOut(tag -> matchingListElements(tag, pattern));
+                } else if (reader.canRead() && reader.peek() == ']') {
+                    reader.skip();
+                    yield fanOut(NbtDataArgument::allListElements);
+                } else {
+                    final int index = reader.readInt();
+                    reader.expect(']');
+                    yield fanOut(tag -> singleListElement(tag, index));
+                }
+            }
+            case '{' -> {
+                if (!atStart) {
+                    throw ERROR_INVALID_NODE.createWithContext(reader);
+                }
+                final CompoundBinaryTag pattern = readPattern(reader);
+                yield fanOut(tag -> selfIfMatches(tag, pattern));
+            }
+            default -> {
+                final String name = readUnquotedName(reader);
+                yield keyStep(reader, name);
+            }
+        };
+    }
+
+    private static Function<List<BinaryTag>, List<BinaryTag>> keyStep(final StringReader reader, final String name) throws CommandSyntaxException {
+        if (name.isEmpty()) {
+            throw ERROR_INVALID_NODE.createWithContext(reader);
+        }
+        if (reader.canRead() && reader.peek() == '{') {
+            final CompoundBinaryTag pattern = readPattern(reader);
+            return fanOut(tag -> matchingField(tag, name, pattern));
+        }
+        return fanOut(tag -> field(tag, name));
+    }
+
+    private static Function<List<BinaryTag>, List<BinaryTag>> fanOut(final UnaryOperator<List<BinaryTag>> perTag) {
+        return candidates -> {
+            final List<BinaryTag> result = new ArrayList<>();
+            for (final BinaryTag candidate : candidates) {
+                result.addAll(perTag.apply(List.of(candidate)));
+            }
+            return result;
+        };
+    }
+
+    private static List<BinaryTag> field(final List<BinaryTag> single, final String name) {
+        final BinaryTag tag = single.getFirst();
+        if (tag instanceof final CompoundBinaryTag compound) {
+            final BinaryTag value = compound.get(name);
+            return value == null ? List.of() : List.of(value);
+        }
+        return List.of();
+    }
+
+    private static List<BinaryTag> matchingField(final List<BinaryTag> single, final String name, final CompoundBinaryTag pattern) {
+        final BinaryTag tag = single.getFirst();
+        if (tag instanceof final CompoundBinaryTag compound) {
+            final BinaryTag value = compound.get(name);
+            if (value != null && NbtMatching.matches(pattern, value)) {
+                return List.of(value);
+            }
+        }
+        return List.of();
+    }
+
+    private static List<BinaryTag> singleListElement(final List<BinaryTag> single, final int index) {
+        final BinaryTag tag = single.getFirst();
+        if (tag instanceof final ListBinaryTag list) {
+            final int size = list.size();
+            final int actual = index < 0 ? size + index : index;
+            if (actual >= 0 && actual < size) {
+                return List.of(list.get(actual));
+            }
+        }
+        return List.of();
+    }
+
+    private static List<BinaryTag> allListElements(final List<BinaryTag> single) {
+        final BinaryTag tag = single.getFirst();
+        if (tag instanceof final ListBinaryTag list) {
+            return List.copyOf(list.stream().toList());
+        }
+        return List.of();
+    }
+
+    private static List<BinaryTag> matchingListElements(final List<BinaryTag> single, final CompoundBinaryTag pattern) {
+        final BinaryTag tag = single.getFirst();
+        if (tag instanceof final ListBinaryTag list) {
+            final List<BinaryTag> out = new ArrayList<>();
+            for (final BinaryTag element : list) {
+                if (NbtMatching.matches(pattern, element)) {
+                    out.add(element);
+                }
+            }
+            return out;
+        }
+        return List.of();
+    }
+
+    private static List<BinaryTag> selfIfMatches(final List<BinaryTag> single, final CompoundBinaryTag pattern) {
+        final BinaryTag tag = single.getFirst();
+        if (tag instanceof CompoundBinaryTag && NbtMatching.matches(pattern, tag)) {
+            return List.of(tag);
+        }
+        return List.of();
+    }
+
+    private static String readUnquotedName(final StringReader reader) throws CommandSyntaxException {
+        final int start = reader.getCursor();
+        while (reader.canRead() && isAllowedUnquoted(reader.peek())) {
+            reader.skip();
+        }
+        if (reader.getCursor() == start) {
+            throw ERROR_INVALID_NODE.createWithContext(reader);
+        }
+        return reader.getString().substring(start, reader.getCursor());
+    }
+
+    private static boolean isAllowedUnquoted(final char c) {
+        return c != ' ' && c != '"' && c != '\'' && c != '[' && c != ']' && c != '.' && c != '{' && c != '}';
+    }
+
+    private static CompoundBinaryTag readPattern(final StringReader reader) throws CommandSyntaxException {
+        final int start = reader.getCursor();
+        int depth = 0;
+        char quote = 0;
+
+        do {
+            if (!reader.canRead()) {
+                throw ERROR_INVALID_NODE.createWithContext(reader);
+            }
+            final char c = reader.read();
+            if (quote != 0) {
+                if (c == '\\' && reader.canRead()) {
+                    reader.skip();
+                } else if (c == quote) {
+                    quote = 0;
+                }
+                continue;
+            }
+            switch (c) {
+                case '"', '\'' -> quote = c;
+                case '{' -> depth++;
+                case '}' -> depth--;
+                default -> { }
+            }
+        } while (depth > 0);
+
+        final String snbt = reader.getString().substring(start, reader.getCursor());
+        try {
+            return TagStringIO.tagStringIO().asCompound(snbt);
+        } catch (final IOException e) {
+            reader.setCursor(start);
+            throw ERROR_INVALID_NODE.createWithContext(reader);
+        }
+    }
+
+    private record ChainPath(String text, List<Function<List<BinaryTag>, List<BinaryTag>>> chain) implements NbtPathResolver {
+        @Override
+            public List<BinaryTag> resolve(final BinaryTag root) {
+                List<BinaryTag> current = List.of(root);
+                for (final Function<List<BinaryTag>, List<BinaryTag>> step : chain) {
+                    current = step.apply(current);
+                    if (current.isEmpty()) {
+                        return List.of();
+                    }
+                }
+                return current;
+            }
+
+            @Override
+            public String asString() {
+                return text;
+            }
+
+            @Override
+            public String toString() {
+                return text;
+            }
+        }
+
+    public static final class Info implements ArgumentTypeRegistrar<NbtDataArgument, Info.Spec> {
+
+        @Override
+        public void serialize(final Spec spec, final PacketBuffer buf) {
+        }
+
+        @Override
+        public Spec deserialize(final PacketBuffer buf) {
+            return new Spec();
+        }
+
+        @Override
+        public void serializeJson(final Spec spec, final JsonObject json) {
+        }
+
+        @Override
+        public Spec access(final NbtDataArgument argument) {
+            return new Spec();
+        }
+
+        public record Spec() implements ArgumentTypeRegistrar.Spec<NbtDataArgument> {
+
+            @Override
+            public NbtDataArgument instantiate() {
+                return NbtDataArgument.nbtPath();
+            }
+
+            @Override
+            public ArgumentTypeRegistrar<NbtDataArgument, ?> type() {
+                return new Info();
+            }
+        }
+    }
+}

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/nbt/NbtMatching.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/nbt/NbtMatching.java
@@ -1,0 +1,58 @@
+package fr.euphyllia.fidorial.server.command.brigadier.argument.nbt;
+
+import net.kyori.adventure.nbt.BinaryTag;
+import net.kyori.adventure.nbt.CompoundBinaryTag;
+import net.kyori.adventure.nbt.ListBinaryTag;
+import org.jspecify.annotations.Nullable;
+
+final class NbtMatching {
+
+    private NbtMatching() {
+    }
+
+    static boolean matches(final CompoundBinaryTag pattern, final @Nullable BinaryTag candidate) {
+        return satisfies(pattern, candidate);
+    }
+
+    private static boolean satisfies(final @Nullable BinaryTag pattern, final @Nullable BinaryTag candidate) {
+        if (pattern == null) {
+            return true;
+        }
+        if (candidate == null) {
+            return false;
+        }
+
+        return switch (pattern) {
+            case final CompoundBinaryTag requiredFields -> candidate instanceof final CompoundBinaryTag actual && allFieldsSatisfied(requiredFields, actual);
+            case final ListBinaryTag requiredElements -> candidate instanceof final ListBinaryTag actual && allElementsSatisfiable(requiredElements, actual);
+            default -> pattern.equals(candidate);
+        };
+    }
+
+    private static boolean allFieldsSatisfied(final CompoundBinaryTag required, final CompoundBinaryTag actual) {
+        for (final String field : required.keySet()) {
+            if (!satisfies(required.get(field), actual.get(field))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean allElementsSatisfiable(final ListBinaryTag required, final ListBinaryTag actual) {
+        for (final BinaryTag requiredElement : required) {
+            if (!satisfiableBySomeElement(requiredElement, actual)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean satisfiableBySomeElement(final BinaryTag requiredElement, final ListBinaryTag candidates) {
+        for (final BinaryTag candidate : candidates) {
+            if (satisfies(requiredElement, candidate)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/player/GameModeArgument.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/player/GameModeArgument.java
@@ -8,20 +8,16 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.exceptions.DynamicCommandExceptionType;
 import com.mojang.brigadier.suggestion.Suggestions;
 import com.mojang.brigadier.suggestion.SuggestionsBuilder;
+import fr.euphyllia.fidorial.server.command.brigadier.argument.util.ExceptionFactory;
 import fr.euphyllia.fidorial.server.command.brigadier.packet.registry.ArgumentTypeRegistrar;
 import fr.euphyllia.fidorial.server.network.PacketBuffer;
 import fr.fidorial.entity.GameMode;
-import net.kyori.adventure.text.Component;
 
 import java.util.concurrent.CompletableFuture;
 
-import static fr.euphyllia.fidorial.server.adventure.brigadier.BrigadierAdventureHelper.MSG_SERIALIZER;
-
 public final class GameModeArgument implements ArgumentType<GameMode> {
 
-    private static final DynamicCommandExceptionType ERROR_INVALID =
-            new DynamicCommandExceptionType(value -> MSG_SERIALIZER.serialize(
-                    Component.translatable("argument.gamemode.invalid", Component.text(value.toString()))));
+    private static final DynamicCommandExceptionType ERROR_INVALID = ExceptionFactory.dynamic("argument.gamemode.invalid");
 
     public static GameModeArgument gameMode() {
         return new GameModeArgument();

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/player/PlayerProfileArgument.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/player/PlayerProfileArgument.java
@@ -12,12 +12,12 @@ import fr.euphyllia.fidorial.server.FidorialServer;
 import fr.euphyllia.fidorial.server.command.brigadier.argument.entity.EntityArgument;
 import fr.euphyllia.fidorial.server.command.brigadier.argument.entity.EntitySelector;
 import fr.euphyllia.fidorial.server.command.brigadier.argument.selector.EntitySelectorParser;
+import fr.euphyllia.fidorial.server.command.brigadier.argument.util.ExceptionFactory;
 import fr.euphyllia.fidorial.server.command.brigadier.packet.registry.ArgumentTypeRegistrar;
 import fr.euphyllia.fidorial.server.network.PacketBuffer;
 import fr.fidorial.command.CommandSource;
 import fr.fidorial.entity.Player;
 import fr.fidorial.entity.PlayerProfileMeta;
-import net.kyori.adventure.text.Component;
 
 import java.util.Collection;
 import java.util.List;
@@ -27,12 +27,9 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
-import static fr.euphyllia.fidorial.server.adventure.brigadier.BrigadierAdventureHelper.MSG_SERIALIZER;
-
 public class PlayerProfileArgument<T> implements ArgumentType<T> {
 
-    public static final SimpleCommandExceptionType ERROR_UNKNOWN_PLAYER =
-            new SimpleCommandExceptionType(MSG_SERIALIZER.serialize(Component.translatable("argument.player.unknown")));
+    public static final SimpleCommandExceptionType ERROR_UNKNOWN_PLAYER = ExceptionFactory.simple("argument.player.unknown");
 
     private static final Predicate<Player> ALL = _ -> true;
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/range/RangeBounds.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/range/RangeBounds.java
@@ -4,20 +4,16 @@ import com.mojang.brigadier.StringReader;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.exceptions.DynamicCommandExceptionType;
 import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
-import net.kyori.adventure.text.Component;
+import fr.euphyllia.fidorial.server.command.brigadier.argument.util.ExceptionFactory;
 
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-import static fr.euphyllia.fidorial.server.adventure.brigadier.BrigadierAdventureHelper.MSG_SERIALIZER;
-
 public interface RangeBounds<T extends Number & Comparable<T>> {
 
-    SimpleCommandExceptionType ERROR_EMPTY = new SimpleCommandExceptionType(
-            MSG_SERIALIZER.serialize(Component.translatable("argument.range.empty")));
-    SimpleCommandExceptionType ERROR_SWAPPED = new SimpleCommandExceptionType(
-            MSG_SERIALIZER.serialize(Component.translatable("argument.range.swapped")));
+    SimpleCommandExceptionType ERROR_EMPTY = ExceptionFactory.simple("argument.range.empty");
+    SimpleCommandExceptionType ERROR_SWAPPED = ExceptionFactory.simple("argument.range.swapped");
 
     Bounds<T> bounds();
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/resource/KeyArgument.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/resource/KeyArgument.java
@@ -5,18 +5,15 @@ import com.mojang.brigadier.StringReader;
 import com.mojang.brigadier.arguments.ArgumentType;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
+import fr.euphyllia.fidorial.server.command.brigadier.argument.util.ExceptionFactory;
 import fr.euphyllia.fidorial.server.command.brigadier.argument.util.KeyReader;
 import fr.euphyllia.fidorial.server.command.brigadier.packet.registry.ArgumentTypeRegistrar;
 import fr.euphyllia.fidorial.server.network.PacketBuffer;
 import net.kyori.adventure.key.Key;
-import net.kyori.adventure.text.Component;
-
-import static fr.euphyllia.fidorial.server.adventure.brigadier.BrigadierAdventureHelper.MSG_SERIALIZER;
 
 public final class KeyArgument implements ArgumentType<Key> {
 
-    public static final SimpleCommandExceptionType ERROR_INVALID_KEY =
-            new SimpleCommandExceptionType(MSG_SERIALIZER.serialize(Component.translatable("argument.id.invalid")));
+    public static final SimpleCommandExceptionType ERROR_INVALID_KEY = ExceptionFactory.simple("argument.id.invalid");
 
     public static KeyArgument key() {
         return new KeyArgument();

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/resource/ResourceArgument.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/resource/ResourceArgument.java
@@ -9,6 +9,7 @@ import com.mojang.brigadier.exceptions.Dynamic2CommandExceptionType;
 import com.mojang.brigadier.suggestion.Suggestions;
 import com.mojang.brigadier.suggestion.SuggestionsBuilder;
 import fr.euphyllia.fidorial.server.FidorialServer;
+import fr.euphyllia.fidorial.server.command.brigadier.argument.util.ExceptionFactory;
 import fr.euphyllia.fidorial.server.command.brigadier.argument.util.KeyReader;
 import fr.euphyllia.fidorial.server.command.brigadier.argument.util.KeyReader.ParsedKey;
 import fr.euphyllia.fidorial.server.command.brigadier.packet.registry.ArgumentTypeRegistrar;
@@ -17,20 +18,13 @@ import fr.fidorial.registry.Registry;
 import fr.fidorial.registry.RegistryKey;
 import fr.fidorial.registry.TypedKey;
 import net.kyori.adventure.key.Key;
-import net.kyori.adventure.text.Component;
 
 import java.util.Locale;
 import java.util.concurrent.CompletableFuture;
 
-import static fr.euphyllia.fidorial.server.adventure.brigadier.BrigadierAdventureHelper.MSG_SERIALIZER;
-
 public final class ResourceArgument<T> implements ArgumentType<T> {
 
-    public static final Dynamic2CommandExceptionType ERROR_UNKNOWN_RESOURCE =
-            new Dynamic2CommandExceptionType((id, registry) -> MSG_SERIALIZER.serialize(Component.translatable(
-                    "argument.resource.not_found",
-                    Component.text(id.toString()),
-                    Component.text(registry.toString()))));
+    public static final Dynamic2CommandExceptionType ERROR_UNKNOWN_RESOURCE = ExceptionFactory.dynamic2("argument.resource.not_found");
 
     private final RegistryKey<T> registryKey;
     private final Registry<T> registryLookup;

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/selector/DoubleRange.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/selector/DoubleRange.java
@@ -3,17 +3,13 @@ package fr.euphyllia.fidorial.server.command.brigadier.argument.selector;
 import com.mojang.brigadier.StringReader;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
-import net.kyori.adventure.text.Component;
+import fr.euphyllia.fidorial.server.command.brigadier.argument.util.ExceptionFactory;
 import org.jspecify.annotations.Nullable;
-
-import static fr.euphyllia.fidorial.server.adventure.brigadier.BrigadierAdventureHelper.MSG_SERIALIZER;
 
 public record DoubleRange(@Nullable Double min, @Nullable Double max) {
 
-    public static final SimpleCommandExceptionType ERROR_EMPTY = new SimpleCommandExceptionType(
-            MSG_SERIALIZER.serialize(Component.translatable("argument.range.empty")));
-    public static final SimpleCommandExceptionType ERROR_SWAPPED = new SimpleCommandExceptionType(
-            MSG_SERIALIZER.serialize(Component.translatable("argument.range.swapped")));
+    public static final SimpleCommandExceptionType ERROR_EMPTY = ExceptionFactory.simple("argument.range.empty");
+    public static final SimpleCommandExceptionType ERROR_SWAPPED = ExceptionFactory.simple("argument.range.swapped");
 
     public static DoubleRange exact(final double value) {
         return new DoubleRange(value, value);

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/selector/EntitySelectorParser.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/selector/EntitySelectorParser.java
@@ -10,8 +10,8 @@ import fr.euphyllia.fidorial.server.command.brigadier.argument.entity.EntitySele
 import fr.euphyllia.fidorial.server.command.brigadier.argument.selector.options.EntitySelectorOptions;
 import fr.euphyllia.fidorial.server.command.brigadier.argument.selector.options.SelectorSetState;
 import fr.euphyllia.fidorial.server.command.brigadier.argument.selector.options.SingleUseOption;
+import fr.euphyllia.fidorial.server.command.brigadier.argument.util.ExceptionFactory;
 import fr.fidorial.entity.Entity;
-import net.kyori.adventure.text.Component;
 import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
@@ -21,24 +21,13 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
-import static fr.euphyllia.fidorial.server.adventure.brigadier.BrigadierAdventureHelper.MSG_SERIALIZER;
-
 public final class EntitySelectorParser {
 
-    public static final SimpleCommandExceptionType ERROR_EXPECTED_END_OF_OPTIONS = new SimpleCommandExceptionType(
-            MSG_SERIALIZER.serialize(Component.translatable("argument.entity.options.unterminated")));
-    public static final DynamicCommandExceptionType ERROR_EXPECTED_OPTION_VALUE = new DynamicCommandExceptionType(
-            name -> MSG_SERIALIZER.serialize(Component.translatable("argument.entity.options.valueless")
-                    .append(Component.text(name.toString()))));
-    public static final DynamicCommandExceptionType ERROR_UNKNOWN_OPTION = new DynamicCommandExceptionType(
-            name -> MSG_SERIALIZER.serialize(Component.translatable("argument.entity.options.unknown")
-                    .append(Component.text(name.toString()))));
-    public static final DynamicCommandExceptionType ERROR_INAPPLICABLE_OPTION = new DynamicCommandExceptionType(
-            name -> MSG_SERIALIZER.serialize(Component.translatable("argument.entity.options.inapplicable")
-                    .append(Component.text(name.toString()))));
-
-    private static final SimpleCommandExceptionType INVALID =
-            new SimpleCommandExceptionType(MSG_SERIALIZER.serialize(Component.translatable("argument.entity.invalid")));
+    public static final SimpleCommandExceptionType ERROR_EXPECTED_END_OF_OPTIONS = ExceptionFactory.simple("argument.entity.options.unterminated");
+    public static final DynamicCommandExceptionType ERROR_EXPECTED_OPTION_VALUE = ExceptionFactory.dynamic("argument.entity.options.valueless");
+    public static final DynamicCommandExceptionType ERROR_UNKNOWN_OPTION = ExceptionFactory.dynamic("argument.entity.options.unknown");
+    public static final DynamicCommandExceptionType ERROR_INAPPLICABLE_OPTION = ExceptionFactory.dynamic("argument.entity.options.inapplicable");
+    private static final SimpleCommandExceptionType INVALID = ExceptionFactory.simple("argument.entity.invalid");
 
     @FunctionalInterface
     private interface SuggestionProvider {

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/selector/options/EntitySelectorOptions.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/selector/options/EntitySelectorOptions.java
@@ -8,27 +8,21 @@ import com.mojang.brigadier.suggestion.SuggestionsBuilder;
 import fr.euphyllia.fidorial.server.command.brigadier.argument.entity.EntitySelector;
 import fr.euphyllia.fidorial.server.command.brigadier.argument.selector.DoubleRange;
 import fr.euphyllia.fidorial.server.command.brigadier.argument.selector.EntitySelectorParser;
+import fr.euphyllia.fidorial.server.command.brigadier.argument.util.ExceptionFactory;
 import fr.fidorial.entity.Player;
-import net.kyori.adventure.text.Component;
 
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.function.Predicate;
 
-import static fr.euphyllia.fidorial.server.adventure.brigadier.BrigadierAdventureHelper.MSG_SERIALIZER;
-
 public final class EntitySelectorOptions {
 
     private static final Map<String, Option> OPTIONS = new HashMap<>();
 
-    public static final SimpleCommandExceptionType ERROR_RANGE_NEGATIVE = new SimpleCommandExceptionType(
-            MSG_SERIALIZER.serialize(Component.translatable("argument.entity.options.distance.negative")));
-    public static final SimpleCommandExceptionType ERROR_LIMIT_TOO_SMALL = new SimpleCommandExceptionType(
-            MSG_SERIALIZER.serialize(Component.translatable("argument.entity.options.limit.toosmall")));
-    public static final DynamicCommandExceptionType ERROR_SORT_UNKNOWN = new DynamicCommandExceptionType(
-            name -> MSG_SERIALIZER.serialize(Component.translatable("argument.entity.options.sort.irreversible")
-                    .append(Component.text(name.toString()))));
+    public static final SimpleCommandExceptionType ERROR_RANGE_NEGATIVE = ExceptionFactory.simple("argument.entity.options.distance.negative");
+    public static final SimpleCommandExceptionType ERROR_LIMIT_TOO_SMALL = ExceptionFactory.simple("argument.entity.options.limit.toosmall");
+    public static final DynamicCommandExceptionType ERROR_SORT_UNKNOWN = ExceptionFactory.dynamic("argument.entity.options.sort.irreversible");
 
     private EntitySelectorOptions() {
     }

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/util/ExceptionFactory.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/argument/util/ExceptionFactory.java
@@ -1,0 +1,33 @@
+package fr.euphyllia.fidorial.server.command.brigadier.argument.util;
+
+import com.mojang.brigadier.exceptions.Dynamic2CommandExceptionType;
+import com.mojang.brigadier.exceptions.DynamicCommandExceptionType;
+import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
+import net.kyori.adventure.text.Component;
+
+import static fr.fidorial.command.MessageComponentSerializer.message;
+
+public final class ExceptionFactory {
+
+    private ExceptionFactory() {
+    }
+
+    public static SimpleCommandExceptionType simple(final String translationKey) {
+        return new SimpleCommandExceptionType(message().serialize(Component.translatable(translationKey)));
+    }
+
+    public static DynamicCommandExceptionType dynamic(final String translationKey) {
+        return new DynamicCommandExceptionType(value -> message().serialize(
+                Component.translatable(translationKey, Component.text(String.valueOf(value)))));
+    }
+
+    public static Dynamic2CommandExceptionType dynamic2(final String translationKey) {
+        return new Dynamic2CommandExceptionType((first, second) -> message().serialize(
+                Component.translatable(translationKey, Component.text(String.valueOf(first)), Component.text(String.valueOf(second)))));
+    }
+
+    public static Dynamic2CommandExceptionType dynamic2Reversed(final String translationKey) {
+        return new Dynamic2CommandExceptionType((first, second) -> message().serialize(
+                Component.translatable(translationKey, Component.text(String.valueOf(second)), Component.text(String.valueOf(first)))));
+    }
+}

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/builtin/exceptions/TranslatableExceptions.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/builtin/exceptions/TranslatableExceptions.java
@@ -4,106 +4,40 @@ import com.mojang.brigadier.exceptions.BuiltInExceptionProvider;
 import com.mojang.brigadier.exceptions.Dynamic2CommandExceptionType;
 import com.mojang.brigadier.exceptions.DynamicCommandExceptionType;
 import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
-import net.kyori.adventure.text.Component;
-
-import static fr.euphyllia.fidorial.server.adventure.brigadier.BrigadierAdventureHelper.MSG_SERIALIZER;
+import fr.euphyllia.fidorial.server.command.brigadier.argument.util.ExceptionFactory;
 
 public final class TranslatableExceptions implements BuiltInExceptionProvider {
 
-    private static final Dynamic2CommandExceptionType DOUBLE_TOO_SMALL =
-            new Dynamic2CommandExceptionType((found, min) -> MSG_SERIALIZER.serialize(Component.translatable(
-                    "argument.double.low", Component.text(min.toString()), Component.text(found.toString()))));
+    private static final Dynamic2CommandExceptionType DOUBLE_TOO_SMALL = ExceptionFactory.dynamic2Reversed("argument.double.low");
+    private static final Dynamic2CommandExceptionType DOUBLE_TOO_BIG = ExceptionFactory.dynamic2Reversed("argument.double.big");
+    private static final Dynamic2CommandExceptionType FLOAT_TOO_SMALL = ExceptionFactory.dynamic2Reversed("argument.float.low");
+    private static final Dynamic2CommandExceptionType FLOAT_TOO_BIG = ExceptionFactory.dynamic2Reversed("argument.float.big");
+    private static final Dynamic2CommandExceptionType INTEGER_TOO_SMALL = ExceptionFactory.dynamic2Reversed("argument.integer.low");
+    private static final Dynamic2CommandExceptionType INTEGER_TOO_BIG = ExceptionFactory.dynamic2Reversed("argument.integer.big");
+    private static final Dynamic2CommandExceptionType LONG_TOO_SMALL = ExceptionFactory.dynamic2Reversed("argument.long.low");
+    private static final Dynamic2CommandExceptionType LONG_TOO_BIG = ExceptionFactory.dynamic2Reversed("argument.long.big");
 
-    private static final Dynamic2CommandExceptionType DOUBLE_TOO_BIG =
-            new Dynamic2CommandExceptionType((found, max) -> MSG_SERIALIZER.serialize(Component.translatable(
-                    "argument.double.big", Component.text(max.toString()), Component.text(found.toString()))));
+    private static final DynamicCommandExceptionType LITERAL_INCORRECT = ExceptionFactory.dynamic("argument.literal.incorrect");
 
-    private static final Dynamic2CommandExceptionType FLOAT_TOO_SMALL =
-            new Dynamic2CommandExceptionType((found, min) -> MSG_SERIALIZER.serialize(Component.translatable(
-                    "argument.float.low", Component.text(min.toString()), Component.text(found.toString()))));
+    private static final SimpleCommandExceptionType READER_EXPECTED_START_OF_QUOTE = ExceptionFactory.simple("parsing.quote.expected.start");
+    private static final SimpleCommandExceptionType READER_EXPECTED_END_OF_QUOTE = ExceptionFactory.simple("parsing.quote.expected.end");
+    private static final DynamicCommandExceptionType READER_INVALID_ESCAPE = ExceptionFactory.dynamic("parsing.quote.escape");
+    private static final DynamicCommandExceptionType READER_INVALID_BOOL = ExceptionFactory.dynamic("parsing.bool.invalid");
+    private static final DynamicCommandExceptionType READER_INVALID_INT = ExceptionFactory.dynamic("parsing.int.invalid");
+    private static final SimpleCommandExceptionType READER_EXPECTED_INT = ExceptionFactory.simple("parsing.int.expected");
+    private static final DynamicCommandExceptionType READER_INVALID_LONG = ExceptionFactory.dynamic("parsing.long.invalid");
+    private static final SimpleCommandExceptionType READER_EXPECTED_LONG = ExceptionFactory.simple("parsing.long.expected");
+    private static final DynamicCommandExceptionType READER_INVALID_DOUBLE = ExceptionFactory.dynamic("parsing.double.invalid");
+    private static final SimpleCommandExceptionType READER_EXPECTED_DOUBLE = ExceptionFactory.simple("parsing.double.expected");
+    private static final DynamicCommandExceptionType READER_INVALID_FLOAT = ExceptionFactory.dynamic("parsing.float.invalid");
+    private static final SimpleCommandExceptionType READER_EXPECTED_FLOAT = ExceptionFactory.simple("parsing.float.expected");
+    private static final SimpleCommandExceptionType READER_EXPECTED_BOOL = ExceptionFactory.simple("parsing.bool.expected");
+    private static final DynamicCommandExceptionType READER_EXPECTED_SYMBOL = ExceptionFactory.dynamic("parsing.expected");
 
-    private static final Dynamic2CommandExceptionType FLOAT_TOO_BIG =
-            new Dynamic2CommandExceptionType((found, max) -> MSG_SERIALIZER.serialize(Component.translatable(
-                    "argument.float.big", Component.text(max.toString()), Component.text(found.toString()))));
-
-    private static final Dynamic2CommandExceptionType INTEGER_TOO_SMALL =
-            new Dynamic2CommandExceptionType((found, min) -> MSG_SERIALIZER.serialize(Component.translatable(
-                    "argument.integer.low", Component.text(min.toString()), Component.text(found.toString()))));
-
-    private static final Dynamic2CommandExceptionType INTEGER_TOO_BIG =
-            new Dynamic2CommandExceptionType((found, max) -> MSG_SERIALIZER.serialize(Component.translatable(
-                    "argument.integer.big", Component.text(max.toString()), Component.text(found.toString()))));
-
-    private static final Dynamic2CommandExceptionType LONG_TOO_SMALL =
-            new Dynamic2CommandExceptionType((found, min) -> MSG_SERIALIZER.serialize(Component.translatable(
-                    "argument.long.low", Component.text(min.toString()), Component.text(found.toString()))));
-
-    private static final Dynamic2CommandExceptionType LONG_TOO_BIG =
-            new Dynamic2CommandExceptionType((found, max) -> MSG_SERIALIZER.serialize(Component.translatable(
-                    "argument.long.big", Component.text(max.toString()), Component.text(found.toString()))));
-
-    private static final DynamicCommandExceptionType LITERAL_INCORRECT =
-            new DynamicCommandExceptionType(expected -> MSG_SERIALIZER.serialize(
-                    Component.translatable("argument.literal.incorrect", Component.text(expected.toString()))));
-
-    private static final SimpleCommandExceptionType READER_EXPECTED_START_OF_QUOTE = new SimpleCommandExceptionType(
-            MSG_SERIALIZER.serialize(Component.translatable("parsing.quote.expected.start")));
-
-    private static final SimpleCommandExceptionType READER_EXPECTED_END_OF_QUOTE = new SimpleCommandExceptionType(
-            MSG_SERIALIZER.serialize(Component.translatable("parsing.quote.expected.end")));
-
-    private static final DynamicCommandExceptionType READER_INVALID_ESCAPE =
-            new DynamicCommandExceptionType(character -> MSG_SERIALIZER.serialize(
-                    Component.translatable("parsing.quote.escape", Component.text(character.toString()))));
-
-    private static final DynamicCommandExceptionType READER_INVALID_BOOL = new DynamicCommandExceptionType(value ->
-            MSG_SERIALIZER.serialize(Component.translatable("parsing.bool.invalid", Component.text(value.toString()))));
-
-    private static final DynamicCommandExceptionType READER_INVALID_INT = new DynamicCommandExceptionType(value ->
-            MSG_SERIALIZER.serialize(Component.translatable("parsing.int.invalid", Component.text(value.toString()))));
-
-    private static final SimpleCommandExceptionType READER_EXPECTED_INT =
-            new SimpleCommandExceptionType(MSG_SERIALIZER.serialize(Component.translatable("parsing.int.expected")));
-
-    private static final DynamicCommandExceptionType READER_INVALID_LONG = new DynamicCommandExceptionType(value ->
-            MSG_SERIALIZER.serialize(Component.translatable("parsing.long.invalid", Component.text(value.toString()))));
-
-    private static final SimpleCommandExceptionType READER_EXPECTED_LONG =
-            new SimpleCommandExceptionType(MSG_SERIALIZER.serialize(Component.translatable("parsing.long.expected")));
-
-    private static final DynamicCommandExceptionType READER_INVALID_DOUBLE =
-            new DynamicCommandExceptionType(value -> MSG_SERIALIZER.serialize(
-                    Component.translatable("parsing.double.invalid", Component.text(value.toString()))));
-
-    private static final SimpleCommandExceptionType READER_EXPECTED_DOUBLE =
-            new SimpleCommandExceptionType(MSG_SERIALIZER.serialize(Component.translatable("parsing.double.expected")));
-
-    private static final DynamicCommandExceptionType READER_INVALID_FLOAT =
-            new DynamicCommandExceptionType(value -> MSG_SERIALIZER.serialize(
-                    Component.translatable("parsing.float.invalid", Component.text(value.toString()))));
-
-    private static final SimpleCommandExceptionType READER_EXPECTED_FLOAT =
-            new SimpleCommandExceptionType(MSG_SERIALIZER.serialize(Component.translatable("parsing.float.expected")));
-
-    private static final SimpleCommandExceptionType READER_EXPECTED_BOOL =
-            new SimpleCommandExceptionType(MSG_SERIALIZER.serialize(Component.translatable("parsing.bool.expected")));
-
-    private static final DynamicCommandExceptionType READER_EXPECTED_SYMBOL = new DynamicCommandExceptionType(symbol ->
-            MSG_SERIALIZER.serialize(Component.translatable("parsing.expected", Component.text(symbol.toString()))));
-
-    public static final SimpleCommandExceptionType DISPATCHER_UNKNOWN_COMMAND =
-            new SimpleCommandExceptionType(MSG_SERIALIZER.serialize(Component.translatable("command.unknown.command")));
-
-    public static final SimpleCommandExceptionType DISPATCHER_UNKNOWN_ARGUMENT = new SimpleCommandExceptionType(
-            MSG_SERIALIZER.serialize(Component.translatable("command.unknown.argument")));
-
-    private static final SimpleCommandExceptionType DISPATCHER_EXPECTED_ARGUMENT_SEPARATOR =
-            new SimpleCommandExceptionType(
-                    MSG_SERIALIZER.serialize(Component.translatable("command.expected.separator")));
-
-    private static final DynamicCommandExceptionType DISPATCHER_PARSE_EXCEPTION =
-            new DynamicCommandExceptionType(message -> MSG_SERIALIZER.serialize(
-                    Component.translatable("command.exception", Component.text(message.toString()))));
+    public static final SimpleCommandExceptionType DISPATCHER_UNKNOWN_COMMAND = ExceptionFactory.simple("command.unknown.command");
+    public static final SimpleCommandExceptionType DISPATCHER_UNKNOWN_ARGUMENT = ExceptionFactory.simple("command.unknown.argument");
+    private static final SimpleCommandExceptionType DISPATCHER_EXPECTED_ARGUMENT_SEPARATOR = ExceptionFactory.simple("command.expected.separator");
+    private static final DynamicCommandExceptionType DISPATCHER_PARSE_EXCEPTION = ExceptionFactory.dynamic("command.exception");
 
     @Override
     public Dynamic2CommandExceptionType doubleTooLow() {

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/packet/registry/ArgumentTypes.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/brigadier/packet/registry/ArgumentTypes.java
@@ -15,6 +15,7 @@ import fr.euphyllia.fidorial.server.command.brigadier.argument.location.AngleArg
 import fr.euphyllia.fidorial.server.command.brigadier.argument.location.BlockPositionArgument;
 import fr.euphyllia.fidorial.server.command.brigadier.argument.location.DimensionArgument;
 import fr.euphyllia.fidorial.server.command.brigadier.argument.location.Vec3Argument;
+import fr.euphyllia.fidorial.server.command.brigadier.argument.nbt.NbtDataArgument;
 import fr.euphyllia.fidorial.server.command.brigadier.argument.player.GameModeArgument;
 import fr.euphyllia.fidorial.server.command.brigadier.argument.player.PlayerProfileArgument;
 import fr.euphyllia.fidorial.server.command.brigadier.argument.primitive.BoolArgumentRegistrar;
@@ -51,6 +52,7 @@ public final class ArgumentTypes {
         register(new HexColorArgument.Info(), ArgumentTypeIds.HEX_COLOR_ARGUMENT_ID);
         register(new ComponentArgument.Info(), ArgumentTypeIds.COMPONENT_ARGUMENT_ID);
         register(new StyleArgument.Info(), ArgumentTypeIds.STYLE_ARGUMENT_ID);
+        register(new NbtDataArgument.Info(), ArgumentTypeIds.NBT_PATH_ARGUMENT_ID);
         register(new AngleArgument.Info(), ArgumentTypeIds.ANGLE_ARGUMENT_ID);
         register(new KeyArgument.Info(), ArgumentTypeIds.RESOURCE_LOCATION_ARGUMENT_ID);
         register(new RangeArgument.Ints.Info(), ArgumentTypeIds.INT_RANGE_ARGUMENT_ID);

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/defaults/BossBarCommand.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/command/defaults/BossBarCommand.java
@@ -9,6 +9,7 @@ import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
 import com.mojang.brigadier.suggestion.SuggestionProvider;
 import com.mojang.brigadier.tree.LiteralCommandNode;
 import fr.euphyllia.fidorial.server.FidorialServer;
+import fr.euphyllia.fidorial.server.command.brigadier.argument.util.ExceptionFactory;
 import fr.euphyllia.fidorial.server.world.BossBarRegistry;
 import fr.fidorial.command.CommandSource;
 import fr.fidorial.command.argument.ArgumentTypes;
@@ -17,74 +18,53 @@ import fr.fidorial.entity.Player;
 import net.kyori.adventure.bossbar.BossBar;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.JoinConfiguration;
+import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.format.NamedTextColor;
 
-import java.util.Collection;
 import java.util.EnumMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.Predicate;
 
-import static fr.euphyllia.fidorial.server.adventure.brigadier.BrigadierAdventureHelper.MSG_SERIALIZER;
 import static fr.fidorial.command.Commands.argument;
 import static fr.fidorial.command.Commands.literal;
 
 public final class BossBarCommand {
 
-    private static final Map<BossBar.Color, NamedTextColor> COLOR_FORMATTING = new EnumMap<>(BossBar.Color.class);
-
-    static {
-        COLOR_FORMATTING.put(BossBar.Color.PINK, NamedTextColor.LIGHT_PURPLE);
-        COLOR_FORMATTING.put(BossBar.Color.BLUE, NamedTextColor.BLUE);
-        COLOR_FORMATTING.put(BossBar.Color.RED, NamedTextColor.RED);
-        COLOR_FORMATTING.put(BossBar.Color.GREEN, NamedTextColor.GREEN);
-        COLOR_FORMATTING.put(BossBar.Color.YELLOW, NamedTextColor.YELLOW);
-        COLOR_FORMATTING.put(BossBar.Color.PURPLE, NamedTextColor.DARK_PURPLE);
-        COLOR_FORMATTING.put(BossBar.Color.WHITE, NamedTextColor.WHITE);
-    }
+    private static final Map<BossBar.Color, NamedTextColor> COLOR_FORMATTING = new EnumMap<>(Map.of(
+            BossBar.Color.PINK, NamedTextColor.LIGHT_PURPLE,
+            BossBar.Color.BLUE, NamedTextColor.BLUE,
+            BossBar.Color.RED, NamedTextColor.RED,
+            BossBar.Color.GREEN, NamedTextColor.GREEN,
+            BossBar.Color.YELLOW, NamedTextColor.YELLOW,
+            BossBar.Color.PURPLE, NamedTextColor.DARK_PURPLE,
+            BossBar.Color.WHITE, NamedTextColor.WHITE));
 
     private static final DynamicCommandExceptionType ERROR_BOSSBAR_EXISTS =
-            new DynamicCommandExceptionType(id -> MSG_SERIALIZER.serialize(
-                    Component.translatable("commands.bossbar.create.failed", Component.text(String.valueOf(id)))));
-
+            ExceptionFactory.dynamic("commands.bossbar.create.failed");
     private static final DynamicCommandExceptionType ERROR_BOSSBAR_UNKNOWN =
-            new DynamicCommandExceptionType(id -> MSG_SERIALIZER.serialize(
-                    Component.translatable("commands.bossbar.unknown", Component.text(String.valueOf(id)))));
-
+            ExceptionFactory.dynamic("commands.bossbar.unknown");
     private static final SimpleCommandExceptionType ERROR_PLAYERS_UNCHANGED =
-            new SimpleCommandExceptionType(MSG_SERIALIZER.serialize(
-                    Component.translatable("commands.bossbar.set.players.unchanged")));
-
+            ExceptionFactory.simple("commands.bossbar.set.players.unchanged");
     private static final SimpleCommandExceptionType ERROR_NAME_UNCHANGED =
-            new SimpleCommandExceptionType(MSG_SERIALIZER.serialize(
-                    Component.translatable("commands.bossbar.set.name.unchanged")));
-
+            ExceptionFactory.simple("commands.bossbar.set.name.unchanged");
     private static final SimpleCommandExceptionType ERROR_COLOR_UNCHANGED =
-            new SimpleCommandExceptionType(MSG_SERIALIZER.serialize(
-                    Component.translatable("commands.bossbar.set.color.unchanged")));
-
+            ExceptionFactory.simple("commands.bossbar.set.color.unchanged");
     private static final SimpleCommandExceptionType ERROR_OVERLAY_UNCHANGED =
-            new SimpleCommandExceptionType(MSG_SERIALIZER.serialize(
-                    Component.translatable("commands.bossbar.set.style.unchanged")));
-
+            ExceptionFactory.simple("commands.bossbar.set.style.unchanged");
     private static final SimpleCommandExceptionType ERROR_VALUE_UNCHANGED =
-            new SimpleCommandExceptionType(MSG_SERIALIZER.serialize(
-                    Component.translatable("commands.bossbar.set.value.unchanged")));
-
+            ExceptionFactory.simple("commands.bossbar.set.value.unchanged");
     private static final SimpleCommandExceptionType ERROR_MAX_UNCHANGED =
-            new SimpleCommandExceptionType(MSG_SERIALIZER.serialize(
-                    Component.translatable("commands.bossbar.set.max.unchanged")));
-
+            ExceptionFactory.simple("commands.bossbar.set.max.unchanged");
     private static final SimpleCommandExceptionType ERROR_VISIBILITY_UNCHANGED_HIDDEN =
-            new SimpleCommandExceptionType(MSG_SERIALIZER.serialize(
-                    Component.translatable("commands.bossbar.set.visibility.unchanged.hidden")));
-
+            ExceptionFactory.simple("commands.bossbar.set.visibility.unchanged.hidden");
     private static final SimpleCommandExceptionType ERROR_VISIBILITY_UNCHANGED_VISIBLE =
-            new SimpleCommandExceptionType(MSG_SERIALIZER.serialize(
-                    Component.translatable("commands.bossbar.set.visibility.unchanged.visible")));
+            ExceptionFactory.simple("commands.bossbar.set.visibility.unchanged.visible");
 
     public static final SuggestionProvider<CommandSource> BOSSBAR_ID_SUGGESTIONS = (ctx, builder) -> {
         bossBars().entries().forEach(entry -> builder.suggest(entry.id().asString()));
@@ -155,6 +135,23 @@ public final class BossBarCommand {
         return bossBars().getEntry(id).orElseThrow(() -> ERROR_BOSSBAR_UNKNOWN.create(id.asString()));
     }
 
+    private static int applyUpdate(
+            final CommandContext<CommandSource> ctx,
+            final BossBarRegistry.BossBarEntry entry,
+            final Predicate<BossBarRegistry.BossBarEntry> unless,
+            final SimpleCommandExceptionType unchangedError,
+            final Runnable mutate,
+            final String successKey
+    ) throws CommandSyntaxException {
+        if (unless.test(entry)) {
+            throw unchangedError.create();
+        }
+        mutate.run();
+        final BossBarRegistry.BossBarEntry updated = bossBars().getEntry(entry.id()).orElse(entry);
+        ctx.getSource().sender().sendMessage(Component.translatable(successKey, displayNameOf(updated)));
+        return Command.SINGLE_SUCCESS;
+    }
+
     private static Component displayNameOf(final BossBarRegistry.BossBarEntry entry) {
         final String idString = entry.id().asString();
         final NamedTextColor color = COLOR_FORMATTING.getOrDefault(entry.bar().color(), NamedTextColor.WHITE);
@@ -173,65 +170,50 @@ public final class BossBarCommand {
         }
 
         final BossBarRegistry.BossBarEntry created = bossBars().getEntry(id).orElseThrow();
-        ctx.getSource().sender().sendMessage(
-                Component.translatable("commands.bossbar.create.success", displayNameOf(created)));
+        ctx.getSource().sender().sendMessage(Component.translatable("commands.bossbar.create.success", displayNameOf(created)));
         return Command.SINGLE_SUCCESS;
     }
 
     private static int deleteBossBar(final CommandContext<CommandSource> ctx, final BossBarRegistry.BossBarEntry entry) {
         final Component displayName = displayNameOf(entry);
         bossBars().unregister(entry.id());
-
-        ctx.getSource().sender().sendMessage(
-                Component.translatable("commands.bossbar.remove.success", displayName));
+        ctx.getSource().sender().sendMessage(Component.translatable("commands.bossbar.remove.success", displayName));
         return bossBars().entries().size();
     }
 
     private static int listBossBars(final CommandContext<CommandSource> ctx) {
-        final Collection<BossBarRegistry.BossBarEntry> entries = bossBars().entries();
-
+        final var entries = bossBars().entries();
         if (entries.isEmpty()) {
             ctx.getSource().sender().sendMessage(Component.translatable("commands.bossbar.list.bars.none"));
         } else {
+            final Component joined = Component.join(JoinConfiguration.commas(true),
+                    entries.stream().map(BossBarCommand::displayNameOf).toList());
             ctx.getSource().sender().sendMessage(Component.translatable(
-                    "commands.bossbar.list.bars.some",
-                    Component.text(entries.size()),
-                    joinComponents(entries.stream().map(BossBarCommand::displayNameOf).toList())));
+                    "commands.bossbar.list.bars.some", Component.text(entries.size()), joined));
         }
 
         return entries.size();
     }
 
     private static int updateName(final CommandContext<CommandSource> ctx, final BossBarRegistry.BossBarEntry entry, final Component name) throws CommandSyntaxException {
-        if (entry.bar().name().equals(name)) {
-            throw ERROR_NAME_UNCHANGED.create();
-        }
-
-        entry.bar().name(name);
-        final BossBarRegistry.BossBarEntry updated = bossBars().getEntry(entry.id()).orElseThrow();
-        ctx.getSource().sender().sendMessage(Component.translatable("commands.bossbar.set.name.success", displayNameOf(updated)));
-        return Command.SINGLE_SUCCESS;
+        return applyUpdate(ctx, entry,
+                e -> e.bar().name().equals(name), ERROR_NAME_UNCHANGED,
+                () -> entry.bar().name(name),
+                "commands.bossbar.set.name.success");
     }
 
     private static int updateColor(final CommandContext<CommandSource> ctx, final BossBarRegistry.BossBarEntry entry, final BossBar.Color color) throws CommandSyntaxException {
-        if (entry.bar().color() == color) {
-            throw ERROR_COLOR_UNCHANGED.create();
-        }
-
-        entry.bar().color(color);
-        final BossBarRegistry.BossBarEntry updated = bossBars().getEntry(entry.id()).orElseThrow();
-        ctx.getSource().sender().sendMessage(Component.translatable("commands.bossbar.set.color.success", displayNameOf(updated)));
-        return Command.SINGLE_SUCCESS;
+        return applyUpdate(ctx, entry,
+                e -> e.bar().color() == color, ERROR_COLOR_UNCHANGED,
+                () -> entry.bar().color(color),
+                "commands.bossbar.set.color.success");
     }
 
     private static int updateOverlay(final CommandContext<CommandSource> ctx, final BossBarRegistry.BossBarEntry entry, final BossBar.Overlay overlay) throws CommandSyntaxException {
-        if (entry.bar().overlay() == overlay) {
-            throw ERROR_OVERLAY_UNCHANGED.create();
-        }
-
-        entry.bar().overlay(overlay);
-        ctx.getSource().sender().sendMessage(Component.translatable("commands.bossbar.set.style.success", displayNameOf(entry)));
-        return Command.SINGLE_SUCCESS;
+        return applyUpdate(ctx, entry,
+                e -> e.bar().overlay() == overlay, ERROR_OVERLAY_UNCHANGED,
+                () -> entry.bar().overlay(overlay),
+                "commands.bossbar.set.style.success");
     }
 
     private static int updateValue(final CommandContext<CommandSource> ctx, final BossBarRegistry.BossBarEntry entry, final int value) throws CommandSyntaxException {
@@ -280,9 +262,7 @@ public final class BossBarCommand {
         } else {
             ctx.getSource().sender().sendMessage(Component.translatable(
                     "commands.bossbar.set.players.success.some",
-                    displayNameOf(entry),
-                    Component.text(targetIds.size()),
-                    joinPlayerNames(targetIds)));
+                    displayNameOf(entry), Component.text(targetIds.size()), joinPlayerNames(targetIds)));
         }
 
         return targetIds.size();
@@ -324,38 +304,21 @@ public final class BossBarCommand {
         } else {
             ctx.getSource().sender().sendMessage(Component.translatable(
                     "commands.bossbar.get.players.some",
-                    displayNameOf(entry),
-                    Component.text(entry.players().size()),
-                    joinPlayerNames(entry.players())));
+                    displayNameOf(entry), Component.text(entry.players().size()), joinPlayerNames(entry.players())));
         }
 
         return entry.players().size();
     }
 
-    private static Component joinComponents(final Collection<Component> parts) {
-        Component joined = Component.empty();
-        boolean first = true;
-        for (final Component part : parts) {
-            if (!first) joined = joined.append(Component.text(", "));
-            joined = joined.append(part);
-            first = false;
-        }
-        return joined;
-    }
-
     private static Component joinPlayerNames(final Set<UUID> ids) {
-        Component joined = Component.empty();
-        boolean first = true;
-        for (final UUID id : ids) {
-            if (!first) joined = joined.append(Component.text(", "));
-            final String display = FidorialServer.getInstance().onlinePlayers().stream()
-                    .filter(p -> p.uuid().equals(id))
-                    .map(Player::name)
-                    .findFirst()
-                    .orElse(id.toString());
-            joined = joined.append(Component.text(display));
-            first = false;
-        }
-        return joined;
+        final List<TextComponent> names = ids.stream()
+                .map(id -> FidorialServer.getInstance().onlinePlayers().stream()
+                        .filter(p -> p.uuid().equals(id))
+                        .map(Player::name)
+                        .findFirst()
+                        .orElse(id.toString()))
+                .map(Component::text)
+                .toList();
+        return Component.join(JoinConfiguration.commas(true), names);
     }
 }

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/console/command/brigadier/FidorialCommandCompleter.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/console/command/brigadier/FidorialCommandCompleter.java
@@ -7,6 +7,7 @@ import com.mojang.brigadier.suggestion.Suggestion;
 import com.mojang.brigadier.suggestion.Suggestions;
 import fr.euphyllia.fidorial.server.command.CommandManager;
 import fr.fidorial.command.CommandSource;
+import fr.fidorial.command.MessageComponentSerializer;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import org.jline.reader.Candidate;
@@ -16,8 +17,6 @@ import org.jline.reader.ParsedLine;
 
 import java.util.List;
 import java.util.function.Supplier;
-
-import static fr.euphyllia.fidorial.server.adventure.brigadier.BrigadierAdventureHelper.MSG_SERIALIZER;
 
 public final class FidorialCommandCompleter implements Completer {
 
@@ -63,7 +62,7 @@ public final class FidorialCommandCompleter implements Completer {
         if (tooltip == null) {
             return new Candidate(value, value, null, null, null, null, false);
         }
-        final Component component = MSG_SERIALIZER.deserialize(tooltip);
+        final Component component = MessageComponentSerializer.message().deserialize(tooltip);
         final String description = PlainTextComponentSerializer.plainText().serialize(component);
         return new Candidate(value, value, null, description, null, null, false);
     }

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/nbt/ComponentResolver.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/nbt/ComponentResolver.java
@@ -223,14 +223,6 @@ public final class ComponentResolver {
             }
         }
 
-        final CompoundBinaryTag customName = CompoundBinaryTag.builder()
-                .putString("text", "Fidorial Test Block Entity")
-                .putString("color", "gold")
-                .putBoolean("bold", true)
-                .build();
-
-        root.put("CustomName", customName);
-
         return root.build();
     }
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/nbt/ComponentResolver.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/nbt/ComponentResolver.java
@@ -1,30 +1,63 @@
 package fr.euphyllia.fidorial.server.network.nbt;
 
+import com.mojang.brigadier.StringReader;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import fr.euphyllia.fidorial.server.codecs.adventure.ComponentCodecs;
 import fr.euphyllia.fidorial.server.command.brigadier.argument.entity.EntitySelector;
+import fr.euphyllia.fidorial.server.command.brigadier.argument.nbt.NbtDataArgument;
+import fr.euphyllia.fidorial.server.entity.AbstractEntity;
+import fr.euphyllia.fidorial.server.world.CoordMath;
+import fr.euphyllia.fidorial.server.world.ServerWorld;
+import fr.euphyllia.fidorial.server.world.block.blockentity.BlockEntity;
+import fr.euphyllia.fidorial.server.world.chunk.ChunkColumn;
+import fr.euphyllia.fidorial.server.world.entity.AnvilEntitySerializer;
 import fr.fidorial.command.CommandSource;
+import fr.fidorial.command.argument.resolvers.NbtPathResolver;
 import fr.fidorial.entity.Entity;
+import fr.fidorial.world.BlockPos;
+import fr.fidorial.world.Location;
+import io.papermc.adventurex.nbt.dfu.BinaryTagOps;
+import net.kyori.adventure.nbt.BinaryTag;
+import net.kyori.adventure.nbt.CompoundBinaryTag;
+import net.kyori.adventure.text.BlockNBTComponent;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.EntityNBTComponent;
+import net.kyori.adventure.text.NBTComponent;
 import net.kyori.adventure.text.SelectorComponent;
+import net.kyori.adventure.text.StorageNBTComponent;
 import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.logger.slf4j.ComponentLogger;
+import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public final class ComponentResolver {
 
+    private static final ComponentLogger LOGGER = ComponentLogger.logger(ComponentResolver.class);
+    private static final int MAX_COMPONENT_DEPTH = 64;
+    private static final AnvilEntitySerializer ENTITY_SERIALIZER = new AnvilEntitySerializer();
+
     public static Component resolve(final Component component, final CommandSource source) {
+        return resolve(component, source, 0);
+    }
+
+    private static Component resolve(final Component component, final CommandSource source, final int depth) {
+        if (depth >= MAX_COMPONENT_DEPTH) {
+            return component;
+        }
+
         Component resolvedContent = switch (component) {
             case SelectorComponent sel -> resolveSelector(sel, source);
             //case ScoreComponent score -> resolveScore(score, source); TBD
-            //case NBTComponent<?> nbt -> resolveNbt(nbt, source); TBD
+            case NBTComponent<?> nbt -> resolveNbt(nbt, source);
             default -> component;
         };
 
         if (!resolvedContent.children().isEmpty()) {
             List<Component> resolvedChildren = new ArrayList<>();
             for (final Component child : resolvedContent.children()) {
-                resolvedChildren.add(resolve(child, source));
+                resolvedChildren.add(resolve(child, source, depth + 1));
             }
             resolvedContent = resolvedContent.children(resolvedChildren);
         }
@@ -58,7 +91,7 @@ public final class ComponentResolver {
         for (int i = 0; i < matches.size(); i++) {
             final Entity entity = matches.get(i);
 
-            final Component name = entity.displayName().hoverEvent(entity.asHoverEvent());
+            final Component name = entity.displayName().hoverEvent(entity);
 
             if (i != 0) {
                 result = result.append(separator);
@@ -67,5 +100,166 @@ public final class ComponentResolver {
         }
 
         return result;
+    }
+
+    private static Component resolveNbt(final NBTComponent<?> nbt, final CommandSource source) {
+        final CompoundBinaryTag root = switch (nbt) {
+            case final BlockNBTComponent block -> resolveBlockRoot(block, source);
+            case final EntityNBTComponent entity -> resolveEntityRoot(entity, source);
+            case final StorageNBTComponent storage -> resolveStorageRoot(storage);
+        };
+        if (root == null) {
+            return Component.empty();
+        }
+
+        final NbtPathResolver path;
+        try {
+            path = NbtDataArgument.nbtPath().parse(new StringReader(nbt.nbtPath()));
+        } catch (final CommandSyntaxException e) {
+            return Component.empty();
+        }
+
+        final List<BinaryTag> matches = path.resolve(root);
+        if (matches.isEmpty()) return Component.empty();
+
+        final Component separator = nbt.separator() != null
+                ? nbt.separator()
+                : Component.text(", ").color(NamedTextColor.GRAY);
+
+        final boolean effectiveInterpret = nbt.interpret() && !nbt.nbtPath().isEmpty();
+
+        return effectiveInterpret
+                ? resolveInterpretting(matches, separator)
+                : resolveFormatting(matches, separator, nbt.plain());
+    }
+
+    private static Component resolveInterpretting(final List<BinaryTag> matches, final Component separator) {
+        Component result = null;
+        for (final BinaryTag tag : matches) {
+            final Component parsed;
+            try {
+                parsed = ComponentCodecs.COMPONENT_CODEC.parse(BinaryTagOps.binaryTagOps(), tag).getOrThrow();
+            } catch (final Exception e) {
+                LOGGER.warn("Failed to parse component: {}", tag, e);
+                continue;
+            }
+            result = (result == null) ? parsed : result.append(separator).append(parsed);
+        }
+        return result == null ? Component.empty() : result;
+    }
+
+    private static Component resolveFormatting(final List<BinaryTag> matches, final Component separator, final boolean plain) {
+        Component result = Component.empty();
+        for (int i = 0; i < matches.size(); i++) {
+            if (i != 0) {
+                result = result.append(separator);
+            }
+            result = result.append(NbtTextDecorator.render(matches.get(i), plain));
+        }
+        return result;
+    }
+
+    private static @Nullable CompoundBinaryTag resolveEntityRoot(final EntityNBTComponent nbt, final CommandSource source) {
+        final EntitySelector selector;
+        try {
+            selector = EntitySelector.parse(nbt.selector());
+        } catch (final CommandSyntaxException e) {
+            return null;
+        }
+
+        final List<Entity> matches;
+        try {
+            matches = new ArrayList<>(selector.findEntities(source));
+        } catch (final CommandSyntaxException e) {
+            return null;
+        }
+
+        if (matches.size() != 1 || !(matches.getFirst() instanceof final AbstractEntity entity)) {
+            return null;
+        }
+
+        return ENTITY_SERIALIZER.toNbt(entity);
+    }
+
+    private static @Nullable CompoundBinaryTag resolveBlockRoot(final BlockNBTComponent nbt, final CommandSource source) {
+        final Entity executor = source.executor();
+        if (executor == null || !(executor.world() instanceof final ServerWorld world)) {
+            return null;
+        }
+
+        final BlockPos pos = resolveBlockPos(nbt.pos(), executor.location());
+        if (pos == null) {
+            return null;
+        }
+
+        final ChunkColumn chunk = world.loadedColumn(pos.chunkX(), pos.chunkZ());
+        if (chunk == null) {
+            return null;
+        }
+
+        final BlockEntity blockEntity = chunk.blockEntity(pos.localX(), pos.y(), pos.localZ());
+        if (blockEntity == null) {
+            return null;
+        }
+
+        final CompoundBinaryTag.Builder root = CompoundBinaryTag.builder();
+        final CompoundBinaryTag extra = blockEntity.data();
+
+        root.putString("id", blockEntity.type().asString());
+        root.putInt("x", pos.x());
+        root.putInt("y", pos.y());
+        root.putInt("z", pos.z());
+
+        root.put("components",
+                (extra != null && extra.keySet().contains("components"))
+                        ? extra.get("components")
+                        : CompoundBinaryTag.empty());
+
+        if (extra != null) {
+            for (final String key : extra.keySet()) {
+                if (!key.equals("components")) {
+                    root.put(key, extra.get(key));
+                }
+            }
+        }
+
+        final CompoundBinaryTag customName = CompoundBinaryTag.builder()
+                .putString("text", "Fidorial Test Block Entity")
+                .putString("color", "gold")
+                .putBoolean("bold", true)
+                .build();
+
+        root.put("CustomName", customName);
+
+        return root.build();
+    }
+
+    private static @Nullable BlockPos resolveBlockPos(final BlockNBTComponent.Pos pos, final Location origin) {
+        return switch (pos) {
+            case final BlockNBTComponent.LocalPos local -> {
+                final Location resolved = CoordMath.applyLocalCoords(
+                        origin, local.left(), local.up(), local.forwards());
+                yield new BlockPos(
+                        (int) Math.floor(resolved.x()),
+                        (int) Math.floor(resolved.y()),
+                        (int) Math.floor(resolved.z()));
+            }
+            case final BlockNBTComponent.WorldPos world -> new BlockPos(
+                    resolveCoordinate(world.x(), (int) Math.floor(origin.x())),
+                    resolveCoordinate(world.y(), (int) Math.floor(origin.y())),
+                    resolveCoordinate(world.z(), (int) Math.floor(origin.z())));
+            default -> null;
+        };
+    }
+
+    private static int resolveCoordinate(final BlockNBTComponent.WorldPos.Coordinate coordinate, final int originCoord) {
+        return coordinate.type() == BlockNBTComponent.WorldPos.Coordinate.Type.RELATIVE
+                ? originCoord + coordinate.value()
+                : coordinate.value();
+    }
+
+    // TODO
+    private static @Nullable CompoundBinaryTag resolveStorageRoot(final StorageNBTComponent nbt) {
+        return null;
     }
 }

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/nbt/NbtTextDecorator.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/nbt/NbtTextDecorator.java
@@ -1,0 +1,164 @@
+package fr.euphyllia.fidorial.server.network.nbt;
+
+import net.kyori.adventure.nbt.BinaryTag;
+import net.kyori.adventure.nbt.ByteArrayBinaryTag;
+import net.kyori.adventure.nbt.ByteBinaryTag;
+import net.kyori.adventure.nbt.CompoundBinaryTag;
+import net.kyori.adventure.nbt.DoubleBinaryTag;
+import net.kyori.adventure.nbt.FloatBinaryTag;
+import net.kyori.adventure.nbt.IntArrayBinaryTag;
+import net.kyori.adventure.nbt.IntBinaryTag;
+import net.kyori.adventure.nbt.ListBinaryTag;
+import net.kyori.adventure.nbt.LongArrayBinaryTag;
+import net.kyori.adventure.nbt.LongBinaryTag;
+import net.kyori.adventure.nbt.ShortBinaryTag;
+import net.kyori.adventure.nbt.StringBinaryTag;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextColor;
+import org.jspecify.annotations.Nullable;
+
+import java.util.function.IntFunction;
+import java.util.regex.Pattern;
+
+public final class NbtTextDecorator {
+
+    private static final int NESTING_LIMIT = 64;
+    private static final int ARRAY_PRINT_LIMIT = 128;
+    private static final Pattern SIMPLE_KEY = Pattern.compile("[A-Za-z0-9._+-]+");
+
+    private final Palette palette;
+    private int nesting = 0;
+
+    private NbtTextDecorator(final Palette palette) {
+        this.palette = palette;
+    }
+
+    public static Component render(final BinaryTag tag, final boolean plain) {
+        final NbtTextDecorator renderer = new NbtTextDecorator(plain ? Palette.NONE : Palette.COLORED);
+        return renderer.write(tag);
+    }
+
+    private Component write(final BinaryTag tag) {
+        return switch (tag) {
+            case final StringBinaryTag t -> quoted(t.value(), palette.stringColor());
+            case final ByteBinaryTag t -> number(String.valueOf(t.value())).append(typeMarker("b"));
+            case final ShortBinaryTag t -> number(String.valueOf(t.value())).append(typeMarker("s"));
+            case final IntBinaryTag t -> number(String.valueOf(t.value()));
+            case final LongBinaryTag t -> number(String.valueOf(t.value())).append(typeMarker("L"));
+            case final FloatBinaryTag t -> number(String.valueOf(t.value())).append(typeMarker("f"));
+            case final DoubleBinaryTag t -> number(String.valueOf(t.value())).append(typeMarker("d"));
+            case final ByteArrayBinaryTag t -> numericArray("B", t.value().length, i -> String.valueOf(t.value()[i]), "b");
+            case final IntArrayBinaryTag t -> numericArray("I", t.value().length, i -> String.valueOf(t.value()[i]), null);
+            case final LongArrayBinaryTag t -> numericArray("L", t.value().length, i -> String.valueOf(t.value()[i]), "L");
+            case final ListBinaryTag t -> list(t);
+            case final CompoundBinaryTag t -> compound(t);
+            default -> plain(String.valueOf(tag));
+        };
+    }
+
+    private Component list(final ListBinaryTag list) {
+        if (list.isEmpty()) {
+            return punctuation("[").append(punctuation("]"));
+        }
+        if (nesting >= NESTING_LIMIT) {
+            return punctuation("[").append(folded()).append(punctuation("]"));
+        }
+
+        nesting++;
+        Component joined = null;
+        for (final BinaryTag element : list) {
+            final Component rendered = write(element);
+            joined = joined == null ? rendered : joined.append(punctuation(",")).append(plain(" ")).append(rendered);
+        }
+        nesting--;
+
+        return punctuation("[").append(joined).append(punctuation("]"));
+    }
+
+    private Component compound(final CompoundBinaryTag compound) {
+        if (compound.keySet().isEmpty()) {
+            return punctuation("{").append(punctuation("}"));
+        }
+        if (nesting >= NESTING_LIMIT) {
+            return punctuation("{").append(folded()).append(punctuation("}"));
+        }
+
+        nesting++;
+        Component joined = null;
+        for (final String key : compound.keySet()) {
+            final Component entry = fieldName(key).append(punctuation(":")).append(plain(" ")).append(write(compound.get(key)));
+            joined = joined == null ? entry : joined.append(punctuation(",")).append(plain(" ")).append(entry);
+        }
+        nesting--;
+
+        return punctuation("{").append(joined).append(punctuation("}"));
+    }
+
+    private Component numericArray(final String typeMarker, final int length, final IntFunction<String> elementText, final @Nullable String elementSuffix) {
+        final int limit = Math.min(length, ARRAY_PRINT_LIMIT);
+        Component body = typeMarker(typeMarker).append(punctuation(";"));
+        for (int i = 0; i < limit; i++) {
+            body = body.append(plain(" ")).append(number(elementText.apply(i)));
+            if (elementSuffix != null) {
+                body = body.append(typeMarker(elementSuffix));
+            }
+            if (i != length - 1) {
+                body = body.append(punctuation(","));
+            }
+        }
+        if (length > ARRAY_PRINT_LIMIT) {
+            body = body.append(plain(" ")).append(folded());
+        }
+        return punctuation("[").append(body).append(punctuation("]"));
+    }
+
+    private Component fieldName(final String key) {
+        if (SIMPLE_KEY.matcher(key).matches()) {
+            return colorize(key, palette.keyColor());
+        }
+        return quoted(key, palette.keyColor());
+    }
+
+    private Component quoted(final String raw, final @Nullable TextColor color) {
+        final StringBuilder escaped = new StringBuilder();
+        for (int i = 0; i < raw.length(); i++) {
+            final char c = raw.charAt(i);
+            if (c == '"' || c == '\\') {
+                escaped.append('\\');
+            }
+            escaped.append(c);
+        }
+        return punctuation("\"").append(colorize(escaped.toString(), color)).append(plain("\""));
+    }
+
+    private Component number(final String text) {
+        return colorize(text, palette.numberColor());
+    }
+
+    private Component typeMarker(final String text) {
+        return colorize(text, palette.typeMarkerColor());
+    }
+
+    private Component punctuation(final String text) {
+        return colorize(text, palette.punctuationColor());
+    }
+
+    private Component folded() {
+        return colorize("...", palette.foldedColor());
+    }
+
+    private Component plain(final String text) {
+        return Component.text(text);
+    }
+
+    private Component colorize(final String text, final @Nullable TextColor color) {
+        final Component base = Component.text(text);
+        return color == null ? base : base.color(color);
+    }
+
+    private record Palette(@Nullable TextColor keyColor, @Nullable TextColor stringColor, @Nullable TextColor numberColor, @Nullable TextColor typeMarkerColor, @Nullable TextColor punctuationColor, @Nullable TextColor foldedColor) {
+        static final Palette NONE = new Palette(null, null, null, null, null, null);
+        static final Palette COLORED = new Palette(NamedTextColor.AQUA, NamedTextColor.GREEN, NamedTextColor.GOLD, NamedTextColor.RED, NamedTextColor.WHITE, NamedTextColor.GRAY);
+    }
+}

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/chunk/ChunkColumn.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/chunk/ChunkColumn.java
@@ -5,6 +5,7 @@ import fr.euphyllia.fidorial.server.world.block.blockentity.BlockEntityTypes;
 import fr.euphyllia.fidorial.server.world.light.ChunkLightData;
 import fr.fidorial.registry.keys.BlockTypeKeys;
 import net.kyori.adventure.key.Key;
+import net.kyori.adventure.nbt.CompoundBinaryTag;
 import org.jetbrains.annotations.UnknownNullability;
 import org.jspecify.annotations.Nullable;
 
@@ -188,6 +189,10 @@ public final class ChunkColumn {
     }
 
     public void setBlock(final int localX, final int worldY, final int localZ, final BlockState state) {
+        setBlock(localX, worldY, localZ, state, null);
+    }
+
+    public void setBlock(final int localX, final int worldY, final int localZ, final BlockState state, final @Nullable CompoundBinaryTag data) {
         final ChunkSection s = sectionForY(worldY);
         if (s == null) {
             return;
@@ -203,7 +208,7 @@ public final class ChunkColumn {
         removeBlockEntity(localX, worldY, localZ);
 
         BlockEntityTypes.typeIdentifier(state.name())
-                .ifPresent(type -> putBlockEntity(BlockEntity.of(localX, worldY, localZ, type)));
+                .ifPresent(type -> putBlockEntity(new BlockEntity(localX, worldY, localZ, type, data)));
     }
 
     public BlockState getBlock(final int localX, final int worldY, final int localZ) {

--- a/fidorial-server/src/main/resources/languages/en_us.json
+++ b/fidorial-server/src/main/resources/languages/en_us.json
@@ -139,6 +139,9 @@
   "console.argument.gamemode.invalid": "Unknown game mode: '<arg:0>'",
   "console.argument.id.invalid": "Invalid ID",
 
+  "console.arguments.nbtpath.node.invalid": "Invalid NBT path element",
+  "console.arguments.nbtpath.nothing_found": "Found no elements matching '<arg:0>'",
+
   "command.time.description": "Changes or queries the day/night cycle of a world",
   "command.time.set": "Time set to <arg:0> in <arg:1>",
   "command.time.query": "<arg:0>: <arg:1> (<arg:2>)",

--- a/fidorial-server/src/main/resources/languages/fr_fr.json
+++ b/fidorial-server/src/main/resources/languages/fr_fr.json
@@ -139,6 +139,9 @@
   "console.argument.gamemode.invalid": "Mode de jeu inconnu : <arg:0>",
   "console.argument.id.invalid": "ID non valide",
 
+  "console.arguments.nbtpath.node.invalid": "Élément de chemin NBT non valide",
+  "console.arguments.nbtpath.nothing_found": "Aucun élément correspondant à \"<arg:0>\" n'a été trouvé",
+
   "command.time.description": "Modifie ou consulte le cycle jour/nuit d'un monde",
   "command.time.set": "Heure définie sur <arg:0> dans <arg:1>",
   "command.time.query": "<arg:0> : <arg:1> (<arg:2>)",

--- a/fidorial-test-plugin/src/main/java/fr/euphyllia/fidorial/testplugin/command/ApiTestCommand.java
+++ b/fidorial-test-plugin/src/main/java/fr/euphyllia/fidorial/testplugin/command/ApiTestCommand.java
@@ -13,11 +13,14 @@ import fr.fidorial.command.CommandSender;
 import fr.fidorial.command.CommandSource;
 import fr.fidorial.command.MessageComponentSerializer;
 import fr.fidorial.command.argument.ArgumentTypes;
+import fr.fidorial.command.argument.resolvers.BlockPosResolver;
+import fr.fidorial.command.argument.resolvers.NbtPathResolver;
 import fr.fidorial.entity.Player;
 import fr.fidorial.inventory.ItemStack;
 import fr.fidorial.registry.RegistryKey;
 import fr.fidorial.registry.data.SoundEvent;
 import fr.fidorial.scheduler.RegionTps;
+import fr.fidorial.world.BlockPos;
 import fr.fidorial.world.ChunkPos;
 import fr.fidorial.world.Location;
 import fr.fidorial.world.World;
@@ -31,6 +34,7 @@ import net.kyori.adventure.resource.ResourcePackInfo;
 import net.kyori.adventure.resource.ResourcePackRequest;
 import net.kyori.adventure.sound.Sound;
 import net.kyori.adventure.sound.SoundStop;
+import net.kyori.adventure.text.BlockNBTComponent;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.event.ClickCallback;
 import net.kyori.adventure.text.event.ClickEvent;
@@ -98,15 +102,15 @@ public final class ApiTestCommand {
                                         .then(argument("z", ArgumentTypes.doubleArg())
                                                 .executes(ApiTestCommand::tp)))))
                 .then(literal("tpworld")
-                        .executes(ctx -> tpWorld(plugin, ctx, Key.key("minecraft", "overworld")))
+                        .executes(ctx -> tpWorld(plugin, ctx, Key.key("overworld")))
                         .then(argument("name", ArgumentTypes.key())
                                 .executes(ctx -> tpWorld(plugin, ctx, ctx.getArgument("name", Key.class)))))
                 .then(literal("createworld")
-                        .executes(ctx -> createWorld(ctx, Key.key("minecraft", UUID.randomUUID().toString())))
+                        .executes(ctx -> createWorld(ctx, Key.key(UUID.randomUUID().toString())))
                         .then(argument("name", ArgumentTypes.key())
                                 .executes(ctx -> createWorld(ctx, ctx.getArgument("name", Key.class)))))
                 .then(literal("unloadworld")
-                        .executes(ctx -> unloadWorld(ctx, Key.key("minecraft", UUID.randomUUID().toString())))
+                        .executes(ctx -> unloadWorld(ctx, Key.key(UUID.randomUUID().toString())))
                         .then(argument("name", ArgumentTypes.key())
                                 .executes(ctx -> unloadWorld(ctx, ctx.getArgument("name", Key.class)))))
                 .then(literal("sound")
@@ -121,7 +125,7 @@ public final class ApiTestCommand {
                         .executes(ApiTestCommand::stopAllSound)
                         .then(argument("key", ArgumentTypes.key()).executes(ApiTestCommand::stopSound)))
                 .then(literal("callback")
-                        .executes(ctx -> clickCallback(ctx)))
+                        .executes(ApiTestCommand::clickCallback))
                 .then(literal("baguette")
                         .then(argument("type", BaguetteArgument.baguette())
                                 .executes(ApiTestCommand::baguette)))
@@ -131,7 +135,20 @@ public final class ApiTestCommand {
                         .executes(ApiTestCommand::resourcePackBroadcast))
                 .then(literal("tablist")
                         .then(literal("broadcast").executes(ApiTestCommand::tabListBroadcast)))
-                // TODO: should become a standalone command in fidorial tbh like vanilla /bossbar, and be expanded to match vanilla args too (with our additional flags)
+                // TODO: should be replaced by server-side /data command
+                .then(literal("nbt")
+                        .then(literal("entity")
+                                .executes(ApiTestCommand::nbtEntitySelf)
+                                .then(argument("path", ArgumentTypes.nbtPath())
+                                        .executes(ApiTestCommand::nbtEntityPath)))
+                        .then(literal("block")
+                                .then(argument("pos", ArgumentTypes.blockPosition())
+                                        .executes(ApiTestCommand::nbtBlockAtPos)
+                                        .then(argument("path", ArgumentTypes.nbtPath())
+                                                .executes(ApiTestCommand::nbtBlockAtPosWithPath))))
+                        .then(literal("storage")
+                                .executes(ApiTestCommand::nbtStorage))
+                )
                 .then(literal("bossbar")
                         .then(literal("show")
                                 .then(argument("name", ArgumentTypes.key())
@@ -146,8 +163,6 @@ public final class ApiTestCommand {
                                 .requires(source -> {
                                     final CommandSender sender = source.sender();
                                     if (!(sender instanceof Player player)) {
-                                        // placeholder, the server command should support non players executors as it will need the players selected
-                                        // look at mc brigadier commands https://mcsrc.dev/1/26.2/net/minecraft/server/commands/BossBarCommands
                                         return false;
                                     }
 
@@ -185,6 +200,73 @@ public final class ApiTestCommand {
         plugin.msg(sender, "[TestPlugin] Broadcasted tab list header/footer to "
                 + plugin.server().playerCount() + " player(s).");
 
+        return Command.SINGLE_SUCCESS;
+    }
+
+    private static int nbtEntitySelf(final CommandContext<CommandSource> ctx) {
+        return nbtEntity(ctx, "");
+    }
+
+    private static int nbtEntityPath(final CommandContext<CommandSource> ctx) {
+        final NbtPathResolver path = ctx.getArgument("path", NbtPathResolver.class);
+        return nbtEntity(ctx, path.asString());
+    }
+
+    private static int nbtEntity(final CommandContext<CommandSource> ctx, final String path) {
+        final CommandSender sender = ctx.getSource().sender();
+        if (!(sender instanceof final Player player)) {
+            plugin.msg(sender, "<red>[TestPlugin] Run this command in-game.</red>");
+            return 0;
+        }
+
+        final Component nbtComponent = Component.entityNBT()
+                .selector("@s")
+                .nbtPath(path)
+                .interpret(true)
+                .build();
+
+        player.sendMessage(nbtComponent);
+        return Command.SINGLE_SUCCESS;
+    }
+
+    private static int nbtBlockAtPos(final CommandContext<CommandSource> ctx) throws CommandSyntaxException {
+        return nbtBlock(ctx, "");
+    }
+
+    private static int nbtBlockAtPosWithPath(final CommandContext<CommandSource> ctx) throws CommandSyntaxException {
+        final NbtPathResolver path = ctx.getArgument("path", NbtPathResolver.class);
+        return nbtBlock(ctx, path.asString());
+    }
+
+    private static int nbtBlock(final CommandContext<CommandSource> ctx, final String path) throws CommandSyntaxException {
+        final CommandSender sender = ctx.getSource().sender();
+        if (!(sender instanceof final Player player)) {
+            plugin.msg(sender, "<red>[TestPlugin] Run this command in-game.</red>");
+            return 0;
+        }
+
+        final BlockPos pos = ctx.getArgument("pos", BlockPosResolver.class).resolve(ctx.getSource());
+
+        final BlockNBTComponent nbtComponent = Component.blockNBT()
+                .absoluteWorldPos(pos.x(), pos.y(), pos.z())
+                .nbtPath(path)
+                .interpret(true)
+                .build();
+
+        player.sendMessage(nbtComponent);
+        return Command.SINGLE_SUCCESS;
+    }
+
+    private static int nbtStorage(final CommandContext<CommandSource> ctx) {
+        final CommandSender sender = ctx.getSource().sender();
+
+        final Component nbtComponent = Component.storageNBT()
+                .storage(Key.key("fidorial", "test"))
+                .nbtPath("")
+                .interpret(true)
+                .build();
+
+        sender.sendMessage(nbtComponent);
         return Command.SINGLE_SUCCESS;
     }
 
@@ -231,14 +313,14 @@ public final class ApiTestCommand {
             return Command.SINGLE_SUCCESS;
         }
 
-        player.playSound(Sound.sound(Key.key("minecraft", "entity.player.levelup"), Sound.Source.PLAYER, 1.0f, 1.0f));
+        player.playSound(Sound.sound(Key.key("entity.player.levelup"), Sound.Source.PLAYER, 1.0f, 1.0f));
 
         player.playSound(
-                Sound.sound(Key.key("minecraft", "entity.experience_orb.pickup"), Sound.Source.MASTER, 0.8f, 1.4f),
+                Sound.sound(Key.key("entity.experience_orb.pickup"), Sound.Source.MASTER, 0.8f, 1.4f),
                 Sound.Emitter.self());
 
         player.playSound(
-                Sound.sound(Key.key("minecraft", "block.bell.use"), Sound.Source.BLOCK, 1.0f, 0.8f), 0.0, 64.0, 0.0);
+                Sound.sound(Key.key("block.bell.use"), Sound.Source.BLOCK, 1.0f, 0.8f), 0.0, 64.0, 0.0);
 
         plugin.msg(player, "[TestPlugin] Sound demo executed.");
 


### PR DESCRIPTION
This PR adds a new `NbtDataArgument` argument for resolving nbt paths along with support for nbt components in `ComponentResolver`.

Also added a new `/apitest nbt [block,entity,storage]` command for testing and refactored existing brigadier arguments to use a helper class for exception creation, to reduce the amt of code.

<img width="628" height="173" alt="image" src="https://github.com/user-attachments/assets/1fe62412-6c66-4da7-9405-5f0986176364" />

### Notes
Nbt storage component support is currently a stub since we don't have that concept yet from what i could see
