### PR TITLE
Introduce DimensionType API

### DIFF
--- a/fidorial-api/src/generated/java/fr/fidorial/world/dimension/types/VanillaDimensionTypes.java
+++ b/fidorial-api/src/generated/java/fr/fidorial/world/dimension/types/VanillaDimensionTypes.java
@@ -1,0 +1,48 @@
+package fr.fidorial.world.dimension.types;
+
+import fr.fidorial.registry.keys.DimensionTypeKeys;
+import fr.fidorial.world.dimension.DimensionTypeDefinition;
+
+/**
+ * Provides the built-in Minecraft dimension type definitions.
+ *
+ * <p>These definitions correspond to the vanilla dimension types registered
+ * by Minecraft and can be used when constructing or referencing vanilla
+ * dimensions.</p>
+ *
+ * @apiNote The dimension types provided by this class mirror those registered
+ * by vanilla and are not guaranteed to remain stable. New dimension types may
+ * be added and existing dimension types may be removed in future Minecraft
+ * versions without notice.
+ *
+ * @since 0.1.0
+ */
+public final class VanillaDimensionTypes {
+    /**
+     * The {@code minecraft:overworld} dimension type.
+     *
+     * @since 0.1.0
+     */
+    public static final DimensionTypeDefinition OVERWORLD = DimensionTypeDefinition.builder(DimensionTypeKeys.OVERWORLD.key()).build();
+
+    /**
+     * The {@code minecraft:overworld_caves} dimension type.
+     *
+     * @since 0.1.0
+     */
+    public static final DimensionTypeDefinition OVERWORLD_CAVES = DimensionTypeDefinition.builder(DimensionTypeKeys.OVERWORLD_CAVES.key()).build();
+
+    /**
+     * The {@code minecraft:the_end} dimension type.
+     *
+     * @since 0.1.0
+     */
+    public static final DimensionTypeDefinition THE_END = DimensionTypeDefinition.builder(DimensionTypeKeys.THE_END.key()).build();
+
+    /**
+     * The {@code minecraft:the_nether} dimension type.
+     *
+     * @since 0.1.0
+     */
+    public static final DimensionTypeDefinition THE_NETHER = DimensionTypeDefinition.builder(DimensionTypeKeys.THE_NETHER.key()).build();
+}

--- a/fidorial-api/src/main/java/fr/fidorial/Server.java
+++ b/fidorial-api/src/main/java/fr/fidorial/Server.java
@@ -17,6 +17,7 @@ import fr.fidorial.translation.TranslationStore;
 import fr.fidorial.world.World;
 import fr.fidorial.world.WorldBuilder;
 import fr.fidorial.world.biome.BiomeRegistry;
+import fr.fidorial.world.dimension.DimensionTypeRegistry;
 import fr.fidorial.world.generation.WorldGenerator;
 import net.kyori.adventure.audience.ForwardingAudience;
 import net.kyori.adventure.key.Key;
@@ -162,6 +163,18 @@ public interface Server extends ForwardingAudience {
      */
     @Contract(pure = true)
     BiomeRegistry biomes();
+
+    /**
+     * Gets the server-wide dimension type registry.
+     *
+     * <p>Dimension types registered there are sent to every client joining afterwards, and may be referenced
+     * by {@link fr.fidorial.world.generation.WorldGenerator generators} through
+     * {@link fr.fidorial.world.generation.GeneratedChunk#setBiome(int, int, int, Key)}.</p>
+     *
+     * @return the biome registry
+     * @since 0.1.0
+     */
+    DimensionTypeRegistry dimensionTypes();
 
     /**
      * Gets the server-wide mob registry.

--- a/fidorial-api/src/main/java/fr/fidorial/world/World.java
+++ b/fidorial-api/src/main/java/fr/fidorial/world/World.java
@@ -1,6 +1,7 @@
 package fr.fidorial.world;
 
 import fr.fidorial.entity.Entity;
+import fr.fidorial.world.dimension.DimensionTypeDefinition;
 import fr.fidorial.world.time.DayNightCycle;
 import net.kyori.adventure.audience.ForwardingAudience;
 import net.kyori.adventure.key.Key;
@@ -16,6 +17,13 @@ public interface World extends Keyed, ForwardingAudience {
     int minY();
 
     int height();
+
+    /**
+     * {@return this world's dimension type}
+     *
+     * @since 0.1.0
+     */
+    DimensionTypeDefinition dimensionType();
 
     DayNightCycle dayNightCycle();
 

--- a/fidorial-api/src/main/java/fr/fidorial/world/dimension/CardinalLight.java
+++ b/fidorial-api/src/main/java/fr/fidorial/world/dimension/CardinalLight.java
@@ -1,0 +1,25 @@
+package fr.fidorial.world.dimension;
+
+/**
+ * Which direction cardinal light comes from, affecting how blocks are shaded.
+ *
+ * @since 0.1.0
+ */
+public enum CardinalLight {
+
+    DEFAULT("default"),
+    NETHER("nether");
+
+    private final String id;
+
+    CardinalLight(final String id) {
+        this.id = id;
+    }
+
+    /**
+     * {@return the identifier expected on the wire}
+     */
+    public String id() {
+        return id;
+    }
+}

--- a/fidorial-api/src/main/java/fr/fidorial/world/dimension/DimensionTypeBuilder.java
+++ b/fidorial-api/src/main/java/fr/fidorial/world/dimension/DimensionTypeBuilder.java
@@ -1,0 +1,333 @@
+package fr.fidorial.world.dimension;
+
+import fr.fidorial.world.environment.EnvironmentAttributes;
+import net.kyori.adventure.key.Key;
+import org.jetbrains.annotations.Contract;
+import org.jspecify.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
+
+/**
+ * Fluent builder for {@link DimensionTypeDefinition}.
+ *
+ * <p>Defaults match the vanilla overworld.</p>
+ *
+ * @since 0.1.0
+ */
+public final class DimensionTypeBuilder {
+
+    private Key key;
+    private double coordinateScale = 1.0D;
+    private boolean hasSkylight = true;
+    private boolean hasCeiling = false;
+    private boolean hasEnderDragonFight = false;
+    private float ambientLight = 0.0F;
+    private boolean hasFixedTime = false;
+    private int monsterSpawnBlockLightLimit = 0;
+    private IntProvider monsterSpawnLightLevel = IntProvider.uniform(0, 7);
+    private int logicalHeight = 384;
+    private int minY = -64;
+    private int height = 384;
+    private Key infiniburn = Key.key("infiniburn_overworld");
+    private Skybox skybox = Skybox.OVERWORLD;
+    private CardinalLight cardinalLight = CardinalLight.DEFAULT;
+    private EnvironmentAttributes.Builder attributes = EnvironmentAttributes.builder();
+    private @Nullable Key defaultClock;
+    private final List<TimelineReference> timelines = new ArrayList<>();
+
+    DimensionTypeBuilder(final Key key) {
+        this.key = Objects.requireNonNull(key, "key");
+    }
+
+    DimensionTypeBuilder(final DimensionTypeDefinition definition) {
+        this.key = definition.key();
+        this.coordinateScale = definition.coordinateScale();
+        this.hasSkylight = definition.hasSkylight();
+        this.hasCeiling = definition.hasCeiling();
+        this.hasEnderDragonFight = definition.hasEnderDragonFight();
+        this.ambientLight = definition.ambientLight();
+        this.hasFixedTime = definition.hasFixedTime();
+        this.monsterSpawnBlockLightLimit = definition.monsterSpawnBlockLightLimit();
+        this.monsterSpawnLightLevel = definition.monsterSpawnLightLevel();
+        this.logicalHeight = definition.logicalHeight();
+        this.minY = definition.minY();
+        this.height = definition.height();
+        this.infiniburn = definition.infiniburn();
+        this.skybox = definition.skybox();
+        this.cardinalLight = definition.cardinalLight();
+        this.attributes = EnvironmentAttributes.builder(definition.attributes());
+        this.defaultClock = definition.defaultClock();
+        this.timelines.addAll(definition.timelines());
+    }
+
+    /**
+     * @param key the namespaced identifier of the dimension type
+     * @return this builder
+     */
+    @Contract("_ -> this")
+    public DimensionTypeBuilder key(final Key key) {
+        this.key = Objects.requireNonNull(key, "key");
+        return this;
+    }
+
+    /**
+     * @param coordinateScale multiplier applied to coordinates when leaving the dimension,
+     *                        within {@code [0.00001, 30000000.0]}
+     * @return this builder
+     */
+    @Contract("_ -> this")
+    public DimensionTypeBuilder coordinateScale(final double coordinateScale) {
+        this.coordinateScale = coordinateScale;
+        return this;
+    }
+
+    /**
+     * @param hasSkylight whether the dimension has skylight; disables weather when {@code false}
+     * @return this builder
+     */
+    @Contract("_ -> this")
+    public DimensionTypeBuilder hasSkylight(final boolean hasSkylight) {
+        this.hasSkylight = hasSkylight;
+        return this;
+    }
+
+    /**
+     * @param hasCeiling whether the dimension has a logical bedrock ceiling
+     * @return this builder
+     */
+    @Contract("_ -> this")
+    public DimensionTypeBuilder hasCeiling(final boolean hasCeiling) {
+        this.hasCeiling = hasCeiling;
+        return this;
+    }
+
+    /**
+     * @param hasEnderDragonFight whether this dimension can host an ender dragon fight
+     * @return this builder
+     */
+    @Contract("_ -> this")
+    public DimensionTypeBuilder hasEnderDragonFight(final boolean hasEnderDragonFight) {
+        this.hasEnderDragonFight = hasEnderDragonFight;
+        return this;
+    }
+
+    /**
+     * @param ambientLight how much light the dimension has regardless of the light level
+     * @return this builder
+     */
+    @Contract("_ -> this")
+    public DimensionTypeBuilder ambientLight(final float ambientLight) {
+        this.ambientLight = ambientLight;
+        return this;
+    }
+
+    /**
+     * @param hasFixedTime whether this dimension has fixed time
+     * @return this builder
+     */
+    @Contract("_ -> this")
+    public DimensionTypeBuilder hasFixedTime(final boolean hasFixedTime) {
+        this.hasFixedTime = hasFixedTime;
+        return this;
+    }
+
+    /**
+     * @param monsterSpawnBlockLightLimit block light must be at or below this, within {@code [0, 15]},
+     *                                    for monsters to spawn
+     * @return this builder
+     */
+    @Contract("_ -> this")
+    public DimensionTypeBuilder monsterSpawnBlockLightLimit(final int monsterSpawnBlockLightLimit) {
+        this.monsterSpawnBlockLightLimit = monsterSpawnBlockLightLimit;
+        return this;
+    }
+
+    /**
+     * @param monsterSpawnLightLevel the computed light level must be at or below this for monsters
+     *                               to spawn
+     * @return this builder
+     */
+    @Contract("_ -> this")
+    public DimensionTypeBuilder monsterSpawnLightLevel(final IntProvider monsterSpawnLightLevel) {
+        this.monsterSpawnLightLevel = Objects.requireNonNull(monsterSpawnLightLevel, "monsterSpawnLightLevel");
+        return this;
+    }
+
+    /**
+     * Shorthand for {@link #monsterSpawnLightLevel(IntProvider)} with a constant value.
+     *
+     * @param constant the light level, within {@code [0, 15]}
+     * @return this builder
+     */
+    @Contract("_ -> this")
+    public DimensionTypeBuilder monsterSpawnLightLevel(final int constant) {
+        this.monsterSpawnLightLevel = IntProvider.constant(constant);
+        return this;
+    }
+
+    /**
+     * @param logicalHeight the maximum height chorus fruits and Nether portals bring
+     *                      players to; must not exceed {@link #height(int)}
+     * @return this builder
+     */
+    @Contract("_ -> this")
+    public DimensionTypeBuilder logicalHeight(final int logicalHeight) {
+        this.logicalHeight = logicalHeight;
+        return this;
+    }
+
+    /**
+     * @param minY lowest buildable height, a multiple of 16 within {@code [-2032, 2031]}
+     * @return this builder
+     */
+    @Contract("_ -> this")
+    public DimensionTypeBuilder minY(final int minY) {
+        this.minY = minY;
+        return this;
+    }
+
+    /**
+     * @param height total buildable height, a multiple of 16 within {@code [16, 4064]};
+     *               {@code minY + height - 1} must not exceed {@code 2031}
+     * @return this builder
+     */
+    @Contract("_ -> this")
+    public DimensionTypeBuilder height(final int height) {
+        this.height = height;
+        return this;
+    }
+
+    /**
+     * Sets {@link #minY(int)} and {@link #height(int)} together, leaving
+     * {@link #logicalHeight(int)} untouched.
+     *
+     * @param minY   lowest buildable height
+     * @param height total buildable height
+     * @return this builder
+     */
+    @Contract("_, _ -> this")
+    public DimensionTypeBuilder bounds(final int minY, final int height) {
+        this.minY = minY;
+        this.height = height;
+        return this;
+    }
+
+    /**
+     * @param infiniburn the block tag whose blocks burn forever
+     * @return this builder
+     */
+    @Contract("_ -> this")
+    public DimensionTypeBuilder infiniburn(final Key infiniburn) {
+        this.infiniburn = Objects.requireNonNull(infiniburn, "infiniburn");
+        return this;
+    }
+
+    /**
+     * @param skybox which skybox the client renders
+     * @return this builder
+     */
+    @Contract("_ -> this")
+    public DimensionTypeBuilder skybox(final Skybox skybox) {
+        this.skybox = Objects.requireNonNull(skybox, "skybox");
+        return this;
+    }
+
+    /**
+     * @param cardinalLight which direction cardinal light comes from
+     * @return this builder
+     */
+    @Contract("_ -> this")
+    public DimensionTypeBuilder cardinalLight(final CardinalLight cardinalLight) {
+        this.cardinalLight = Objects.requireNonNull(cardinalLight, "cardinalLight");
+        return this;
+    }
+
+    /**
+     * Replaces the whole environment attribute map.
+     *
+     * @param attributes the environment attributes this dimension sets
+     * @return this builder
+     */
+    @Contract("_ -> this")
+    public DimensionTypeBuilder attributes(final EnvironmentAttributes attributes) {
+        this.attributes = EnvironmentAttributes.builder(attributes);
+        return this;
+    }
+
+    /**
+     * Configures the environment attributes in place, starting from what is already set.
+     *
+     * @param configurer callback receiving the attribute builder
+     * @return this builder
+     */
+    @Contract("_ -> this")
+    public DimensionTypeBuilder attributes(final Consumer<EnvironmentAttributes.Builder> configurer) {
+        configurer.accept(this.attributes);
+        return this;
+    }
+
+    /**
+     * @param defaultClock the world clock used as default for this dimension, or
+     *                     {@code null} if it has none
+     * @return this builder
+     */
+    @Contract("_ -> this")
+    public DimensionTypeBuilder defaultClock(final @Nullable Key defaultClock) {
+        this.defaultClock = defaultClock;
+        return this;
+    }
+
+    /**
+     * Adds one timeline to the list of timelines active in this dimension.
+     *
+     * @param timeline the timeline to add
+     * @return this builder
+     */
+    @Contract("_ -> this")
+    public DimensionTypeBuilder addTimeline(final TimelineReference timeline) {
+        this.timelines.add(Objects.requireNonNull(timeline, "timeline"));
+        return this;
+    }
+
+    /**
+     * Replaces the whole list of timelines active in this dimension.
+     *
+     * @param timelines the timelines
+     * @return this builder
+     */
+    @Contract("_ -> this")
+    public DimensionTypeBuilder timelines(final List<TimelineReference> timelines) {
+        this.timelines.clear();
+        this.timelines.addAll(timelines);
+        return this;
+    }
+
+    /**
+     * {@return the immutable definition described by this builder}
+     */
+    @Contract("-> new")
+    public DimensionTypeDefinition build() {
+        return new DimensionTypeDefinition(
+                key,
+                coordinateScale,
+                hasSkylight,
+                hasCeiling,
+                hasEnderDragonFight,
+                ambientLight,
+                hasFixedTime,
+                monsterSpawnBlockLightLimit,
+                monsterSpawnLightLevel,
+                logicalHeight,
+                minY,
+                height,
+                infiniburn,
+                skybox,
+                cardinalLight,
+                attributes.build(),
+                defaultClock,
+                List.copyOf(timelines));
+    }
+}

--- a/fidorial-api/src/main/java/fr/fidorial/world/dimension/DimensionTypeDefinition.java
+++ b/fidorial-api/src/main/java/fr/fidorial/world/dimension/DimensionTypeDefinition.java
@@ -1,0 +1,124 @@
+package fr.fidorial.world.dimension;
+
+import fr.fidorial.registry.RegistryKey;
+import fr.fidorial.registry.TypedKey;
+import fr.fidorial.registry.data.DimensionType;
+import fr.fidorial.world.environment.EnvironmentAttributes;
+import net.kyori.adventure.key.Key;
+import org.jetbrains.annotations.Contract;
+import org.jspecify.annotations.Nullable;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * A complete dimension type definition, ready to be sent to clients.
+ *
+ * @param key                        the namespaced identifier of the dimension type
+ * @param coordinateScale            multiplier applied to coordinates when leaving the dimension,
+ *                                   within {@code [0.00001, 30000000.0]}
+ * @param hasSkylight                whether the dimension has skylight; disables weather when {@code false}
+ * @param hasCeiling                 whether the dimension has a logical bedrock ceiling
+ * @param hasEnderDragonFight        whether this dimension can host an ender dragon fight
+ * @param ambientLight               how much light the dimension has regardless of the light level
+ * @param hasFixedTime               whether this dimension has fixed time
+ * @param monsterSpawnBlockLightLimit block light must be at or below this, within {@code [0, 15]},
+ *                                    for monsters to spawn
+ * @param monsterSpawnLightLevel     the computed light level must be at or below this for monsters
+ *                                   to spawn
+ * @param logicalHeight              the maximum height chorus fruits and Nether portals bring
+ *                                   players to; must not exceed {@code height}
+ * @param minY                       lowest buildable height, a multiple of 16 within {@code [-2032, 2031]}
+ * @param height                     total buildable height, a multiple of 16 within {@code [16, 4064]};
+ *                                   {@code minY + height - 1} must not exceed {@code 2031}
+ * @param infiniburn                 the block tag whose blocks burn forever
+ * @param skybox                     which skybox the client renders
+ * @param cardinalLight              which direction cardinal light comes from
+ * @param attributes                 the environment attributes this dimension sets, possibly empty
+ * @param defaultClock               the world clock used as default for this dimension, or
+ *                                   {@code null} if it has none
+ * @param timelines                  the timelines active in this dimension, possibly empty
+ * @since 0.1.0
+ */
+public record DimensionTypeDefinition(
+        Key key,
+        double coordinateScale,
+        boolean hasSkylight,
+        boolean hasCeiling,
+        boolean hasEnderDragonFight,
+        float ambientLight,
+        boolean hasFixedTime,
+        int monsterSpawnBlockLightLimit,
+        IntProvider monsterSpawnLightLevel,
+        int logicalHeight,
+        int minY,
+        int height,
+        Key infiniburn,
+        Skybox skybox,
+        CardinalLight cardinalLight,
+        EnvironmentAttributes attributes,
+        @Nullable Key defaultClock,
+        List<TimelineReference> timelines
+) implements DimensionType {
+
+    public DimensionTypeDefinition {
+        Objects.requireNonNull(key, "key");
+        Objects.requireNonNull(monsterSpawnLightLevel, "monsterSpawnLightLevel");
+        Objects.requireNonNull(infiniburn, "infiniburn");
+        Objects.requireNonNull(skybox, "skybox");
+        Objects.requireNonNull(cardinalLight, "cardinalLight");
+        Objects.requireNonNull(attributes, "attributes");
+        timelines = List.copyOf(timelines);
+
+        if (coordinateScale < 0.00001D || coordinateScale > 30_000_000.0D) {
+            throw new IllegalArgumentException(
+                    "coordinateScale must be within [0.00001, 30000000.0], got " + coordinateScale);
+        }
+        if (monsterSpawnBlockLightLimit < 0 || monsterSpawnBlockLightLimit > 15) {
+            throw new IllegalArgumentException(
+                    "monsterSpawnBlockLightLimit must be within [0, 15], got " + monsterSpawnBlockLightLimit);
+        }
+        if (minY < -2032 || minY > 2031 || minY % 16 != 0) {
+            throw new IllegalArgumentException("minY must be a multiple of 16 within [-2032, 2031], got " + minY);
+        }
+        if (height < 16 || height > 4064 || height % 16 != 0) {
+            throw new IllegalArgumentException("height must be a multiple of 16 within [16, 4064], got " + height);
+        }
+        if (minY + height - 1 > 2031) {
+            throw new IllegalArgumentException(
+                    "minY + height - 1 must not exceed 2031, got " + (minY + height - 1));
+        }
+        if (logicalHeight > height) {
+            throw new IllegalArgumentException(
+                    "logicalHeight (" + logicalHeight + ") must not exceed height (" + height + ")");
+        }
+    }
+
+    /**
+     * {@return a new builder for the dimension type identified by {@code key}}
+     *
+     * @param key the namespaced identifier of the dimension type
+     */
+    @Contract(value = "_ -> new", pure = true)
+    public static DimensionTypeBuilder builder(final Key key) {
+        return new DimensionTypeBuilder(key);
+    }
+
+    /**
+     * {@return a new builder pre-filled with the values of {@code definition}}
+     *
+     * @param definition the definition to copy
+     */
+    @Contract(value = "_ -> new", pure = true)
+    public static DimensionTypeBuilder builder(final DimensionTypeDefinition definition) {
+        return new DimensionTypeBuilder(definition);
+    }
+
+    /**
+     * {@return this dimension type's key, typed against the {@code minecraft:dimension_type} registry}
+     */
+    @Contract(value = "-> new", pure = true)
+    public TypedKey<DimensionType> typedKey() {
+        return TypedKey.create(RegistryKey.DIMENSION_TYPE, key);
+    }
+}

--- a/fidorial-api/src/main/java/fr/fidorial/world/dimension/DimensionTypeRegistry.java
+++ b/fidorial-api/src/main/java/fr/fidorial/world/dimension/DimensionTypeRegistry.java
@@ -1,0 +1,140 @@
+package fr.fidorial.world.dimension;
+
+import fr.fidorial.registry.TypedKey;
+import fr.fidorial.registry.data.DimensionType;
+import net.kyori.adventure.key.Key;
+import org.jetbrains.annotations.Contract;
+
+import java.util.Collection;
+import java.util.Optional;
+
+/**
+ * Server-wide registry of dimension types, holding both the vanilla ones and those added by
+ * plugins.
+ *
+ * @since 0.1.0
+ */
+public interface DimensionTypeRegistry {
+
+    /**
+     * Registers a new dimension type.
+     *
+     * @param definition the dimension type to add
+     * @return the registered definition
+     * @throws IllegalStateException if a dimension type is already registered under the same key;
+     *                               use {@link #overwrite(DimensionTypeDefinition)} to replace it
+     *                               on purpose
+     * @since 0.1.0
+     */
+    @Contract("_ -> param1")
+    DimensionTypeDefinition register(DimensionTypeDefinition definition);
+
+    /**
+     * Builds and registers a new dimension type.
+     *
+     * @param builder the builder describing the dimension type
+     * @return the registered definition
+     * @throws IllegalStateException if a dimension type is already registered under the same key
+     * @since 0.1.0
+     */
+    default DimensionTypeDefinition register(final DimensionTypeBuilder builder) {
+        return register(builder.build());
+    }
+
+    /**
+     * Reads a dimension type from its data pack JSON representation and registers it.
+     *
+     * @param key  the key to register the dimension type under
+     * @param json the JSON object describing the dimension type
+     * @return the registered definition
+     * @throws IllegalArgumentException if the JSON is malformed or misses a mandatory field
+     * @throws IllegalStateException    if a dimension type is already registered under the same key
+     * @since 0.1.0
+     */
+    DimensionTypeDefinition registerFromJson(Key key, String json);
+
+    /**
+     * Registers a dimension type, replacing any existing one sharing its key.
+     *
+     * @param definition the dimension type to add or replace
+     * @return the definition previously registered under that key, if any
+     * @since 0.1.0
+     */
+    Optional<DimensionTypeDefinition> overwrite(DimensionTypeDefinition definition);
+
+    /**
+     * Removes a dimension type from the registry.
+     *
+     * @param key the key of the dimension type to remove
+     * @return {@code true} if a dimension type was removed, {@code false} if none was registered
+     * @since 0.1.0
+     */
+    boolean unregister(Key key);
+
+    /**
+     * Removes a dimension type from the registry.
+     *
+     * @param key the typed key of the dimension type to remove
+     * @return {@code true} if a dimension type was removed, {@code false} if none was registered
+     * @since 0.1.0
+     */
+    default boolean unregister(final TypedKey<DimensionType> key) {
+        return unregister(key.key());
+    }
+
+    /**
+     * {@return the definition registered under {@code key}, if that dimension type carries one}
+     *
+     * @param key the dimension type key
+     * @since 0.1.0
+     */
+    Optional<DimensionTypeDefinition> definition(Key key);
+
+    /**
+     * {@return whether a dimension type is registered under {@code key}}
+     *
+     * @param key the dimension type key
+     * @since 0.1.0
+     */
+    boolean contains(Key key);
+
+    /**
+     * {@return whether {@code key} maps to a dimension type defined by this server rather than a
+     * stock vanilla one}
+     *
+     * @param key the dimension type key
+     * @since 0.1.0
+     */
+    boolean isCustom(Key key);
+
+    /**
+     * {@return every registered dimension type key, in network order}
+     *
+     * @since 0.1.0
+     */
+    @Contract(pure = true)
+    Collection<Key> keys();
+
+    /**
+     * {@return every dimension type defined by this server, vanilla overrides included}
+     *
+     * @since 0.1.0
+     */
+    @Contract(pure = true)
+    Collection<DimensionTypeDefinition> definitions();
+
+    /**
+     * {@return the network identifier of {@code key}, or {@code -1} if it is not registered}
+     *
+     * @param key the dimension type key
+     * @since 0.1.0
+     */
+    int networkId(Key key);
+
+    /**
+     * {@return the number of registered dimension types}
+     *
+     * @since 0.1.0
+     */
+    int totalRegistered();
+}

--- a/fidorial-api/src/main/java/fr/fidorial/world/dimension/IntProvider.java
+++ b/fidorial-api/src/main/java/fr/fidorial/world/dimension/IntProvider.java
@@ -1,0 +1,177 @@
+package fr.fidorial.world.dimension;
+
+import org.jetbrains.annotations.Contract;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * A value, or a random distribution of values, used by
+ * {@link DimensionTypeDefinition#monsterSpawnLightLevel()}.
+ *
+ * @since 0.1.0
+ */
+public sealed interface IntProvider
+        permits IntProvider.Constant, IntProvider.Uniform, IntProvider.BiasedToBottom,
+        IntProvider.Clamped, IntProvider.ClampedNormal, IntProvider.WeightedList {
+
+    /**
+     * {@return a provider always yielding {@code value}}
+     *
+     * @param value the constant value
+     */
+    @Contract(value = "_ -> new", pure = true)
+    static IntProvider constant(final int value) {
+        return new Constant(value);
+    }
+
+    /**
+     * {@return a provider picking uniformly within {@code [minInclusive, maxInclusive]}}
+     *
+     * @param minInclusive the minimum possible value
+     * @param maxInclusive the maximum possible value
+     */
+    @Contract(value = "_, _ -> new", pure = true)
+    static IntProvider uniform(final int minInclusive, final int maxInclusive) {
+        return new Uniform(minInclusive, maxInclusive);
+    }
+
+    /**
+     * {@return a provider within {@code [minInclusive, maxInclusive]}, weighted towards the bottom}
+     *
+     * @param minInclusive the minimum possible value
+     * @param maxInclusive the maximum possible value
+     */
+    @Contract(value = "_, _ -> new", pure = true)
+    static IntProvider biasedToBottom(final int minInclusive, final int maxInclusive) {
+        return new BiasedToBottom(minInclusive, maxInclusive);
+    }
+
+    /**
+     * {@return {@code source}, clamped to {@code [minInclusive, maxInclusive]}}
+     *
+     * @param minInclusive the minimum allowed value
+     * @param maxInclusive the maximum allowed value
+     * @param source       the provider being clamped
+     */
+    @Contract(value = "_, _, _ -> new", pure = true)
+    static IntProvider clamped(final int minInclusive, final int maxInclusive, final IntProvider source) {
+        return new Clamped(minInclusive, maxInclusive, source);
+    }
+
+    /**
+     * {@return a provider following a normal distribution, clamped to {@code [minInclusive, maxInclusive]}}
+     *
+     * @param mean         the mean of the normal distribution
+     * @param deviation    the deviation of the normal distribution
+     * @param minInclusive the minimum allowed value
+     * @param maxInclusive the maximum allowed value
+     */
+    @Contract(value = "_, _, _, _ -> new", pure = true)
+    static IntProvider clampedNormal(
+            final float mean, final float deviation, final int minInclusive, final int maxInclusive) {
+        return new ClampedNormal(mean, deviation, minInclusive, maxInclusive);
+    }
+
+    /**
+     * {@return a provider picking randomly among {@code distribution}, honoring each entry's weight}
+     *
+     * @param distribution the pool to pick from, never empty
+     */
+    @Contract(value = "_ -> new", pure = true)
+    static IntProvider weightedList(final List<WeightedList.Entry> distribution) {
+        return new WeightedList(distribution);
+    }
+
+    /**
+     * @param value the constant value
+     * @since 0.1.0
+     */
+    record Constant(int value) implements IntProvider {
+    }
+
+    /**
+     * @param minInclusive the minimum possible value
+     * @param maxInclusive the maximum possible value
+     * @since 0.1.0
+     */
+    record Uniform(int minInclusive, int maxInclusive) implements IntProvider {
+        public Uniform {
+            requireOrdered(minInclusive, maxInclusive);
+        }
+    }
+
+    /**
+     * @param minInclusive the minimum possible value
+     * @param maxInclusive the maximum possible value
+     * @since 0.1.0
+     */
+    record BiasedToBottom(int minInclusive, int maxInclusive) implements IntProvider {
+        public BiasedToBottom {
+            requireOrdered(minInclusive, maxInclusive);
+        }
+    }
+
+    /**
+     * @param minInclusive the minimum allowed value that the result will be
+     * @param maxInclusive the maximum allowed value that the result will be
+     * @param source       the provider being clamped
+     * @since 0.1.0
+     */
+    record Clamped(int minInclusive, int maxInclusive, IntProvider source) implements IntProvider {
+        public Clamped {
+            requireOrdered(minInclusive, maxInclusive);
+            Objects.requireNonNull(source, "source");
+        }
+    }
+
+    /**
+     * @param mean         the mean of the normal distribution
+     * @param deviation    the deviation of the normal distribution
+     * @param minInclusive the minimum allowed value that the result will be
+     * @param maxInclusive the maximum allowed value that the result will be
+     * @since 0.1.0
+     */
+    record ClampedNormal(float mean, float deviation, int minInclusive, int maxInclusive) implements IntProvider {
+        public ClampedNormal {
+            requireOrdered(minInclusive, maxInclusive);
+        }
+    }
+
+    /**
+     * @param distribution the pool of weighted entries to pick from, never empty
+     * @since 0.1.0
+     */
+    record WeightedList(List<Entry> distribution) implements IntProvider {
+
+        public WeightedList {
+            distribution = List.copyOf(distribution);
+            if (distribution.isEmpty()) {
+                throw new IllegalArgumentException("distribution must not be empty");
+            }
+        }
+
+        /**
+         * One entry of a {@link WeightedList}.
+         *
+         * @param data   the value or nested provider this entry yields
+         * @param weight this entry's weight; must be positive
+         * @since 0.1.0
+         */
+        public record Entry(IntProvider data, int weight) {
+            public Entry {
+                Objects.requireNonNull(data, "data");
+                if (weight <= 0) {
+                    throw new IllegalArgumentException("weight must be positive, got " + weight);
+                }
+            }
+        }
+    }
+
+    private static void requireOrdered(final int minInclusive, final int maxInclusive) {
+        if (maxInclusive < minInclusive) {
+            throw new IllegalArgumentException(
+                    "maxInclusive (" + maxInclusive + ") must not be less than minInclusive (" + minInclusive + ")");
+        }
+    }
+}

--- a/fidorial-api/src/main/java/fr/fidorial/world/dimension/Skybox.java
+++ b/fidorial-api/src/main/java/fr/fidorial/world/dimension/Skybox.java
@@ -1,0 +1,26 @@
+package fr.fidorial.world.dimension;
+
+/**
+ * Which skybox the client renders for a dimension.
+ *
+ * @since 0.1.0
+ */
+public enum Skybox {
+
+    NONE("none"),
+    OVERWORLD("overworld"),
+    END("end");
+
+    private final String id;
+
+    Skybox(final String id) {
+        this.id = id;
+    }
+
+    /**
+     * {@return the identifier expected on the wire}
+     */
+    public String id() {
+        return id;
+    }
+}

--- a/fidorial-api/src/main/java/fr/fidorial/world/dimension/TimelineReference.java
+++ b/fidorial-api/src/main/java/fr/fidorial/world/dimension/TimelineReference.java
@@ -1,0 +1,53 @@
+package fr.fidorial.world.dimension;
+
+import net.kyori.adventure.key.Key;
+import org.jetbrains.annotations.Contract;
+
+import java.util.Objects;
+
+/**
+ * A reference to a single object specified by {@link DimensionTypeDefinition#timelines()}
+ * It can be either a single timeline or a tag grouping several.
+ *
+ * @since 0.1.0
+ */
+public sealed interface TimelineReference permits TimelineReference.Id, TimelineReference.Tag {
+
+    /**
+     * @param key the timeline's namespaced identifier
+     * @return the reference
+     */
+    @Contract(value = "_ -> new", pure = true)
+    static TimelineReference id(final Key key) {
+        return new Id(key);
+    }
+
+    /**
+     * @param key the tag's namespaced identifier, without the leading {@code #}
+     * @return the reference
+     */
+    @Contract(value = "_ -> new", pure = true)
+    static TimelineReference tag(final Key key) {
+        return new Tag(key);
+    }
+
+    /**
+     * @param key the timeline's namespaced identifier
+     * @since 0.1.0
+     */
+    record Id(Key key) implements TimelineReference {
+        public Id {
+            Objects.requireNonNull(key, "key");
+        }
+    }
+
+    /**
+     * @param key the tag's namespaced identifier, without the leading {@code #}
+     * @since 0.1.0
+     */
+    record Tag(Key key) implements TimelineReference {
+        public Tag {
+            Objects.requireNonNull(key, "key");
+        }
+    }
+}

--- a/fidorial-api/src/main/java/fr/fidorial/world/environment/BedRule.java
+++ b/fidorial-api/src/main/java/fr/fidorial/world/environment/BedRule.java
@@ -1,0 +1,95 @@
+package fr.fidorial.world.environment;
+
+import net.kyori.adventure.text.Component;
+
+import java.util.Optional;
+
+/**
+ * Controls whether beds can be used to sleep or set a spawn point in a dimension.
+ *
+ * @since 0.1.0
+ */
+public record BedRule(AccessCondition sleepAllowed, AccessCondition spawnAllowed, boolean explodes, Optional<Component> failureMessage) {
+
+    /**
+     * Allows beds to always be used to sleep and set a spawn point.
+     *
+     * @return bed rule
+     * @since 0.1.0
+     */
+    public static BedRule alwaysAllowed() {
+        return new BedRule(AccessCondition.ALWAYS, AccessCondition.ALWAYS, false, Optional.empty());
+    }
+
+    /**
+     * Allows beds to only be used to sleep and set a spawn point when its nighttime.
+     *
+     * @return bed rule
+     * @since 0.1.0
+     */
+    public static BedRule allowedAtNight() {
+        return new BedRule(AccessCondition.WHEN_DARK, AccessCondition.ALWAYS, false, Optional.empty());
+    }
+
+    /**
+     * Allows beds to only be used to sleep and set a spawn point when its nighttime.
+     *
+     * @param reason the reason shown to the player for why sleep is not allowed
+     * @return bed rule
+     * @since 0.1.0
+     */
+    public static BedRule allowedAtNight(final Component reason) {
+        return new BedRule(AccessCondition.WHEN_DARK, AccessCondition.ALWAYS, false, Optional.of(reason));
+    }
+
+    /**
+     * Forbids beds from ever being used to sleep and set a spawn point.
+     *
+     * @return bed rule
+     * @since 0.1.0
+     */
+    public static BedRule neverAllowed() {
+        return new BedRule(AccessCondition.NEVER, AccessCondition.NEVER, true, Optional.empty());
+    }
+
+    /**
+     * Controls when a particular bed action is permitted.
+     *
+     * @since 0.1.0
+     */
+    public enum AccessCondition {
+        /**
+         * Always permitted, regardless of the day time.
+         */
+        ALWAYS("always"),
+
+        /**
+         * Only permitted during nighttime.
+         */
+        WHEN_DARK("when_dark"),
+
+        /**
+         * Never permitted.
+         */
+        NEVER("never");
+
+        private final String id;
+
+        AccessCondition(final String id) {
+            this.id = id;
+        }
+
+        public String id() {
+            return this.id;
+        }
+
+        public static Optional<AccessCondition> fromId(final String id) {
+            for (final AccessCondition access : values()) {
+                if (access.id.equals(id)) {
+                    return Optional.of(access);
+                }
+            }
+            return Optional.empty();
+        }
+    }
+}

--- a/fidorial-api/src/main/java/fr/fidorial/world/environment/EnvironmentAttributes.java
+++ b/fidorial-api/src/main/java/fr/fidorial/world/environment/EnvironmentAttributes.java
@@ -1,5 +1,6 @@
 package fr.fidorial.world.environment;
 
+import net.kyori.adventure.key.Key;
 import org.jetbrains.annotations.Contract;
 import org.jspecify.annotations.Nullable;
 
@@ -9,38 +10,60 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * @param fogColor               distance fog color, packed RGB — {@code minecraft:visual/fog_color}
- * @param skyColor               sky color, packed RGB — {@code minecraft:visual/sky_color}
- * @param waterFogColor          underwater fog color, packed RGB — {@code minecraft:visual/water_fog_color}
- * @param waterFogEndDistance    distance in blocks at which underwater fog reaches full density — {@code minecraft:visual/water_fog_end_distance}
- * @param extraFog               whether to use dense, Nether-like fog — {@code minecraft:visual/extra_fog}
- * @param musicVolume            volume music fades to, within {@code [0, 1]} — {@code minecraft:audio/music_volume}
- * @param canStartRaid           whether a raid can begin here — {@code minecraft:gameplay/can_start_raid}
- * @param canPillagerPatrolSpawn whether pillager patrols spawn here — {@code minecraft:gameplay/can_pillager_patrol_spawn}
- * @param waterEvaporates        whether placed water evaporates — {@code minecraft:gameplay/water_evaporates}
- * @param respawnAnchorWorks     whether respawn anchors set spawn instead of exploding — {@code minecraft:gameplay/respawn_anchor_works}
- * @param increasedFireBurnout   whether fire burns out faster — {@code minecraft:gameplay/increased_fire_burnout}
- * @param piglinsZombify         whether piglins and hoglins zombify — {@code minecraft:gameplay/piglins_zombify}
- * @param snowGolemMelts         whether snow golems take damage — {@code minecraft:gameplay/snow_golem_melts}
- * @param ambientParticles       particles randomly spawned around the camera, possibly empty — {@code minecraft:visual/ambient_particles}
- * @param ambientSounds          looping, mood and additions sounds — {@code minecraft:audio/ambient_sounds}
- * @param backgroundMusic        music tracks — {@code minecraft:audio/background_music}
+ * @param fogColor                    distance fog color, packed RGB — {@code minecraft:visual/fog_color}
+ * @param fogStartDistance            distance in blocks at which fog begins — {@code minecraft:visual/fog_start_distance}
+ * @param fogEndDistance               distance in blocks at which fog reaches full density — {@code minecraft:visual/fog_end_distance}
+ * @param skyColor                    sky color, packed RGB — {@code minecraft:visual/sky_color}
+ * @param cloudColor                  cloud color, packed ARGB — {@code minecraft:visual/cloud_color}
+ * @param cloudHeight                 height, in blocks, at which clouds render — {@code minecraft:visual/cloud_height}
+ * @param skyLightColor               sky light color, packed RGB — {@code minecraft:visual/sky_light_color}
+ * @param skyLightFactor              multiplier applied to sky light, within {@code [0, 1]} — {@code minecraft:visual/sky_light_factor}
+ * @param ambientLightColor           ambient light color, packed RGB — {@code minecraft:visual/ambient_light_color}
+ * @param defaultDripstoneParticle    particle used by dripping dripstone — {@code minecraft:visual/default_dripstone_particle}
+ * @param waterFogColor               underwater fog color, packed RGB — {@code minecraft:visual/water_fog_color}
+ * @param waterFogEndDistance         distance in blocks at which underwater fog reaches full density — {@code minecraft:visual/water_fog_end_distance}
+ * @param musicVolume                 volume music fades to, within {@code [0, 1]} — {@code minecraft:audio/music_volume}
+ * @param canStartRaid                whether a raid can begin here — {@code minecraft:gameplay/can_start_raid}
+ * @param canPillagerPatrolSpawn      whether pillager patrols spawn here — {@code minecraft:gameplay/can_pillager_patrol_spawn}
+ * @param waterEvaporates             whether placed water evaporates — {@code minecraft:gameplay/water_evaporates}
+ * @param bedRule                     when beds are usable to sleep/set spawn — {@code minecraft:gameplay/bed_rule}
+ * @param respawnAnchorWorks          whether respawn anchors set spawn instead of exploding — {@code minecraft:gameplay/respawn_anchor_works}
+ * @param netherPortalSpawnsPiglin    whether entering a nether portal can spawn a piglin — {@code minecraft:gameplay/nether_portal_spawns_piglin}
+ * @param fastLava                    whether lava flows and spreads at Nether speed — {@code minecraft:gameplay/fast_lava}
+ * @param increasedFireBurnout        whether fire burns out faster — {@code minecraft:gameplay/increased_fire_burnout}
+ * @param piglinsZombify              whether piglins and hoglins zombify — {@code minecraft:gameplay/piglins_zombify}
+ * @param snowGolemMelts              whether snow golems take damage — {@code minecraft:gameplay/snow_golem_melts}
+ * @param skyLightLevel               sky light level, within {@code [0, 15]} — {@code minecraft:gameplay/sky_light_level}
+ * @param ambientParticles            particles randomly spawned around the camera, possibly empty — {@code minecraft:visual/ambient_particles}
+ * @param ambientSounds                looping, mood and additions sounds — {@code minecraft:audio/ambient_sounds}
+ * @param backgroundMusic              music tracks — {@code minecraft:audio/background_music}
  * @since 0.1.0
  */
 public record EnvironmentAttributes(
         @Nullable Attribute<Integer> fogColor,
+        @Nullable Attribute<Float> fogStartDistance,
+        @Nullable Attribute<Float> fogEndDistance,
         @Nullable Attribute<Integer> skyColor,
+        @Nullable Attribute<Integer> cloudColor,
+        @Nullable Attribute<Float> cloudHeight,
+        @Nullable Attribute<Integer> skyLightColor,
+        @Nullable Attribute<Float> skyLightFactor,
+        @Nullable Attribute<Integer> ambientLightColor,
+        @Nullable Attribute<Key> defaultDripstoneParticle,
         @Nullable Attribute<Integer> waterFogColor,
         @Nullable Attribute<Float> waterFogEndDistance,
-        @Nullable Attribute<Boolean> extraFog,
         @Nullable Attribute<Float> musicVolume,
         @Nullable Attribute<Boolean> canStartRaid,
         @Nullable Attribute<Boolean> canPillagerPatrolSpawn,
         @Nullable Attribute<Boolean> waterEvaporates,
+        @Nullable Attribute<BedRule> bedRule,
         @Nullable Attribute<Boolean> respawnAnchorWorks,
+        @Nullable Attribute<Boolean> netherPortalSpawnsPiglin,
+        @Nullable Attribute<Boolean> fastLava,
         @Nullable Attribute<Boolean> increasedFireBurnout,
         @Nullable Attribute<Boolean> piglinsZombify,
         @Nullable Attribute<Boolean> snowGolemMelts,
+        @Nullable Attribute<Float> skyLightLevel,
         List<AmbientParticle> ambientParticles,
         @Nullable AmbientSounds ambientSounds,
         @Nullable BackgroundMusic backgroundMusic
@@ -99,18 +122,29 @@ public record EnvironmentAttributes(
     public static final class Builder {
         private final List<AmbientParticle> ambientParticles = new ArrayList<>();
         private @Nullable Attribute<Integer> fogColor;
+        private @Nullable Attribute<Float> fogStartDistance;
+        private @Nullable Attribute<Float> fogEndDistance;
         private @Nullable Attribute<Integer> skyColor;
+        private @Nullable Attribute<Integer> cloudColor;
+        private @Nullable Attribute<Float> cloudHeight;
+        private @Nullable Attribute<Integer> skyLightColor;
+        private @Nullable Attribute<Float> skyLightFactor;
+        private @Nullable Attribute<Integer> ambientLightColor;
+        private @Nullable Attribute<Key> defaultDripstoneParticle;
         private @Nullable Attribute<Integer> waterFogColor;
         private @Nullable Attribute<Float> waterFogEndDistance;
-        private @Nullable Attribute<Boolean> extraFog;
         private @Nullable Attribute<Float> musicVolume;
         private @Nullable Attribute<Boolean> canStartRaid;
         private @Nullable Attribute<Boolean> canPillagerPatrolSpawn;
         private @Nullable Attribute<Boolean> waterEvaporates;
+        private @Nullable Attribute<BedRule> bedRule;
         private @Nullable Attribute<Boolean> respawnAnchorWorks;
+        private @Nullable Attribute<Boolean> netherPortalSpawnsPiglin;
+        private @Nullable Attribute<Boolean> fastLava;
         private @Nullable Attribute<Boolean> increasedFireBurnout;
         private @Nullable Attribute<Boolean> piglinsZombify;
         private @Nullable Attribute<Boolean> snowGolemMelts;
+        private @Nullable Attribute<Float> skyLightLevel;
         private @Nullable AmbientSounds ambientSounds;
         private @Nullable BackgroundMusic backgroundMusic;
 
@@ -119,18 +153,29 @@ public record EnvironmentAttributes(
 
         private Builder(final EnvironmentAttributes attributes) {
             this.fogColor = attributes.fogColor;
+            this.fogStartDistance = attributes.fogStartDistance;
+            this.fogEndDistance = attributes.fogEndDistance;
             this.skyColor = attributes.skyColor;
+            this.cloudColor = attributes.cloudColor;
+            this.cloudHeight = attributes.cloudHeight;
+            this.skyLightColor = attributes.skyLightColor;
+            this.skyLightFactor = attributes.skyLightFactor;
+            this.ambientLightColor = attributes.ambientLightColor;
+            this.defaultDripstoneParticle = attributes.defaultDripstoneParticle;
             this.waterFogColor = attributes.waterFogColor;
             this.waterFogEndDistance = attributes.waterFogEndDistance;
-            this.extraFog = attributes.extraFog;
             this.musicVolume = attributes.musicVolume;
             this.canStartRaid = attributes.canStartRaid;
             this.canPillagerPatrolSpawn = attributes.canPillagerPatrolSpawn;
             this.waterEvaporates = attributes.waterEvaporates;
+            this.bedRule = attributes.bedRule;
             this.respawnAnchorWorks = attributes.respawnAnchorWorks;
+            this.netherPortalSpawnsPiglin = attributes.netherPortalSpawnsPiglin;
+            this.fastLava = attributes.fastLava;
             this.increasedFireBurnout = attributes.increasedFireBurnout;
             this.piglinsZombify = attributes.piglinsZombify;
             this.snowGolemMelts = attributes.snowGolemMelts;
+            this.skyLightLevel = attributes.skyLightLevel;
             this.ambientParticles.addAll(attributes.ambientParticles);
             this.ambientSounds = attributes.ambientSounds;
             this.backgroundMusic = attributes.backgroundMusic;
@@ -162,6 +207,56 @@ public record EnvironmentAttributes(
         }
 
         /**
+         * Sets {@code minecraft:visual/fog_start_distance} as a plain override.
+         *
+         * @param value distance in blocks at which fog begins, or {@code null} to leave unset
+         * @return this builder
+         */
+        @Contract("_ -> this")
+        public Builder fogStartDistance(final @Nullable Float value) {
+            this.fogStartDistance = value == null ? null : Attribute.of(value);
+            return this;
+        }
+
+        /**
+         * Sets {@code minecraft:visual/fog_start_distance}, deriving from the dimension's value.
+         *
+         * @param value    the modifier argument
+         * @param modifier how to combine it
+         * @return this builder
+         */
+        @Contract("_, _ -> this")
+        public Builder fogStartDistance(final Float value, final Modifier modifier) {
+            this.fogStartDistance = Attribute.of(value, modifier);
+            return this;
+        }
+
+        /**
+         * Sets {@code minecraft:visual/fog_end_distance} as a plain override.
+         *
+         * @param value distance in blocks at which fog reaches full density, or {@code null} to leave unset
+         * @return this builder
+         */
+        @Contract("_ -> this")
+        public Builder fogEndDistance(final @Nullable Float value) {
+            this.fogEndDistance = value == null ? null : Attribute.of(value);
+            return this;
+        }
+
+        /**
+         * Sets {@code minecraft:visual/fog_end_distance}, deriving from the dimension's value.
+         *
+         * @param value    the modifier argument
+         * @param modifier how to combine it
+         * @return this builder
+         */
+        @Contract("_, _ -> this")
+        public Builder fogEndDistance(final Float value, final Modifier modifier) {
+            this.fogEndDistance = Attribute.of(value, modifier);
+            return this;
+        }
+
+        /**
          * Sets {@code minecraft:visual/sky_color} as a plain override.
          *
          * @param value sky color, packed RGB, or {@code null} to leave unset
@@ -183,6 +278,156 @@ public record EnvironmentAttributes(
         @Contract("_, _ -> this")
         public Builder skyColor(final Integer value, final Modifier modifier) {
             this.skyColor = Attribute.of(value, modifier);
+            return this;
+        }
+
+        /**
+         * Sets {@code minecraft:visual/cloud_color} as a plain override.
+         *
+         * @param value cloud color, packed ARGB, or {@code null} to leave unset
+         * @return this builder
+         */
+        @Contract("_ -> this")
+        public Builder cloudColor(final @Nullable Integer value) {
+            this.cloudColor = value == null ? null : Attribute.of(value);
+            return this;
+        }
+
+        /**
+         * Sets {@code minecraft:visual/cloud_color}, deriving from the dimension's value.
+         *
+         * @param value    the modifier argument
+         * @param modifier how to combine it
+         * @return this builder
+         */
+        @Contract("_, _ -> this")
+        public Builder cloudColor(final Integer value, final Modifier modifier) {
+            this.cloudColor = Attribute.of(value, modifier);
+            return this;
+        }
+
+        /**
+         * Sets {@code minecraft:visual/cloud_height} as a plain override.
+         *
+         * @param value height, in blocks, at which clouds render, or {@code null} to leave unset
+         * @return this builder
+         */
+        @Contract("_ -> this")
+        public Builder cloudHeight(final @Nullable Float value) {
+            this.cloudHeight = value == null ? null : Attribute.of(value);
+            return this;
+        }
+
+        /**
+         * Sets {@code minecraft:visual/cloud_height}, deriving from the dimension's value.
+         *
+         * @param value    the modifier argument
+         * @param modifier how to combine it
+         * @return this builder
+         */
+        @Contract("_, _ -> this")
+        public Builder cloudHeight(final Float value, final Modifier modifier) {
+            this.cloudHeight = Attribute.of(value, modifier);
+            return this;
+        }
+
+        /**
+         * Sets {@code minecraft:visual/sky_light_color} as a plain override.
+         *
+         * @param value sky light color, packed RGB, or {@code null} to leave unset
+         * @return this builder
+         */
+        @Contract("_ -> this")
+        public Builder skyLightColor(final @Nullable Integer value) {
+            this.skyLightColor = value == null ? null : Attribute.of(value);
+            return this;
+        }
+
+        /**
+         * Sets {@code minecraft:visual/sky_light_color}, deriving from the dimension's value.
+         *
+         * @param value    the modifier argument
+         * @param modifier how to combine it
+         * @return this builder
+         */
+        @Contract("_, _ -> this")
+        public Builder skyLightColor(final Integer value, final Modifier modifier) {
+            this.skyLightColor = Attribute.of(value, modifier);
+            return this;
+        }
+
+        /**
+         * Sets {@code minecraft:visual/sky_light_factor} as a plain override.
+         *
+         * @param value multiplier applied to sky light, within {@code [0, 1]}, or {@code null} to leave unset
+         * @return this builder
+         */
+        @Contract("_ -> this")
+        public Builder skyLightFactor(final @Nullable Float value) {
+            this.skyLightFactor = value == null ? null : Attribute.of(value);
+            return this;
+        }
+
+        /**
+         * Sets {@code minecraft:visual/sky_light_factor}, deriving from the dimension's value.
+         *
+         * @param value    the modifier argument
+         * @param modifier how to combine it
+         * @return this builder
+         */
+        @Contract("_, _ -> this")
+        public Builder skyLightFactor(final Float value, final Modifier modifier) {
+            this.skyLightFactor = Attribute.of(value, modifier);
+            return this;
+        }
+
+        /**
+         * Sets {@code minecraft:visual/ambient_light_color} as a plain override.
+         *
+         * @param value ambient light color, packed RGB, or {@code null} to leave unset
+         * @return this builder
+         */
+        @Contract("_ -> this")
+        public Builder ambientLightColor(final @Nullable Integer value) {
+            this.ambientLightColor = value == null ? null : Attribute.of(value);
+            return this;
+        }
+
+        /**
+         * Sets {@code minecraft:visual/ambient_light_color}, deriving from the dimension's value.
+         *
+         * @param value    the modifier argument
+         * @param modifier how to combine it
+         * @return this builder
+         */
+        @Contract("_, _ -> this")
+        public Builder ambientLightColor(final Integer value, final Modifier modifier) {
+            this.ambientLightColor = Attribute.of(value, modifier);
+            return this;
+        }
+
+        /**
+         * Sets {@code minecraft:visual/default_dripstone_particle} as a plain override.
+         *
+         * @param value particle used by dripping dripstone, or {@code null} to leave unset
+         * @return this builder
+         */
+        @Contract("_ -> this")
+        public Builder defaultDripstoneParticle(final @Nullable Key value) {
+            this.defaultDripstoneParticle = value == null ? null : Attribute.of(value);
+            return this;
+        }
+
+        /**
+         * Sets {@code minecraft:visual/default_dripstone_particle}, deriving from the dimension's value.
+         *
+         * @param value    the modifier argument
+         * @param modifier how to combine it
+         * @return this builder
+         */
+        @Contract("_, _ -> this")
+        public Builder defaultDripstoneParticle(final Key value, final Modifier modifier) {
+            this.defaultDripstoneParticle = Attribute.of(value, modifier);
             return this;
         }
 
@@ -233,31 +478,6 @@ public record EnvironmentAttributes(
         @Contract("_, _ -> this")
         public Builder waterFogEndDistance(final Float value, final Modifier modifier) {
             this.waterFogEndDistance = Attribute.of(value, modifier);
-            return this;
-        }
-
-        /**
-         * Sets {@code minecraft:visual/extra_fog} as a plain override.
-         *
-         * @param value whether to use dense, Nether-like fog, or {@code null} to leave unset
-         * @return this builder
-         */
-        @Contract("_ -> this")
-        public Builder extraFog(final @Nullable Boolean value) {
-            this.extraFog = value == null ? null : Attribute.of(value);
-            return this;
-        }
-
-        /**
-         * Sets {@code minecraft:visual/extra_fog}, deriving from the dimension's value.
-         *
-         * @param value    the modifier argument
-         * @param modifier how to combine it
-         * @return this builder
-         */
-        @Contract("_, _ -> this")
-        public Builder extraFog(final Boolean value, final Modifier modifier) {
-            this.extraFog = Attribute.of(value, modifier);
             return this;
         }
 
@@ -362,6 +582,31 @@ public record EnvironmentAttributes(
         }
 
         /**
+         * Sets {@code minecraft:gameplay/bed_rule} as a plain override.
+         *
+         * @param value when beds are usable to sleep/set spawn, or {@code null} to leave unset
+         * @return this builder
+         */
+        @Contract("_ -> this")
+        public Builder bedRule(final @Nullable BedRule value) {
+            this.bedRule = value == null ? null : Attribute.of(value);
+            return this;
+        }
+
+        /**
+         * Sets {@code minecraft:gameplay/bed_rule}, deriving from the dimension's value.
+         *
+         * @param value    the modifier argument
+         * @param modifier how to combine it
+         * @return this builder
+         */
+        @Contract("_, _ -> this")
+        public Builder bedRule(final BedRule value, final Modifier modifier) {
+            this.bedRule = Attribute.of(value, modifier);
+            return this;
+        }
+
+        /**
          * Sets {@code minecraft:gameplay/respawn_anchor_works} as a plain override.
          *
          * @param value whether respawn anchors set spawn instead of exploding, or {@code null} to leave unset
@@ -383,6 +628,56 @@ public record EnvironmentAttributes(
         @Contract("_, _ -> this")
         public Builder respawnAnchorWorks(final Boolean value, final Modifier modifier) {
             this.respawnAnchorWorks = Attribute.of(value, modifier);
+            return this;
+        }
+
+        /**
+         * Sets {@code minecraft:gameplay/nether_portal_spawns_piglin} as a plain override.
+         *
+         * @param value whether entering a nether portal can spawn a piglin, or {@code null} to leave unset
+         * @return this builder
+         */
+        @Contract("_ -> this")
+        public Builder netherPortalSpawnsPiglin(final @Nullable Boolean value) {
+            this.netherPortalSpawnsPiglin = value == null ? null : Attribute.of(value);
+            return this;
+        }
+
+        /**
+         * Sets {@code minecraft:gameplay/nether_portal_spawns_piglin}, deriving from the dimension's value.
+         *
+         * @param value    the modifier argument
+         * @param modifier how to combine it
+         * @return this builder
+         */
+        @Contract("_, _ -> this")
+        public Builder netherPortalSpawnsPiglin(final Boolean value, final Modifier modifier) {
+            this.netherPortalSpawnsPiglin = Attribute.of(value, modifier);
+            return this;
+        }
+
+        /**
+         * Sets {@code minecraft:gameplay/fast_lava} as a plain override.
+         *
+         * @param value whether lava flows and spreads at Nether speed, or {@code null} to leave unset
+         * @return this builder
+         */
+        @Contract("_ -> this")
+        public Builder fastLava(final @Nullable Boolean value) {
+            this.fastLava = value == null ? null : Attribute.of(value);
+            return this;
+        }
+
+        /**
+         * Sets {@code minecraft:gameplay/fast_lava}, deriving from the dimension's value.
+         *
+         * @param value    the modifier argument
+         * @param modifier how to combine it
+         * @return this builder
+         */
+        @Contract("_, _ -> this")
+        public Builder fastLava(final Boolean value, final Modifier modifier) {
+            this.fastLava = Attribute.of(value, modifier);
             return this;
         }
 
@@ -462,6 +757,31 @@ public record EnvironmentAttributes(
         }
 
         /**
+         * Sets {@code minecraft:gameplay/sky_light_level} as a plain override.
+         *
+         * @param value sky light level, within {@code [0, 15]}, or {@code null} to leave unset
+         * @return this builder
+         */
+        @Contract("_ -> this")
+        public Builder skyLightLevel(final @Nullable Float value) {
+            this.skyLightLevel = value == null ? null : Attribute.of(value);
+            return this;
+        }
+
+        /**
+         * Sets {@code minecraft:gameplay/sky_light_level}, deriving from the dimension's value.
+         *
+         * @param value    the modifier argument
+         * @param modifier how to combine it
+         * @return this builder
+         */
+        @Contract("_, _ -> this")
+        public Builder skyLightLevel(final Float value, final Modifier modifier) {
+            this.skyLightLevel = Attribute.of(value, modifier);
+            return this;
+        }
+
+        /**
          * Adds one ambient particle to {@code minecraft:visual/ambient_particles}.
          *
          * @param particle the particle
@@ -516,20 +836,30 @@ public record EnvironmentAttributes(
         @Contract(value = "-> new", pure = true)
         public EnvironmentAttributes build() {
             return new EnvironmentAttributes(
-
                     fogColor,
+                    fogStartDistance,
+                    fogEndDistance,
                     skyColor,
+                    cloudColor,
+                    cloudHeight,
+                    skyLightColor,
+                    skyLightFactor,
+                    ambientLightColor,
+                    defaultDripstoneParticle,
                     waterFogColor,
                     waterFogEndDistance,
-                    extraFog,
                     musicVolume,
                     canStartRaid,
                     canPillagerPatrolSpawn,
                     waterEvaporates,
+                    bedRule,
                     respawnAnchorWorks,
+                    netherPortalSpawnsPiglin,
+                    fastLava,
                     increasedFireBurnout,
                     piglinsZombify,
                     snowGolemMelts,
+                    skyLightLevel,
                     List.copyOf(ambientParticles),
                     ambientSounds,
                     backgroundMusic);

--- a/fidorial-api/src/main/java/fr/fidorial/world/generation/WorldGenerator.java
+++ b/fidorial-api/src/main/java/fr/fidorial/world/generation/WorldGenerator.java
@@ -1,15 +1,15 @@
 package fr.fidorial.world.generation;
 
+import fr.fidorial.world.dimension.DimensionTypeDefinition;
+import fr.fidorial.world.dimension.types.VanillaDimensionTypes;
+
 @FunctionalInterface
 public interface WorldGenerator {
+
     void generate(GeneratedChunk chunk);
 
-    default int minY() {
-        return -64;
-    }
-
-    default int height() {
-        return 384;
+    default DimensionTypeDefinition dimensionType() {
+        return VanillaDimensionTypes.OVERWORLD;
     }
 
     default GenerationDescriptor describeForSave() {

--- a/fidorial-api/src/main/java/module-info.java
+++ b/fidorial-api/src/main/java/module-info.java
@@ -80,6 +80,8 @@ module fr.fidorial {
     exports fr.fidorial.command.argument.custom;
     exports fr.fidorial.world.biome;
     exports fr.fidorial.world.environment;
+    exports fr.fidorial.world.dimension;
+    exports fr.fidorial.world.dimension.types;
 
     requires com.google.common;
     requires com.google.gson;

--- a/fidorial-registry-generator/src/main/java/fr/fidorial/registrygen/generate/DimensionTypesGenerator.java
+++ b/fidorial-registry-generator/src/main/java/fr/fidorial/registrygen/generate/DimensionTypesGenerator.java
@@ -1,0 +1,78 @@
+package fr.fidorial.registrygen.generate;
+
+import com.palantir.javapoet.ClassName;
+import com.palantir.javapoet.FieldSpec;
+import com.palantir.javapoet.JavaFile;
+import com.palantir.javapoet.TypeSpec;
+import fr.fidorial.registrygen.GenerationUtils;
+import fr.fidorial.registrygen.model.RegistryDefinition;
+import fr.fidorial.registrygen.model.RegistryEntryDefinition;
+
+import javax.lang.model.element.Modifier;
+import java.io.IOException;
+import java.nio.file.Path;
+
+public final class DimensionTypesGenerator {
+
+    private static final ClassName DIMENSION_TYPE_DEFINITION =
+            ClassName.get("fr.fidorial.world.dimension", "DimensionTypeDefinition");
+    private static final ClassName DIMENSION_TYPE_KEYS =
+            ClassName.get("fr.fidorial.registry.keys", "DimensionTypeKeys");
+
+    public void generate(final RegistryDefinition registry, final Path outputDirectory) throws IOException {
+        final TypeSpec.Builder type = TypeSpec.classBuilder("VanillaDimensionTypes")
+                .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+                .addJavadoc("""
+                        Provides the built-in Minecraft dimension type definitions.
+
+                        <p>These definitions correspond to the vanilla dimension types registered
+                        by Minecraft and can be used when constructing or referencing vanilla
+                        dimensions.</p>
+
+                        @apiNote The dimension types provided by this class mirror those registered
+                        by vanilla and are not guaranteed to remain stable. New dimension types may
+                        be added and existing dimension types may be removed in future Minecraft
+                        versions without notice.
+
+                        @since 0.1.0
+                        """);
+
+        for (final RegistryEntryDefinition entry : registry.entries()) {
+            addDimensionTypeField(type, entry);
+        }
+
+        JavaFile.builder("fr.fidorial.world.dimension.types", type.build())
+                .indent("    ")
+                .skipJavaLangImports(true)
+                .build()
+                .writeTo(outputDirectory);
+    }
+
+    private static void addDimensionTypeField(
+            final TypeSpec.Builder type,
+            final RegistryEntryDefinition entry
+    ) {
+        final String fieldName = GenerationUtils.constantName(entry.identifier());
+
+        type.addField(
+                FieldSpec.builder(
+                                DIMENSION_TYPE_DEFINITION,
+                                fieldName,
+                                Modifier.PUBLIC,
+                                Modifier.STATIC,
+                                Modifier.FINAL
+                        )
+                        .initializer(
+                                "$T.builder($T.$N.key()).build()",
+                                DIMENSION_TYPE_DEFINITION,
+                                DIMENSION_TYPE_KEYS,
+                                fieldName
+                        )
+                        .addJavadoc(
+                                "The {@code $L} dimension type.\n\n@since 0.1.0\n",
+                                entry.identifier()
+                        )
+                        .build()
+        );
+    }
+}

--- a/fidorial-registry-generator/src/main/java/fr/fidorial/registrygen/generate/RegistryGenerator.java
+++ b/fidorial-registry-generator/src/main/java/fr/fidorial/registrygen/generate/RegistryGenerator.java
@@ -8,6 +8,7 @@ import fr.fidorial.registrygen.model.ProtocolIdTarget;
 import fr.fidorial.registrygen.model.RegistriesHolder;
 import fr.fidorial.registrygen.model.RegistryDefinition;
 import fr.fidorial.registrygen.model.RegistryTypeDefinition;
+import fr.fidorial.registrygen.model.SupportedRegistries;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -33,6 +34,7 @@ public final class RegistryGenerator {
     private final BlockReportParser blockReportParser;
     private final PrismarineBlockReportParser prismarineBlockReportParser;
     private final BlockStateGenerator blockStateGenerator;
+    private final DimensionTypesGenerator dimensionTypesGenerator;
 
     /**
      * Creates a registry generator using the standard parser and
@@ -47,7 +49,8 @@ public final class RegistryGenerator {
                 new RegistryProtocolIdGenerator(),
                 new BlockReportParser(),
                 new PrismarineBlockReportParser(),
-                new BlockStateGenerator());
+                new BlockStateGenerator(),
+                new DimensionTypesGenerator());
     }
 
     /**
@@ -64,6 +67,7 @@ public final class RegistryGenerator {
      * @param blockReportParser   blocks report parser
      * @param prismarineBlockReportParser prismarine block report parser
      * @param blockStateGenerator block type registration generator
+     * @param dimensionTypesGenerator the dimension types generator
      */
     public RegistryGenerator(final RegistryReportParser parser,
                              final RegistryDataGenerator dataGenerator,
@@ -72,7 +76,8 @@ public final class RegistryGenerator {
                              final RegistryProtocolIdGenerator protocolIdGenerator,
                              final BlockReportParser blockReportParser,
                              final PrismarineBlockReportParser prismarineBlockReportParser,
-                             final BlockStateGenerator blockStateGenerator) {
+                             final BlockStateGenerator blockStateGenerator,
+                             final DimensionTypesGenerator dimensionTypesGenerator) {
 
         this.parser = Objects.requireNonNull(parser, "parser");
         this.dataGenerator = Objects.requireNonNull(dataGenerator, "dataGenerator");
@@ -82,6 +87,7 @@ public final class RegistryGenerator {
         this.blockReportParser = Objects.requireNonNull(blockReportParser, "blockReportParser");
         this.prismarineBlockReportParser = Objects.requireNonNull(prismarineBlockReportParser, "prismarineBlockReportParser");
         this.blockStateGenerator = Objects.requireNonNull(blockStateGenerator, "blockStateGenerator");
+        this.dimensionTypesGenerator = Objects.requireNonNull(dimensionTypesGenerator, "dimensionTypesGenerator");
     }
 
     /**
@@ -131,6 +137,10 @@ public final class RegistryGenerator {
 
             dataGenerator.generate(registryType, outputDirectory);
             keysGenerator.generate(registryType, registryDefinition.get(), outputDirectory);
+
+            if (registryType.identifier().equals(SupportedRegistries.DIMENSION_TYPE.identifier())) {
+                dimensionTypesGenerator.generate(registryDefinition.get(), outputDirectory);
+            }
         }
 
         /*

--- a/fidorial-registry-generator/src/main/java/fr/fidorial/registrygen/model/SupportedRegistries.java
+++ b/fidorial-registry-generator/src/main/java/fr/fidorial/registrygen/model/SupportedRegistries.java
@@ -20,6 +20,8 @@ public final class SupportedRegistries {
 
   public static final RegistryTypeDefinition BLOCK = registry("minecraft:block", "BlockType");
 
+  public static final RegistryTypeDefinition DIMENSION_TYPE = registry("minecraft:dimension_type", "DimensionType");
+
   public static final List<RegistryTypeDefinition> ALL = List.of(
           registry("minecraft:attribute", "Attribute"),
           registry("minecraft:banner_pattern", "BannerPattern"),
@@ -35,7 +37,7 @@ public final class SupportedRegistries {
           registry("minecraft:damage_type", "DamageType"),
           registry("minecraft:data_component_type", "DataComponentType"),
           registry("minecraft:dialog", "Dialog"),
-          registry("minecraft:dimension_type", "DimensionType"),
+          DIMENSION_TYPE,
           registry("minecraft:enchantment", "Enchantment"),
           registry("minecraft:frog_variant", "FrogVariant"),
           registry("minecraft:game_event", "GameEvent"),

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/FidorialServer.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/FidorialServer.java
@@ -43,6 +43,7 @@ import fr.euphyllia.fidorial.server.registry.biome.FidorialBiomeRegistry;
 import fr.euphyllia.fidorial.server.registry.data.BlockStateIds;
 import fr.euphyllia.fidorial.server.registry.data.BlockStateLightProperties;
 import fr.euphyllia.fidorial.server.registry.dialog.FidorialDialogRegistry;
+import fr.euphyllia.fidorial.server.registry.dimension.FidorialDimensionTypeRegistry;
 import fr.euphyllia.fidorial.server.schedulers.AiWorker;
 import fr.euphyllia.fidorial.server.schedulers.DayNightThread;
 import fr.euphyllia.fidorial.server.schedulers.LightUpdateDispatcher;
@@ -58,7 +59,6 @@ import fr.euphyllia.fidorial.server.world.ChunkNetworkSerializer;
 import fr.euphyllia.fidorial.server.world.FlatChunkGenerator;
 import fr.euphyllia.fidorial.server.world.ServerWorld;
 import fr.euphyllia.fidorial.server.world.ServiceBackedChunkGenerator;
-import fr.euphyllia.fidorial.server.world.WorldConstants;
 import fr.euphyllia.fidorial.server.world.WorldManager;
 import fr.euphyllia.fidorial.server.world.block.FidorialBlockRegistry;
 import fr.euphyllia.fidorial.server.world.chunk.BlockStateProperties;
@@ -91,6 +91,7 @@ import fr.fidorial.world.World;
 import fr.fidorial.world.WorldBuilder;
 import fr.fidorial.world.biome.BiomeRegistry;
 import fr.fidorial.world.block.Blocks;
+import fr.fidorial.world.dimension.types.VanillaDimensionTypes;
 import fr.fidorial.world.entity.EntitySpawnBridge;
 import fr.fidorial.world.fluid.FluidManager;
 import fr.fidorial.world.weather.WeatherManager;
@@ -346,9 +347,7 @@ public final class FidorialServer implements Server {
         });
         worldManager.setDefaultGenerator(new ServiceBackedChunkGenerator(
                 services,
-                FlatChunkGenerator.cobblestone(WorldConstants.MIN_Y, WorldConstants.HEIGHT),
-                WorldConstants.MIN_Y,
-                WorldConstants.HEIGHT));
+                FlatChunkGenerator.cobblestone(VanillaDimensionTypes.OVERWORLD)));
         worldManager.overworld();
         weatherEngine.start();
         dayNightEngine.start();
@@ -523,6 +522,11 @@ public final class FidorialServer implements Server {
     @Override
     public FidorialDialogRegistry dialogs() {
         return registries.dialogs();
+    }
+
+    @Override
+    public FidorialDimensionTypeRegistry dimensionTypes() {
+        return registries.dimensionTypes();
     }
 
     @Override

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/codecs/dialog/DialogCodecs.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/codecs/dialog/DialogCodecs.java
@@ -163,21 +163,21 @@ public final class DialogCodecs {
     static {
         BODY_CODEC = DispatchCodecs.<DialogBody>matcher("type", List.of(
                 DispatchCodecs.Variant.of(
-                        "minecraft:plain_message", null, true, DialogBody.PlainMessage.class, PLAIN_MESSAGE_CODEC),
+                        "plain_message", null, true, DialogBody.PlainMessage.class, PLAIN_MESSAGE_CODEC),
                 DispatchCodecs.Variant.of(
-                        "minecraft:item", null, true, DialogBody.Item.class, ITEM_BODY_CODEC)
+                        "item", null, true, DialogBody.Item.class, ITEM_BODY_CODEC)
         )).codec();
 
         INPUT_CODEC = DispatchCodecs.<DialogInput>matcher("type", List.of(
                 DispatchCodecs.Variant.of(
-                        "minecraft:text", null, true, DialogInput.Text.class, TEXT_INPUT_CODEC),
+                        "text", null, true, DialogInput.Text.class, TEXT_INPUT_CODEC),
                 DispatchCodecs.Variant.of(
-                        "minecraft:boolean", null, true, DialogInput.Bool.class, BOOL_INPUT_CODEC),
+                        "boolean", null, true, DialogInput.Bool.class, BOOL_INPUT_CODEC),
                 DispatchCodecs.Variant.of(
-                        "minecraft:single_option", null, true,
+                        "single_option", null, true,
                         DialogInput.SingleOption.class, SINGLE_OPTION_INPUT_CODEC),
                 DispatchCodecs.Variant.of(
-                        "minecraft:number_range", null, true,
+                        "number_range", null, true,
                         DialogInput.NumberRange.class, NUMBER_RANGE_INPUT_CODEC)
         )).codec();
 
@@ -185,18 +185,18 @@ public final class DialogCodecs {
             final Codec<Dialog> dialog = eitherReferenceOr(self);
             return DispatchCodecs.<DialogDefinition>matcher("type", List.of(
                     DispatchCodecs.Variant.of(
-                            "minecraft:notice", null, true, NoticeDialog.class, noticeCodec()),
+                            "notice", null, true, NoticeDialog.class, noticeCodec()),
                     DispatchCodecs.Variant.of(
-                            "minecraft:confirmation", null, true,
+                            "confirmation", null, true,
                             ConfirmationDialog.class, confirmationCodec()),
                     DispatchCodecs.Variant.of(
-                            "minecraft:multi_action", null, true,
+                            "multi_action", null, true,
                             MultiActionDialog.class, multiActionCodec()),
                     DispatchCodecs.Variant.of(
-                            "minecraft:server_links", null, true,
+                            "server_links", null, true,
                             ServerLinksDialog.class, serverLinksCodec()),
                     DispatchCodecs.Variant.of(
-                            "minecraft:dialog_list", null, true,
+                            "dialog_list", null, true,
                             DialogListDialog.class, dialogListCodec(dialog))
             )).codec();
         });

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/codecs/dialog/DialogItemCodecs.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/codecs/dialog/DialogItemCodecs.java
@@ -16,11 +16,11 @@ public class DialogItemCodecs {
 
     private static final MapCodec<ItemComponents> COMPONENTS_CODEC =
             RecordCodecBuilder.mapCodec(instance -> instance.group(
-                    COMPONENT_CODEC.optionalFieldOf("minecraft:custom_name")
+                    COMPONENT_CODEC.optionalFieldOf("custom_name")
                             .forGetter(ItemComponents::customName),
-                    COMPONENT_CODEC.optionalFieldOf("minecraft:item_name")
+                    COMPONENT_CODEC.optionalFieldOf("item_name")
                             .forGetter(ItemComponents::itemName),
-                    COMPONENT_CODEC.listOf().optionalFieldOf("minecraft:lore")
+                    COMPONENT_CODEC.listOf().optionalFieldOf("lore")
                             .forGetter(ItemComponents::lore)
             ).apply(instance, ItemComponents::new));
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/codecs/world/DimensionTypeCodecs.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/codecs/world/DimensionTypeCodecs.java
@@ -1,0 +1,149 @@
+package fr.euphyllia.fidorial.server.codecs.world;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+import com.mojang.datafixers.util.Either;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.DataResult;
+import com.mojang.serialization.JsonOps;
+import com.mojang.serialization.MapCodec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import fr.euphyllia.fidorial.server.codecs.CommonCodecs;
+import fr.fidorial.world.dimension.CardinalLight;
+import fr.fidorial.world.dimension.DimensionTypeDefinition;
+import fr.fidorial.world.dimension.Skybox;
+import fr.fidorial.world.dimension.TimelineReference;
+import fr.fidorial.world.environment.EnvironmentAttributes;
+import io.papermc.adventurex.nbt.dfu.BinaryTagOps;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.nbt.BinaryTag;
+import net.kyori.adventure.nbt.CompoundBinaryTag;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+
+public final class DimensionTypeCodecs {
+
+    public static final Codec<Skybox> SKYBOX = byId(Skybox.values(), Skybox::id, "skybox");
+
+    public static final Codec<CardinalLight> CARDINAL_LIGHT =
+            byId(CardinalLight.values(), CardinalLight::id, "cardinal light");
+
+    public static final Codec<Key> TAG_KEY = Codec.STRING.comapFlatMap(
+            s -> s.startsWith("#") && Key.parseable(s.substring(1))
+                    ? DataResult.success(Key.key(s.substring(1)))
+                    : DataResult.error(() -> "Expected a #tag, got: " + s),
+            key -> "#" + key.asString());
+
+    private static final Codec<TimelineReference> SINGLE_TIMELINE = Codec.STRING.comapFlatMap(
+            s -> {
+                final String raw = s.startsWith("#") ? s.substring(1) : s;
+                if (!Key.parseable(raw)) {
+                    return DataResult.error(() -> "Not a valid key: " + s);
+                }
+                final Key key = Key.key(raw);
+                return DataResult.success(s.startsWith("#") ? TimelineReference.tag(key) : TimelineReference.id(key));
+            },
+            timeline -> switch (timeline) {
+                case final TimelineReference.Id id -> id.key().asString();
+                case final TimelineReference.Tag tag -> "#" + tag.key().asString();
+            });
+
+    private static final Codec<List<TimelineReference>> TIMELINES = Codec.either(
+            SINGLE_TIMELINE.listOf(), SINGLE_TIMELINE
+    ).xmap(
+            either -> either.map(list -> list, List::of),
+            list -> list.size() == 1 ? Either.right(list.getFirst()) : Either.left(list));
+
+    private record Extras(Skybox skybox, CardinalLight cardinalLight, @Nullable Key defaultClock, List<TimelineReference> timelines) { }
+
+    private static final MapCodec<Extras> EXTRAS = RecordCodecBuilder.mapCodec(instance -> instance.group(
+            SKYBOX.optionalFieldOf("skybox", Skybox.OVERWORLD).forGetter(Extras::skybox),
+            CARDINAL_LIGHT.optionalFieldOf("cardinal_light", CardinalLight.DEFAULT).forGetter(Extras::cardinalLight),
+            CommonCodecs.KEY_CODEC.optionalFieldOf("default_clock")
+                    .forGetter(e -> Optional.ofNullable(e.defaultClock())),
+            TIMELINES.optionalFieldOf("timelines", List.of()).forGetter(Extras::timelines)
+    ).apply(instance, (skybox, cardinalLight, defaultClock, timelines) ->
+            new Extras(skybox, cardinalLight, defaultClock.orElse(null), timelines)));
+
+    private DimensionTypeCodecs() {
+        throw new UnsupportedOperationException("DimensionTypeCodecs cannot be instantiated.");
+    }
+
+    public static Codec<DimensionTypeDefinition> codec(final Key key) {
+        return RecordCodecBuilder.create(instance -> instance.group(
+                Codec.DOUBLE.validate(scale -> scale >= 0.00001D && scale <= 30_000_000.0D
+                                ? DataResult.success(scale)
+                                : DataResult.error(() -> "coordinate_scale out of range: " + scale))
+                        .fieldOf("coordinate_scale").forGetter(DimensionTypeDefinition::coordinateScale),
+                Codec.BOOL.fieldOf("has_skylight").forGetter(DimensionTypeDefinition::hasSkylight),
+                Codec.BOOL.fieldOf("has_ceiling").forGetter(DimensionTypeDefinition::hasCeiling),
+                Codec.BOOL.fieldOf("has_ender_dragon_fight")
+                        .forGetter(DimensionTypeDefinition::hasEnderDragonFight),
+                Codec.FLOAT.fieldOf("ambient_light").forGetter(DimensionTypeDefinition::ambientLight),
+                Codec.BOOL.optionalFieldOf("has_fixed_time", false)
+                        .forGetter(DimensionTypeDefinition::hasFixedTime),
+                Codec.intRange(0, 15).fieldOf("monster_spawn_block_light_limit")
+                        .forGetter(DimensionTypeDefinition::monsterSpawnBlockLightLimit),
+                IntProviderCodecs.INT_PROVIDER.fieldOf("monster_spawn_light_level")
+                        .forGetter(DimensionTypeDefinition::monsterSpawnLightLevel),
+                Codec.INT.fieldOf("logical_height").forGetter(DimensionTypeDefinition::logicalHeight),
+                Codec.INT.fieldOf("min_y").forGetter(DimensionTypeDefinition::minY),
+                Codec.INT.fieldOf("height").forGetter(DimensionTypeDefinition::height),
+                TAG_KEY.fieldOf("infiniburn").forGetter(DimensionTypeDefinition::infiniburn),
+                EnvironmentAttributeCodecs.ATTRIBUTES.optionalFieldOf("attributes", EnvironmentAttributes.EMPTY)
+                        .forGetter(DimensionTypeDefinition::attributes),
+                EXTRAS.forGetter(d -> new Extras(d.skybox(), d.cardinalLight(), d.defaultClock(), d.timelines()))
+        ).apply(instance, (scale, skylight, ceiling, dragonFight, ambient, fixedTime, blockLightLimit,
+                           lightLevel, logicalHeight, minY, height, infiniburn, attributes, extras) ->
+                new DimensionTypeDefinition(
+                        key, scale, skylight, ceiling, dragonFight, ambient, fixedTime, blockLightLimit,
+                        lightLevel, logicalHeight, minY, height, infiniburn, extras.skybox(), extras.cardinalLight(),
+                        attributes, extras.defaultClock(), extras.timelines())));
+    }
+
+    public static CompoundBinaryTag encodeNbt(final DimensionTypeDefinition dimensionType) {
+        final BinaryTag tag = codec(dimensionType.key())
+                .encodeStart(BinaryTagOps.binaryTagOps(), dimensionType)
+                .getOrThrow(message -> new IllegalStateException(
+                        "Failed to encode dimension type " + dimensionType.key().asString() + ": " + message));
+
+        if (!(tag instanceof final CompoundBinaryTag compound)) {
+            throw new IllegalStateException(
+                    "Dimension type " + dimensionType.key().asString() + " did not encode to a compound tag");
+        }
+
+        return compound;
+    }
+
+    public static DimensionTypeDefinition fromJson(final Key key, final String json) {
+        final JsonElement element;
+        try {
+            element = JsonParser.parseString(json);
+        } catch (final RuntimeException exception) {
+            throw new IllegalArgumentException("Dimension type " + key.asString() + " is not valid JSON", exception);
+        }
+
+        return codec(key)
+                .parse(JsonOps.INSTANCE, element)
+                .getOrThrow(message -> new IllegalArgumentException(
+                        "Failed to read dimension type " + key.asString() + ": " + message));
+    }
+
+    private static <E extends Enum<E>> Codec<E> byId(
+            final E[] values,
+            final Function<E, String> id,
+            final String what
+    ) {
+        return Codec.STRING.comapFlatMap(
+                name -> Arrays.stream(values)
+                        .filter(value -> id.apply(value).equals(name))
+                        .findFirst()
+                        .map(DataResult::success)
+                        .orElseGet(() -> DataResult.error(() -> "Unknown " + what + ": " + name)),
+                id);
+    }
+}

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/codecs/world/EnvironmentAttributeCodecs.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/codecs/world/EnvironmentAttributeCodecs.java
@@ -3,22 +3,26 @@ package fr.euphyllia.fidorial.server.codecs.world;
 import com.mojang.datafixers.util.Either;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.DataResult;
+import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import fr.euphyllia.fidorial.server.codecs.CommonCodecs;
+import fr.euphyllia.fidorial.server.codecs.adventure.ComponentCodecs;
 import fr.fidorial.world.environment.AdditionsSound;
 import fr.fidorial.world.environment.AmbientParticle;
 import fr.fidorial.world.environment.AmbientSounds;
 import fr.fidorial.world.environment.Attribute;
 import fr.fidorial.world.environment.BackgroundMusic;
+import fr.fidorial.world.environment.BedRule;
 import fr.fidorial.world.environment.EnvironmentAttributes;
 import fr.fidorial.world.environment.Modifier;
 import fr.fidorial.world.environment.MoodSound;
 import fr.fidorial.world.environment.MusicTrack;
+import net.kyori.adventure.key.Key;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-
 
 public class EnvironmentAttributeCodecs {
 
@@ -27,6 +31,11 @@ public class EnvironmentAttributeCodecs {
                     either -> either.map(EnvironmentAttributeCodecs::parseHexColor, DataResult::success),
                     color -> Either.left(formatHexColor(color)));
 
+    public static final Codec<Integer> ARGB_COLOR = Codec.either(Codec.STRING, Codec.INT)
+            .comapFlatMap(
+                    either -> either.map(EnvironmentAttributeCodecs::parseHexColorARGB, DataResult::success),
+                    color -> Either.left(formatHexColorARGB(color)));
+
     public static final Codec<Modifier> MODIFIER = Codec.STRING.comapFlatMap(
             name -> Arrays.stream(Modifier.values())
                     .filter(modifier -> modifier.id().equals(name))
@@ -34,6 +43,19 @@ public class EnvironmentAttributeCodecs {
                     .map(DataResult::success)
                     .orElseGet(() -> DataResult.error(() -> "Unknown attribute modifier: " + name)),
             Modifier::id);
+
+    public static final Codec<BedRule.AccessCondition> SLEEP_ACCESS = Codec.STRING.comapFlatMap(
+            id -> BedRule.AccessCondition.fromId(id)
+                    .map(DataResult::success)
+                    .orElseGet(() -> DataResult.error(() -> "Unknown bed rule value: " + id)),
+            BedRule.AccessCondition::id);
+
+    public static final Codec<BedRule> BED_RULE = RecordCodecBuilder.create(instance -> instance.group(
+            SLEEP_ACCESS.fieldOf("can_sleep").forGetter(BedRule::sleepAllowed),
+            SLEEP_ACCESS.fieldOf("can_set_spawn").forGetter(BedRule::spawnAllowed),
+            Codec.BOOL.optionalFieldOf("explodes", false).forGetter(BedRule::explodes),
+            ComponentCodecs.COMPONENT_CODEC.optionalFieldOf("error_message").forGetter(BedRule::failureMessage)
+    ).apply(instance, BedRule::new));
 
     public static final Codec<AmbientParticle> AMBIENT_PARTICLE = RecordCodecBuilder.create(instance -> instance.group(
             BiomeCodecs.PARTICLE_OPTIONS.fieldOf("particle").forGetter(AmbientParticle::type),
@@ -73,56 +95,161 @@ public class EnvironmentAttributeCodecs {
     ).apply(instance, (normal, underwater, creative) ->
             new BackgroundMusic(normal.orElse(null), underwater.orElse(null), creative.orElse(null))));
 
-    public static final Codec<EnvironmentAttributes> ATTRIBUTES = RecordCodecBuilder.create(instance -> instance.group(
+    private record VisualPart(
+            @Nullable Attribute<Integer> fogColor,
+            @Nullable Attribute<Float> fogStartDistance,
+            @Nullable Attribute<Float> fogEndDistance,
+            @Nullable Attribute<Integer> skyColor,
+            @Nullable Attribute<Integer> cloudColor,
+            @Nullable Attribute<Float> cloudHeight,
+            @Nullable Attribute<Integer> skyLightColor,
+            @Nullable Attribute<Float> skyLightFactor,
+            @Nullable Attribute<Integer> ambientLightColor,
+            @Nullable Attribute<Key> defaultDripstoneParticle,
+            @Nullable Attribute<Integer> waterFogColor,
+            @Nullable Attribute<Float> waterFogEndDistance
+    ) { }
 
-            modifiable(RGB_COLOR).optionalFieldOf("minecraft:visual/fog_color")
-                    .forGetter(a -> Optional.ofNullable(a.fogColor())),
-            modifiable(RGB_COLOR).optionalFieldOf("minecraft:visual/sky_color")
-                    .forGetter(a -> Optional.ofNullable(a.skyColor())),
-            modifiable(RGB_COLOR).optionalFieldOf("minecraft:visual/water_fog_color")
-                    .forGetter(a -> Optional.ofNullable(a.waterFogColor())),
-            modifiable(Codec.FLOAT).optionalFieldOf("minecraft:visual/water_fog_end_distance")
-                    .forGetter(a -> Optional.ofNullable(a.waterFogEndDistance())),
-            modifiable(Codec.BOOL).optionalFieldOf("minecraft:visual/extra_fog")
-                    .forGetter(a -> Optional.ofNullable(a.extraFog())),
-            modifiable(Codec.FLOAT).optionalFieldOf("minecraft:audio/music_volume")
-                    .forGetter(a -> Optional.ofNullable(a.musicVolume())),
-            modifiable(Codec.BOOL).optionalFieldOf("minecraft:gameplay/can_start_raid")
-                    .forGetter(a -> Optional.ofNullable(a.canStartRaid())),
-            modifiable(Codec.BOOL).optionalFieldOf("minecraft:gameplay/can_pillager_patrol_spawn")
-                    .forGetter(a -> Optional.ofNullable(a.canPillagerPatrolSpawn())),
-            modifiable(Codec.BOOL).optionalFieldOf("minecraft:gameplay/water_evaporates")
-                    .forGetter(a -> Optional.ofNullable(a.waterEvaporates())),
-            modifiable(Codec.BOOL).optionalFieldOf("minecraft:gameplay/respawn_anchor_works")
-                    .forGetter(a -> Optional.ofNullable(a.respawnAnchorWorks())),
-            modifiable(Codec.BOOL).optionalFieldOf("minecraft:gameplay/increased_fire_burnout")
-                    .forGetter(a -> Optional.ofNullable(a.increasedFireBurnout())),
-            modifiable(Codec.BOOL).optionalFieldOf("minecraft:gameplay/piglins_zombify")
-                    .forGetter(a -> Optional.ofNullable(a.piglinsZombify())),
-            modifiable(Codec.BOOL).optionalFieldOf("minecraft:gameplay/snow_golem_melts")
-                    .forGetter(a -> Optional.ofNullable(a.snowGolemMelts())),
-            AMBIENT_PARTICLE.listOf().optionalFieldOf("minecraft:visual/ambient_particles", List.of())
-                    .forGetter(EnvironmentAttributes::ambientParticles),
-            AMBIENT_SOUNDS.optionalFieldOf("minecraft:audio/ambient_sounds")
-                    .forGetter(a -> Optional.ofNullable(a.ambientSounds())),
-            BACKGROUND_MUSIC.optionalFieldOf("minecraft:audio/background_music")
-                    .forGetter(a -> Optional.ofNullable(a.backgroundMusic()))
-    ).apply(instance, (fogColor, skyColor, waterFogColor, waterFogEndDistance, extraFog, musicVolume, canStartRaid, canPillagerPatrolSpawn, waterEvaporates, respawnAnchorWorks, increasedFireBurnout, piglinsZombify, snowGolemMelts, ambientParticles, ambientSounds, backgroundMusic) ->
-            new EnvironmentAttributes(
+    private record GameplayPart(
+            @Nullable Attribute<Float> musicVolume,
+            @Nullable Attribute<Boolean> canStartRaid,
+            @Nullable Attribute<Boolean> canPillagerPatrolSpawn,
+            @Nullable Attribute<Boolean> waterEvaporates,
+            @Nullable Attribute<BedRule> bedRule,
+            @Nullable Attribute<Boolean> respawnAnchorWorks,
+            @Nullable Attribute<Boolean> netherPortalSpawnsPiglin,
+            @Nullable Attribute<Boolean> fastLava,
+            @Nullable Attribute<Boolean> increasedFireBurnout,
+            @Nullable Attribute<Boolean> piglinsZombify,
+            @Nullable Attribute<Boolean> snowGolemMelts,
+            @Nullable Attribute<Float> skyLightLevel
+    ) { }
 
+    private static final MapCodec<VisualPart> VISUAL = RecordCodecBuilder.mapCodec(instance -> instance.group(
+            modifiable(RGB_COLOR).optionalFieldOf("visual/fog_color")
+                    .forGetter(v -> Optional.ofNullable(v.fogColor())),
+            modifiable(Codec.FLOAT).optionalFieldOf("visual/fog_start_distance")
+                    .forGetter(v -> Optional.ofNullable(v.fogStartDistance())),
+            modifiable(Codec.FLOAT).optionalFieldOf("visual/fog_end_distance")
+                    .forGetter(v -> Optional.ofNullable(v.fogEndDistance())),
+            modifiable(RGB_COLOR).optionalFieldOf("visual/sky_color")
+                    .forGetter(v -> Optional.ofNullable(v.skyColor())),
+            modifiable(ARGB_COLOR).optionalFieldOf("visual/cloud_color")
+                    .forGetter(v -> Optional.ofNullable(v.cloudColor())),
+            modifiable(Codec.FLOAT).optionalFieldOf("visual/cloud_height")
+                    .forGetter(v -> Optional.ofNullable(v.cloudHeight())),
+            modifiable(RGB_COLOR).optionalFieldOf("visual/sky_light_color")
+                    .forGetter(v -> Optional.ofNullable(v.skyLightColor())),
+            modifiable(Codec.FLOAT).optionalFieldOf("visual/sky_light_factor")
+                    .forGetter(v -> Optional.ofNullable(v.skyLightFactor())),
+            modifiable(RGB_COLOR).optionalFieldOf("visual/ambient_light_color")
+                    .forGetter(v -> Optional.ofNullable(v.ambientLightColor())),
+            modifiable(BiomeCodecs.PARTICLE_OPTIONS).optionalFieldOf("visual/default_dripstone_particle")
+                    .forGetter(v -> Optional.ofNullable(v.defaultDripstoneParticle())),
+            modifiable(RGB_COLOR).optionalFieldOf("visual/water_fog_color")
+                    .forGetter(v -> Optional.ofNullable(v.waterFogColor())),
+            modifiable(Codec.FLOAT).optionalFieldOf("visual/water_fog_end_distance")
+                    .forGetter(v -> Optional.ofNullable(v.waterFogEndDistance()))
+    ).apply(instance, (fogColor, fogStartDistance, fogEndDistance, skyColor, cloudColor, cloudHeight, skyLightColor,
+                       skyLightFactor, ambientLightColor, defaultDripstoneParticle, waterFogColor,
+                       waterFogEndDistance) ->
+            new VisualPart(
                     fogColor.orElse(null),
+                    fogStartDistance.orElse(null),
+                    fogEndDistance.orElse(null),
                     skyColor.orElse(null),
+                    cloudColor.orElse(null),
+                    cloudHeight.orElse(null),
+                    skyLightColor.orElse(null),
+                    skyLightFactor.orElse(null),
+                    ambientLightColor.orElse(null),
+                    defaultDripstoneParticle.orElse(null),
                     waterFogColor.orElse(null),
-                    waterFogEndDistance.orElse(null),
-                    extraFog.orElse(null),
+                    waterFogEndDistance.orElse(null))));
+
+    private static final MapCodec<GameplayPart> GAMEPLAY = RecordCodecBuilder.mapCodec(instance -> instance.group(
+            modifiable(Codec.FLOAT).optionalFieldOf("audio/music_volume")
+                    .forGetter(g -> Optional.ofNullable(g.musicVolume())),
+            modifiable(Codec.BOOL).optionalFieldOf("gameplay/can_start_raid")
+                    .forGetter(g -> Optional.ofNullable(g.canStartRaid())),
+            modifiable(Codec.BOOL).optionalFieldOf("gameplay/can_pillager_patrol_spawn")
+                    .forGetter(g -> Optional.ofNullable(g.canPillagerPatrolSpawn())),
+            modifiable(Codec.BOOL).optionalFieldOf("gameplay/water_evaporates")
+                    .forGetter(g -> Optional.ofNullable(g.waterEvaporates())),
+            modifiable(BED_RULE).optionalFieldOf("gameplay/bed_rule")
+                    .forGetter(g -> Optional.ofNullable(g.bedRule())),
+            modifiable(Codec.BOOL).optionalFieldOf("gameplay/respawn_anchor_works")
+                    .forGetter(g -> Optional.ofNullable(g.respawnAnchorWorks())),
+            modifiable(Codec.BOOL).optionalFieldOf("gameplay/nether_portal_spawns_piglin")
+                    .forGetter(g -> Optional.ofNullable(g.netherPortalSpawnsPiglin())),
+            modifiable(Codec.BOOL).optionalFieldOf("gameplay/fast_lava")
+                    .forGetter(g -> Optional.ofNullable(g.fastLava())),
+            modifiable(Codec.BOOL).optionalFieldOf("gameplay/increased_fire_burnout")
+                    .forGetter(g -> Optional.ofNullable(g.increasedFireBurnout())),
+            modifiable(Codec.BOOL).optionalFieldOf("gameplay/piglins_zombify")
+                    .forGetter(g -> Optional.ofNullable(g.piglinsZombify())),
+            modifiable(Codec.BOOL).optionalFieldOf("gameplay/snow_golem_melts")
+                    .forGetter(g -> Optional.ofNullable(g.snowGolemMelts())),
+            modifiable(Codec.FLOAT).optionalFieldOf("gameplay/sky_light_level")
+                    .forGetter(g -> Optional.ofNullable(g.skyLightLevel()))
+    ).apply(instance, (musicVolume, canStartRaid, canPillagerPatrolSpawn, waterEvaporates, bedRule,
+                       respawnAnchorWorks, netherPortalSpawnsPiglin, fastLava, increasedFireBurnout,
+                       piglinsZombify, snowGolemMelts, skyLightLevel) ->
+            new GameplayPart(
                     musicVolume.orElse(null),
                     canStartRaid.orElse(null),
                     canPillagerPatrolSpawn.orElse(null),
                     waterEvaporates.orElse(null),
+                    bedRule.orElse(null),
                     respawnAnchorWorks.orElse(null),
+                    netherPortalSpawnsPiglin.orElse(null),
+                    fastLava.orElse(null),
                     increasedFireBurnout.orElse(null),
                     piglinsZombify.orElse(null),
                     snowGolemMelts.orElse(null),
+                    skyLightLevel.orElse(null))));
+
+    public static final Codec<EnvironmentAttributes> ATTRIBUTES = RecordCodecBuilder.create(instance -> instance.group(
+            VISUAL.forGetter(a -> new VisualPart(
+                    a.fogColor(), a.fogStartDistance(), a.fogEndDistance(), a.skyColor(), a.cloudColor(),
+                    a.cloudHeight(), a.skyLightColor(), a.skyLightFactor(), a.ambientLightColor(),
+                    a.defaultDripstoneParticle(), a.waterFogColor(), a.waterFogEndDistance())),
+            GAMEPLAY.forGetter(a -> new GameplayPart(
+                    a.musicVolume(), a.canStartRaid(), a.canPillagerPatrolSpawn(), a.waterEvaporates(),
+                    a.bedRule(), a.respawnAnchorWorks(), a.netherPortalSpawnsPiglin(), a.fastLava(),
+                    a.increasedFireBurnout(), a.piglinsZombify(), a.snowGolemMelts(), a.skyLightLevel())),
+            AMBIENT_PARTICLE.listOf().optionalFieldOf("visual/ambient_particles", List.of())
+                    .forGetter(EnvironmentAttributes::ambientParticles),
+            AMBIENT_SOUNDS.optionalFieldOf("audio/ambient_sounds")
+                    .forGetter(a -> Optional.ofNullable(a.ambientSounds())),
+            BACKGROUND_MUSIC.optionalFieldOf("audio/background_music")
+                    .forGetter(a -> Optional.ofNullable(a.backgroundMusic()))
+    ).apply(instance, (visual, gameplay, ambientParticles, ambientSounds, backgroundMusic) ->
+            new EnvironmentAttributes(
+                    visual.fogColor(),
+                    visual.fogStartDistance(),
+                    visual.fogEndDistance(),
+                    visual.skyColor(),
+                    visual.cloudColor(),
+                    visual.cloudHeight(),
+                    visual.skyLightColor(),
+                    visual.skyLightFactor(),
+                    visual.ambientLightColor(),
+                    visual.defaultDripstoneParticle(),
+                    visual.waterFogColor(),
+                    visual.waterFogEndDistance(),
+                    gameplay.musicVolume(),
+                    gameplay.canStartRaid(),
+                    gameplay.canPillagerPatrolSpawn(),
+                    gameplay.waterEvaporates(),
+                    gameplay.bedRule(),
+                    gameplay.respawnAnchorWorks(),
+                    gameplay.netherPortalSpawnsPiglin(),
+                    gameplay.fastLava(),
+                    gameplay.increasedFireBurnout(),
+                    gameplay.piglinsZombify(),
+                    gameplay.snowGolemMelts(),
+                    gameplay.skyLightLevel(),
                     ambientParticles,
                     ambientSounds.orElse(null),
                     backgroundMusic.orElse(null))));
@@ -155,6 +282,22 @@ public class EnvironmentAttributeCodecs {
         }
         try {
             return DataResult.success(Integer.parseInt(digits, 16));
+        } catch (final NumberFormatException exception) {
+            return DataResult.error(() -> "Malformed hexadecimal color: " + value);
+        }
+    }
+
+    private static String formatHexColorARGB(final int color) {
+        return String.format("#%08x", color);
+    }
+
+    private static DataResult<Integer> parseHexColorARGB(final String value) {
+        final String digits = value.startsWith("#") ? value.substring(1) : value;
+        if (digits.length() != 8) {
+            return DataResult.error(() -> "Expected a #aarrggbb color, got " + value);
+        }
+        try {
+            return DataResult.success((int) Long.parseLong(digits, 16));
         } catch (final NumberFormatException exception) {
             return DataResult.error(() -> "Malformed hexadecimal color: " + value);
         }

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/codecs/world/IntProviderCodecs.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/codecs/world/IntProviderCodecs.java
@@ -1,0 +1,76 @@
+package fr.euphyllia.fidorial.server.codecs.world;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import fr.euphyllia.fidorial.server.codecs.DispatchCodecs;
+import fr.fidorial.world.dimension.IntProvider;
+
+import java.util.List;
+
+public final class IntProviderCodecs {
+
+    public static final Codec<IntProvider> INT_PROVIDER =
+            Codec.recursive("fidorial:int_provider", IntProviderCodecs::createCodec);
+
+    private IntProviderCodecs() {
+        throw new UnsupportedOperationException("IntProviderCodecs cannot be instantiated.");
+    }
+
+    private static Codec<IntProvider> createCodec(final Codec<IntProvider> self) {
+        final MapCodec<IntProvider.Constant> constantCodec = RecordCodecBuilder.mapCodec(instance -> instance.group(
+                Codec.INT.fieldOf("value").forGetter(IntProvider.Constant::value)
+        ).apply(instance, IntProvider.Constant::new));
+
+        final MapCodec<IntProvider.Uniform> uniformCodec = RecordCodecBuilder.mapCodec(instance -> instance.group(
+                Codec.INT.fieldOf("min_inclusive").forGetter(IntProvider.Uniform::minInclusive),
+                Codec.INT.fieldOf("max_inclusive").forGetter(IntProvider.Uniform::maxInclusive)
+        ).apply(instance, IntProvider.Uniform::new));
+
+        final MapCodec<IntProvider.BiasedToBottom> biasedCodec = RecordCodecBuilder.mapCodec(instance -> instance.group(
+                Codec.INT.fieldOf("min_inclusive").forGetter(IntProvider.BiasedToBottom::minInclusive),
+                Codec.INT.fieldOf("max_inclusive").forGetter(IntProvider.BiasedToBottom::maxInclusive)
+        ).apply(instance, IntProvider.BiasedToBottom::new));
+
+        final MapCodec<IntProvider.Clamped> clampedCodec = RecordCodecBuilder.mapCodec(instance -> instance.group(
+                Codec.INT.fieldOf("min_inclusive").forGetter(IntProvider.Clamped::minInclusive),
+                Codec.INT.fieldOf("max_inclusive").forGetter(IntProvider.Clamped::maxInclusive),
+                self.fieldOf("source").forGetter(IntProvider.Clamped::source)
+        ).apply(instance, IntProvider.Clamped::new));
+
+        final MapCodec<IntProvider.ClampedNormal> clampedNormalCodec =
+                RecordCodecBuilder.mapCodec(instance -> instance.group(
+                        Codec.FLOAT.fieldOf("mean").forGetter(IntProvider.ClampedNormal::mean),
+                        Codec.FLOAT.fieldOf("deviation").forGetter(IntProvider.ClampedNormal::deviation),
+                        Codec.INT.fieldOf("min_inclusive").forGetter(IntProvider.ClampedNormal::minInclusive),
+                        Codec.INT.fieldOf("max_inclusive").forGetter(IntProvider.ClampedNormal::maxInclusive)
+                ).apply(instance, IntProvider.ClampedNormal::new));
+
+        final Codec<IntProvider.WeightedList.Entry> entryCodec = RecordCodecBuilder.create(instance -> instance.group(
+                self.fieldOf("data").forGetter(IntProvider.WeightedList.Entry::data),
+                Codec.INT.fieldOf("weight").forGetter(IntProvider.WeightedList.Entry::weight)
+        ).apply(instance, IntProvider.WeightedList.Entry::new));
+
+        final MapCodec<IntProvider.WeightedList> weightedListCodec = entryCodec.listOf()
+                .fieldOf("distribution")
+                .xmap(IntProvider.WeightedList::new, IntProvider.WeightedList::distribution);
+
+        final Codec<IntProvider> dispatch = DispatchCodecs.<IntProvider>matcher("type", List.of(
+                DispatchCodecs.Variant.of("constant", null, true, IntProvider.Constant.class, constantCodec),
+                DispatchCodecs.Variant.of("uniform", null, true, IntProvider.Uniform.class, uniformCodec),
+                DispatchCodecs.Variant.of(
+                        "biased_to_bottom", null, true, IntProvider.BiasedToBottom.class, biasedCodec),
+                DispatchCodecs.Variant.of("clamped", null, true, IntProvider.Clamped.class, clampedCodec),
+                DispatchCodecs.Variant.of(
+                        "clamped_normal", null, true, IntProvider.ClampedNormal.class, clampedNormalCodec),
+                DispatchCodecs.Variant.of(
+                        "weighted_list", null, true, IntProvider.WeightedList.class, weightedListCodec)
+        )).codec();
+
+        return Codec.either(Codec.INT, dispatch).xmap(
+                either -> either.map(IntProvider.Constant::new, provider -> provider),
+                provider -> provider instanceof IntProvider.Constant(int value)
+                        ? com.mojang.datafixers.util.Either.left(value)
+                        : com.mojang.datafixers.util.Either.right(provider));
+    }
+}

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/ClientConnection.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/ClientConnection.java
@@ -133,11 +133,19 @@ public final class ClientConnection extends SimpleChannelInboundHandler<ByteBuf>
     }
 
     public void send(final ClientboundPacket packet) {
-        write(packet).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
+        final ChannelFuture future = write(packet);
+        if (future != null) {
+            future.addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
+        }
     }
 
     public void sendAndClose(final ClientboundPacket packet) {
-        write(packet).addListener(ChannelFutureListener.CLOSE);
+        final ChannelFuture future = write(packet);
+        if (future != null) {
+            future.addListener(ChannelFutureListener.CLOSE);
+        } else {
+            close();
+        }
     }
 
     public void disconnect(final Component reason) {
@@ -154,7 +162,11 @@ public final class ClientConnection extends SimpleChannelInboundHandler<ByteBuf>
         }
     }
 
-    private ChannelFuture write(final ClientboundPacket packet) {
+    private @Nullable ChannelFuture write(final ClientboundPacket packet) {
+        if (!isActive()) {
+            return null;
+        }
+
         final ByteBuf out = ctx.alloc().buffer();
         try {
             final PacketBuffer p = new PacketBuffer(out);

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/listener/ConfigurationPacketHandler.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/listener/ConfigurationPacketHandler.java
@@ -24,6 +24,7 @@ import fr.euphyllia.fidorial.server.registry.Registry;
 import fr.euphyllia.fidorial.server.registry.RegistryHolder;
 import fr.euphyllia.fidorial.server.registry.biome.FidorialBiomeRegistry;
 import fr.euphyllia.fidorial.server.registry.dialog.FidorialDialogRegistry;
+import fr.euphyllia.fidorial.server.registry.dimension.FidorialDimensionTypeRegistry;
 import net.kyori.adventure.nbt.CompoundBinaryTag;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.logger.slf4j.ComponentLogger;
@@ -161,7 +162,8 @@ public final class ConfigurationPacketHandler implements ConfigurationPacketList
                 continue;
             }
             if (reg.name().equals(FidorialBiomeRegistry.REGISTRY_NAME)
-                    || reg.name().equals(FidorialDialogRegistry.REGISTRY_NAME)) {
+                    || reg.name().equals(FidorialDialogRegistry.REGISTRY_NAME)
+                    || reg.name().equals(FidorialDimensionTypeRegistry.REGISTRY_NAME)) {
                 continue;
             }
             connection.send(ClientboundRegistryDataPacket.knownOnly(reg.name(), reg.entries()));
@@ -174,11 +176,15 @@ public final class ConfigurationPacketHandler implements ConfigurationPacketList
         connection.send(new ClientboundRegistryDataPacket(
                 FidorialDialogRegistry.REGISTRY_NAME,
                 server.dialogs().networkEntries()));
+
+        connection.send(new ClientboundRegistryDataPacket(
+                FidorialDimensionTypeRegistry.REGISTRY_NAME,
+                server.dimensionTypes().networkEntries()));
     }
 
     private void sendTags() {
         connection.send(new ClientboundUpdateTagsPacket(
-                server.dynamicRegistries(), server.biomeRegistry(), server.dialogs()));
+                server.dynamicRegistries(), server.biomeRegistry(), server.dialogs(), server.dimensionTypes()));
     }
 
     private boolean sendResourcePackIfConfigured() {

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/listener/PlayPacketHandler.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/listener/PlayPacketHandler.java
@@ -660,8 +660,7 @@ public final class PlayPacketHandler implements PlayPacketListener {
         target.addEntity(player);
 
         final RegistryHolder dynamic = server.dynamicRegistries();
-        final int dimensionType =
-                Math.max(0, dynamic.networkId(Key.key("dimension_type"), target.dimension().id()));
+        final int dimensionType = server.dimensionTypes().networkId(target.generator.dimensionType().key());
         connection.send(new ClientboundRespawnPacket(
                 target.dimension().id(),
                 dimensionType,
@@ -778,9 +777,7 @@ public final class PlayPacketHandler implements PlayPacketListener {
 
         player.resetOnRespawn();
 
-        final RegistryHolder dynamic = server.dynamicRegistries();
-        final int dimensionType =
-                Math.max(0, dynamic.networkId(Key.key("dimension_type"), world.dimension().id()));
+        final int dimensionType = server.dimensionTypes().networkId(world.generator.dimensionType().key());
         connection.send(new ClientboundRespawnPacket(
                 world.dimension().id(),
                 dimensionType,

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/listener/PlayPacketHandler.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/listener/PlayPacketHandler.java
@@ -129,7 +129,7 @@ public final class PlayPacketHandler implements PlayPacketListener {
         connection.setPlayer(player);
         world.addEntity(player);
 
-        sendLoginSequence(dynamic);
+        sendLoginSequence();
         openChunkView(world, dynamic, spawn.chunk());
         spawnPlayer(spawn);
 
@@ -237,8 +237,8 @@ public final class PlayPacketHandler implements PlayPacketListener {
         }
     }
 
-    private void sendLoginSequence(final RegistryHolder dynamic) {
-        final int dimensionType = Math.max(0, dynamic.networkId(Key.key("dimension_type"), worldId()));
+    private void sendLoginSequence() {
+        final int dimensionType = server.dimensionTypes().networkId(worldManager().world(worldId()).generator.dimensionType().key());
         final Key[] dimensions = worldManager().worlds().stream().map(ServerWorld::key).toArray(Key[]::new);
         connection.send(new ClientboundLoginPacket(
                 player.entityId(),

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/protocol/packet/clientbound/configuration/ClientboundUpdateTagsPacket.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/protocol/packet/clientbound/configuration/ClientboundUpdateTagsPacket.java
@@ -7,6 +7,7 @@ import fr.euphyllia.fidorial.server.registry.Registry;
 import fr.euphyllia.fidorial.server.registry.RegistryHolder;
 import fr.euphyllia.fidorial.server.registry.biome.FidorialBiomeRegistry;
 import fr.euphyllia.fidorial.server.registry.dialog.FidorialDialogRegistry;
+import fr.euphyllia.fidorial.server.registry.dimension.FidorialDimensionTypeRegistry;
 import net.kyori.adventure.key.Key;
 
 import java.util.ArrayList;
@@ -17,7 +18,8 @@ import java.util.function.ToIntFunction;
 public record ClientboundUpdateTagsPacket(
         RegistryHolder dynamic,
         FidorialBiomeRegistry biomes,
-        FidorialDialogRegistry dialogs
+        FidorialDialogRegistry dialogs,
+        FidorialDimensionTypeRegistry dimensionTypes
 ) implements ClientboundPacket {
 
     @Override
@@ -39,6 +41,9 @@ public record ClientboundUpdateTagsPacket(
             } else if (reg.name().equals(FidorialDialogRegistry.REGISTRY_NAME)) {
                 tags = dialogs.networkTags();
                 networkId = dialogs::networkId;
+            } else if (reg.name().equals(FidorialDimensionTypeRegistry.REGISTRY_NAME)) {
+                tags = reg.tags();
+                networkId = dimensionTypes::networkId;
             } else {
                 tags = reg.tags();
                 final List<Key> entries = reg.entries();

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/protocol/packet/clientbound/play/ClientboundLevelChunkWithLightPacket.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/protocol/packet/clientbound/play/ClientboundLevelChunkWithLightPacket.java
@@ -15,18 +15,19 @@ public final class ClientboundLevelChunkWithLightPacket implements ClientboundPa
     private final byte[] payload;
 
     public ClientboundLevelChunkWithLightPacket(
-            final ChunkNetworkSerializer serializer, final ChunkColumn column) {
-        this(serializer, column, ByteBufAllocator.DEFAULT);
+            final ChunkNetworkSerializer serializer, final ChunkColumn column, final boolean hasSkylight) {
+        this(serializer, column, ByteBufAllocator.DEFAULT, hasSkylight);
     }
 
     public ClientboundLevelChunkWithLightPacket(
             final ChunkNetworkSerializer serializer,
             final ChunkColumn column,
-            final ByteBufAllocator allocator) {
+            final ByteBufAllocator allocator,
+            final boolean hasSkylight) {
 
         final ByteBuf scratch = allocator.buffer();
         try {
-            serializer.writeChunk(new PacketBuffer(scratch), allocator, column);
+            serializer.writeChunk(new PacketBuffer(scratch), allocator, column, hasSkylight);
             this.payload = new byte[scratch.readableBytes()];
             scratch.readBytes(this.payload);
         } finally {

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/protocol/packet/clientbound/play/ClientboundLightUpdatePacket.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/protocol/packet/clientbound/play/ClientboundLightUpdatePacket.java
@@ -14,21 +14,22 @@ public final class ClientboundLightUpdatePacket implements ClientboundPacket {
 
     private final byte[] payload;
 
-    public ClientboundLightUpdatePacket(final ChunkNetworkSerializer serializer, final ChunkColumn column) {
-        this(serializer, column, ByteBufAllocator.DEFAULT);
+    public ClientboundLightUpdatePacket(final ChunkNetworkSerializer serializer, final ChunkColumn column, final boolean hasSkylight) {
+        this(serializer, column, ByteBufAllocator.DEFAULT, hasSkylight);
     }
 
     public ClientboundLightUpdatePacket(
             final ChunkNetworkSerializer serializer,
             final ChunkColumn column,
-            final ByteBufAllocator allocator) {
+            final ByteBufAllocator allocator,
+            final boolean hasSkylight) {
 
         final ByteBuf scratch = allocator.buffer();
         try {
             final PacketBuffer out = new PacketBuffer(scratch);
             out.writeVarInt(column.chunkX());
             out.writeVarInt(column.chunkZ());
-            serializer.writeLightData(out, column);
+            serializer.writeLightData(out, column, hasSkylight);
             this.payload = new byte[scratch.readableBytes()];
             scratch.readBytes(this.payload);
         } finally {

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/session/ChunkViewTracker.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/session/ChunkViewTracker.java
@@ -175,7 +175,7 @@ public final class ChunkViewTracker implements ChunkViewSource {
 
         final ClientboundLevelChunkWithLightPacket packet;
         synchronized (world.lightManager()) {
-            packet = new ClientboundLevelChunkWithLightPacket(serializer, column);
+            packet = new ClientboundLevelChunkWithLightPacket(serializer, column, world.generator.dimensionType().hasSkylight());
         }
         connection.send(packet);
     }

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/registry/Registries.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/registry/Registries.java
@@ -2,6 +2,7 @@ package fr.euphyllia.fidorial.server.registry;
 
 import fr.euphyllia.fidorial.server.registry.biome.FidorialBiomeRegistry;
 import fr.euphyllia.fidorial.server.registry.dialog.FidorialDialogRegistry;
+import fr.euphyllia.fidorial.server.registry.dimension.FidorialDimensionTypeRegistry;
 import fr.euphyllia.fidorial.server.registry.entity.EntityTypeRegistry;
 import fr.fidorial.registry.Registry;
 import fr.fidorial.registry.RegistryKey;
@@ -20,7 +21,6 @@ import fr.fidorial.registry.data.CowVariant;
 import fr.fidorial.registry.data.DamageType;
 import fr.fidorial.registry.data.DataComponentType;
 import fr.fidorial.registry.data.Dialog;
-import fr.fidorial.registry.data.DimensionType;
 import fr.fidorial.registry.data.Enchantment;
 import fr.fidorial.registry.data.FrogVariant;
 import fr.fidorial.registry.data.GameEvent;
@@ -57,7 +57,6 @@ import fr.fidorial.registry.keys.CowVariantKeys;
 import fr.fidorial.registry.keys.DamageTypeKeys;
 import fr.fidorial.registry.keys.DataComponentTypeKeys;
 import fr.fidorial.registry.keys.DialogKeys;
-import fr.fidorial.registry.keys.DimensionTypeKeys;
 import fr.fidorial.registry.keys.EnchantmentKeys;
 import fr.fidorial.registry.keys.FrogVariantKeys;
 import fr.fidorial.registry.keys.GameEventKeys;
@@ -96,19 +95,22 @@ public final class Registries {
     private final Map<RegistryKey<?>, Registry<?>> typedRegistries;
     private final FidorialBiomeRegistry biomes;
     private final FidorialDialogRegistry dialogs;
+    private final FidorialDimensionTypeRegistry dimensionTypes;
 
     private Registries(
             final RegistryHolder dynamic,
             final RegistryHolder frozen,
             final Map<RegistryKey<?>, Registry<?>> typedRegistries,
             final FidorialBiomeRegistry biomes,
-            final FidorialDialogRegistry dialogs
+            final FidorialDialogRegistry dialogs,
+            final FidorialDimensionTypeRegistry dimensionTypes
     ) {
         this.dynamic = dynamic;
         this.frozen = frozen;
         this.typedRegistries = Map.copyOf(typedRegistries);
         this.biomes = biomes;
         this.dialogs = dialogs;
+        this.dimensionTypes = dimensionTypes;
     }
 
     public static Registries load() {
@@ -117,6 +119,7 @@ public final class Registries {
         final RegistryHolder dynamic = RegistryHolder.of(data.dynamic());
         final FidorialBiomeRegistry biomes = FidorialBiomeRegistry.bootstrap(dynamic, FALLBACK_BIOME);
         final FidorialDialogRegistry dialogs = FidorialDialogRegistry.bootstrap(dynamic);
+        final FidorialDimensionTypeRegistry dimensionTypes = FidorialDimensionTypeRegistry.bootstrap(dynamic);
 
         // bootstrap our API registries
         registries.put(RegistryKey.ATTRIBUTE, simple(RegistryKey.ATTRIBUTE, Attribute.class, AttributeKeys.values()));
@@ -133,7 +136,6 @@ public final class Registries {
         registries.put(RegistryKey.DAMAGE_TYPE, simple(RegistryKey.DAMAGE_TYPE, DamageType.class, DamageTypeKeys.values()));
         registries.put(RegistryKey.DATA_COMPONENT_TYPE, simple(RegistryKey.DATA_COMPONENT_TYPE, DataComponentType.class, DataComponentTypeKeys.values()));
         registries.put(RegistryKey.DIALOG, simple(RegistryKey.DIALOG, Dialog.class, DialogKeys.values()));
-        registries.put(RegistryKey.DIMENSION_TYPE, simple(RegistryKey.DIMENSION_TYPE, DimensionType.class, DimensionTypeKeys.values()));
         registries.put(RegistryKey.ENCHANTMENT, simple(RegistryKey.ENCHANTMENT, Enchantment.class, EnchantmentKeys.values()));
         registries.put(RegistryKey.FROG_VARIANT, simple(RegistryKey.FROG_VARIANT, FrogVariant.class, FrogVariantKeys.values()));
         registries.put(RegistryKey.GAME_EVENT, simple(RegistryKey.GAME_EVENT, GameEvent.class, GameEventKeys.values()));
@@ -159,7 +161,7 @@ public final class Registries {
         registries.put(RegistryKey.ZOMBIE_NAUTILUS_VARIANT, simple(RegistryKey.ZOMBIE_NAUTILUS_VARIANT, ZombieNautilusVariant.class, ZombieNautilusVariantKeys.values()));
         registries.put(RegistryKey.ENTITY_TYPE, new EntityTypeRegistry());
 
-        return new Registries(dynamic, RegistryHolder.of(data.frozen()), registries, biomes, dialogs);
+        return new Registries(dynamic, RegistryHolder.of(data.frozen()), registries, biomes, dialogs, dimensionTypes);
     }
 
     private static <T> SimpleRegistry<T> simple(
@@ -176,6 +178,10 @@ public final class Registries {
 
     public FidorialDialogRegistry dialogs() {
         return dialogs;
+    }
+
+    public FidorialDimensionTypeRegistry dimensionTypes() {
+        return dimensionTypes;
     }
 
     public RegistryHolder dynamic() {

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/registry/dimension/FidorialDimensionTypeRegistry.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/registry/dimension/FidorialDimensionTypeRegistry.java
@@ -1,0 +1,241 @@
+package fr.euphyllia.fidorial.server.registry.dimension;
+
+import fr.euphyllia.fidorial.server.codecs.world.DimensionTypeCodecs;
+import fr.euphyllia.fidorial.server.registry.RegistryEntry;
+import fr.euphyllia.fidorial.server.registry.RegistryHolder;
+import fr.fidorial.registry.Registry;
+import fr.fidorial.registry.RegistryKey;
+import fr.fidorial.registry.TypedKey;
+import fr.fidorial.registry.data.DimensionType;
+import fr.fidorial.world.dimension.DimensionTypeDefinition;
+import fr.fidorial.world.dimension.DimensionTypeRegistry;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.nbt.CompoundBinaryTag;
+import net.kyori.adventure.text.logger.slf4j.ComponentLogger;
+import org.jspecify.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Stream;
+
+public final class FidorialDimensionTypeRegistry implements DimensionTypeRegistry, Registry<DimensionType> {
+
+    public static final Key REGISTRY_NAME = Key.key("dimension_type");
+
+    private static final ComponentLogger LOGGER = ComponentLogger.logger(FidorialDimensionTypeRegistry.class);
+
+    private final AtomicBoolean started = new AtomicBoolean(false);
+
+    private volatile Snapshot snapshot;
+
+    private FidorialDimensionTypeRegistry(final List<Key> vanilla) {
+        final Map<Key, @Nullable DimensionTypeDefinition> initial = new LinkedHashMap<>();
+        for (final Key key : vanilla) {
+            initial.put(key, null);
+        }
+        this.snapshot = Snapshot.of(initial);
+    }
+
+    public static FidorialDimensionTypeRegistry bootstrap(final RegistryHolder dynamic) {
+        final fr.euphyllia.fidorial.server.registry.Registry source = dynamic.get(REGISTRY_NAME);
+        final List<Key> entries = source == null ? List.of() : source.entries();
+
+        if (entries.isEmpty()) {
+            LOGGER.warn("No vanilla dimension type found in the registry dump, starting empty.");
+        }
+
+        return new FidorialDimensionTypeRegistry(entries);
+    }
+
+    @Override
+    public DimensionTypeDefinition register(final DimensionTypeDefinition definition) {
+        Objects.requireNonNull(definition, "definition");
+        synchronized (this) {
+            if (snapshot.definitions.containsKey(definition.key()) || snapshot.ids.containsKey(definition.key())) {
+                throw new IllegalStateException("A dimension type is already registered under "
+                        + definition.key().asString() + "; use overwrite(DimensionTypeDefinition) to replace it.");
+            }
+            final Map<Key, @Nullable DimensionTypeDefinition> next = snapshot.mutableCopy();
+            next.put(definition.key(), definition);
+            publish(next, "registered", definition.key());
+        }
+        return definition;
+    }
+
+    @Override
+    public DimensionTypeDefinition registerFromJson(final Key key, final String json) {
+        return register(DimensionTypeCodecs.fromJson(key, json));
+    }
+
+    @Override
+    public Optional<DimensionTypeDefinition> overwrite(final DimensionTypeDefinition definition) {
+        Objects.requireNonNull(definition, "definition");
+        synchronized (this) {
+            final DimensionTypeDefinition previous = snapshot.definitions.get(definition.key());
+            final Map<Key, @Nullable DimensionTypeDefinition> next = snapshot.mutableCopy();
+            next.put(definition.key(), definition);
+            publish(next, previous == null && !snapshot.ids.containsKey(definition.key())
+                    ? "registered" : "redefined", definition.key());
+            return Optional.ofNullable(previous);
+        }
+    }
+
+    @Override
+    public boolean unregister(final Key key) {
+        Objects.requireNonNull(key, "key");
+        synchronized (this) {
+            if (!snapshot.ids.containsKey(key)) {
+                return false;
+            }
+            final Map<Key, @Nullable DimensionTypeDefinition> next = snapshot.mutableCopy();
+            next.remove(key);
+            publish(next, "unregistered", key);
+            return true;
+        }
+    }
+
+    @Override
+    public Optional<DimensionTypeDefinition> definition(final Key key) {
+        return Optional.ofNullable(snapshot.definitions.get(key));
+    }
+
+    @Override
+    public boolean contains(final Key key) {
+        return snapshot.ids.containsKey(key);
+    }
+
+    @Override
+    public boolean isCustom(final Key key) {
+        return snapshot.definitions.containsKey(key);
+    }
+
+    @Override
+    public Collection<Key> keys() {
+        return snapshot.order;
+    }
+
+    @Override
+    public Collection<DimensionTypeDefinition> definitions() {
+        return snapshot.definitions.values();
+    }
+
+    @Override
+    public int networkId(final Key key) {
+        final Integer id = snapshot.ids.get(key);
+        return id == null ? -1 : id;
+    }
+
+    @Override
+    public int totalRegistered() {
+        return snapshot.order.size();
+    }
+
+    public List<RegistryEntry> networkEntries() {
+        final Snapshot current = snapshot;
+        final List<RegistryEntry> entries = new ArrayList<>(current.order.size());
+        for (final Key key : current.order) {
+            entries.add(new RegistryEntry(key, current.payloads.get(key)));
+        }
+        return entries;
+    }
+
+    @Override
+    public RegistryKey<DimensionType> registryKey() {
+        return RegistryKey.DIMENSION_TYPE;
+    }
+
+    @Override
+    public DimensionType get(final TypedKey<DimensionType> key) {
+        return snapshot.values.get(key.key());
+    }
+
+    @Override
+    public Optional<DimensionType> find(final TypedKey<DimensionType> key) {
+        return Optional.ofNullable(snapshot.values.get(key.key()));
+    }
+
+    @Override
+    public TypedKey<DimensionType> key(final DimensionType value) {
+        return TypedKey.create(RegistryKey.DIMENSION_TYPE, value.key());
+    }
+
+    @Override
+    public Collection<DimensionType> values() {
+        return snapshot.valueList;
+    }
+
+    @Override
+    public Stream<DimensionType> stream() {
+        return snapshot.valueList.stream();
+    }
+
+    private void publish(final Map<Key, @Nullable DimensionTypeDefinition> next, final String action, final Key key) {
+        this.snapshot = Snapshot.of(next);
+        if (started.get()) {
+            LOGGER.warn("Dimension type {} {} after startup: only clients connecting from now on will see the change.",
+                    key.asString(), action);
+        } else {
+            LOGGER.debug("Dimension type {} {}.", key.asString(), action);
+        }
+    }
+
+    private record Snapshot(
+            List<Key> order,
+            Map<Key, Integer> ids,
+            Map<Key, DimensionTypeDefinition> definitions,
+            Map<Key, CompoundBinaryTag> payloads,
+            Map<Key, DimensionType> values,
+            List<DimensionType> valueList
+    ) {
+
+        static Snapshot of(final Map<Key, @Nullable DimensionTypeDefinition> source) {
+            final List<Key> order = new ArrayList<>(source.size());
+            final Map<Key, Integer> ids = new LinkedHashMap<>(source.size());
+            final Map<Key, DimensionTypeDefinition> definitions = new LinkedHashMap<>();
+            final Map<Key, CompoundBinaryTag> payloads = new LinkedHashMap<>();
+            final Map<Key, DimensionType> values = new LinkedHashMap<>(source.size());
+            final List<DimensionType> valueList = new ArrayList<>(source.size());
+
+            int index = 0;
+            for (final Map.Entry<Key, @Nullable DimensionTypeDefinition> entry : source.entrySet()) {
+                final Key key = entry.getKey();
+                final DimensionTypeDefinition definition = entry.getValue();
+                final DimensionType value = definition != null ? definition : new VanillaDimensionType(key);
+
+                order.add(key);
+                ids.put(key, index++);
+                if (definition != null) {
+                    definitions.put(key, definition);
+                    payloads.put(key, DimensionTypeCodecs.encodeNbt(definition));
+                }
+                values.put(key, value);
+                valueList.add(value);
+            }
+
+            return new Snapshot(
+                    List.copyOf(order),
+                    Map.copyOf(ids),
+                    java.util.Collections.unmodifiableMap(definitions),
+                    Map.copyOf(payloads),
+                    Map.copyOf(values),
+                    List.copyOf(valueList));
+        }
+
+        Map<Key, @Nullable DimensionTypeDefinition> mutableCopy() {
+            final Map<Key, @Nullable DimensionTypeDefinition> copy = new LinkedHashMap<>();
+            for (final Key key : order) {
+                copy.put(key, definitions.get(key));
+            }
+            return copy;
+        }
+    }
+
+    private record VanillaDimensionType(Key key) implements DimensionType {
+    }
+}

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/schedulers/LightUpdateDispatcher.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/schedulers/LightUpdateDispatcher.java
@@ -203,7 +203,7 @@ public class LightUpdateDispatcher {
                                 if (column == null) {
                                     continue;
                                 }
-                                broadcaster.accept(new ClientboundLightUpdatePacket(serializer, column));
+                                broadcaster.accept(new ClientboundLightUpdatePacket(serializer, column, serverWorld.generator.dimensionType().hasSkylight()));
                             }
                         }
                     } catch (final InterruptedException e) {
@@ -301,7 +301,7 @@ public class LightUpdateDispatcher {
                         if (column == null) {
                             continue;
                         }
-                        broadcaster.accept(new ClientboundLightUpdatePacket(serializer, column));
+                        broadcaster.accept(new ClientboundLightUpdatePacket(serializer, column, serverWorld.generator.dimensionType().hasSkylight()));
                     }
                 }
             } catch (final InterruptedException e) {

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/ChunkGenerator.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/ChunkGenerator.java
@@ -1,6 +1,7 @@
 package fr.euphyllia.fidorial.server.world;
 
 import fr.euphyllia.fidorial.server.world.chunk.ChunkColumn;
+import fr.fidorial.world.dimension.DimensionTypeDefinition;
 
 public interface ChunkGenerator {
 
@@ -8,7 +9,5 @@ public interface ChunkGenerator {
 
     ChunkGeneratorConfig describeForSave();
 
-    int minY();
-
-    int height();
+    DimensionTypeDefinition dimensionType();
 }

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/ChunkNetworkSerializer.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/ChunkNetworkSerializer.java
@@ -34,7 +34,7 @@ public final class ChunkNetworkSerializer {
         this.biomes = biomes;
     }
 
-    public void writeChunk(final PacketBuffer p, final ByteBufAllocator alloc, final ChunkColumn chunk) {
+    public void writeChunk(final PacketBuffer p, final ByteBufAllocator alloc, final ChunkColumn chunk, final boolean hasSkylight) {
         p.writeInt(chunk.chunkX());
         p.writeInt(chunk.chunkZ());
         p.writeVarInt(0); // heightmaps : 0 → le client recalcule
@@ -44,7 +44,7 @@ public final class ChunkNetworkSerializer {
 
         writeBlockEntities(p, chunk);
 
-        writeLightData(p, chunk);
+        writeLightData(p, chunk, hasSkylight);
     }
 
     /**
@@ -164,13 +164,17 @@ public final class ChunkNetworkSerializer {
             for (final Key biome : palette) {
                 sp.writeVarInt(biomes.networkIdOrFallback(biome));
             }
-            writeLongs(sp, container.packedData(), bits, ChunkSection.BIOME_COUNT);
+            writeLongs(sp, BitPacking.pack(snap.data(), bits), bits, ChunkSection.BIOME_COUNT);
             return;
         }
 
         final int directBits = BitPacking.bitsFor(biomes.totalRegistered(), 1);
         sp.writeByte(directBits);
-        writeLongs(sp, container.packedGlobal(directBits, biomes::networkIdOrFallback), directBits, ChunkSection.BIOME_COUNT);
+        final int[] global = new int[snap.data().length];
+        for (int i = 0; i < global.length; i++) {
+            global[i] = biomes.networkIdOrFallback(snap.get(i));
+        }
+        writeLongs(sp, BitPacking.pack(global, directBits), directBits, ChunkSection.BIOME_COUNT);
     }
 
     public byte[] buildBiomes(final ByteBufAllocator alloc, final ChunkColumn chunk) {
@@ -196,7 +200,7 @@ public final class ChunkNetworkSerializer {
         }
     }
 
-    public void writeLightData(final PacketBuffer p, final ChunkColumn chunk) {
+    public void writeLightData(final PacketBuffer p, final ChunkColumn chunk, final boolean hasSkylight) {
         final int worldSections = chunk.sectionCount();
         final int lightSections = worldSections + 2;
         final int topIndex = lightSections - 1;
@@ -214,7 +218,9 @@ public final class ChunkNetworkSerializer {
         for (int i = 0; i < lightSections; i++) {
             final byte[] sky;
 
-            if (i == topIndex) {
+            if (!hasSkylight) {
+                sky = null; // no sky light layer for this dimension at all
+            } else if (i == topIndex) {
                 sky = FULL_LIGHT;
             } else if (i == 0) {
                 sky = null;

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/FlatChunkGenerator.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/FlatChunkGenerator.java
@@ -3,33 +3,31 @@ package fr.euphyllia.fidorial.server.world;
 import fr.euphyllia.fidorial.server.world.chunk.BlockState;
 import fr.euphyllia.fidorial.server.world.chunk.ChunkColumn;
 import fr.fidorial.registry.keys.BlockTypeKeys;
+import fr.fidorial.world.dimension.DimensionTypeDefinition;
 import net.kyori.adventure.key.Key;
 
 public final class FlatChunkGenerator implements ChunkGenerator {
 
-    private final int minY;
-    private final int height;
     private final BlockState floor;
     private final Key biome;
     private final int floorThickness;
+    private final DimensionTypeDefinition dimensionType;
 
-    public FlatChunkGenerator(int minY, int height, BlockState floor, Key biome, int floorThickness) {
-        this.minY = minY;
-        this.height = height;
+    public FlatChunkGenerator(DimensionTypeDefinition dimensionType, BlockState floor, Key biome, int floorThickness) {
+        this.dimensionType = dimensionType;
         this.floor = floor;
         this.biome = biome;
         this.floorThickness = floorThickness;
     }
 
-    public static FlatChunkGenerator cobblestone(int minY, int height) {
-        return new FlatChunkGenerator(minY, height,
-                BlockState.of(Key.key("cobblestone")), Key.key("plains"), 16);
+    public static FlatChunkGenerator cobblestone(final DimensionTypeDefinition dimensionType) {
+        return new FlatChunkGenerator(dimensionType, BlockState.of(Key.key("cobblestone")), Key.key("plains"), 16);
     }
 
     @Override
     public ChunkColumn generate(int chunkX, int chunkZ) {
-        ChunkColumn chunk = new ChunkColumn(chunkX, chunkZ, minY, height, BlockState.of(BlockTypeKeys.AIR.key()), biome);
-        for (int y = minY; y < minY + floorThickness; y++) {
+        ChunkColumn chunk = new ChunkColumn(chunkX, chunkZ, dimensionType.minY(), dimensionType.height(), BlockState.of(BlockTypeKeys.AIR.key()), biome);
+        for (int y = dimensionType.minY(); y < dimensionType.minY() + floorThickness; y++) {
             for (int z = 0; z < 16; z++) {
                 for (int x = 0; x < 16; x++) {
                     chunk.setBlock(x, y, z, floor);
@@ -45,12 +43,7 @@ public final class FlatChunkGenerator implements ChunkGenerator {
     }
 
     @Override
-    public int minY() {
-        return this.minY;
-    }
-
-    @Override
-    public int height() {
-        return this.height;
+    public DimensionTypeDefinition dimensionType() {
+        return dimensionType;
     }
 }

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/PluginBackedChunkGenerator.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/PluginBackedChunkGenerator.java
@@ -2,6 +2,7 @@ package fr.euphyllia.fidorial.server.world;
 
 import fr.euphyllia.fidorial.server.world.chunk.BlockState;
 import fr.euphyllia.fidorial.server.world.chunk.ChunkColumn;
+import fr.fidorial.world.dimension.DimensionTypeDefinition;
 import fr.fidorial.world.generation.GenerationDescriptor;
 import fr.fidorial.world.generation.WorldGenerator;
 import net.kyori.adventure.key.Key;
@@ -14,20 +15,17 @@ public final class PluginBackedChunkGenerator implements ChunkGenerator {
 
     private final WorldGenerator generator;
     private final ChunkGenerator fallback;
-    private final int minY;
-    private final int height;
+    private final DimensionTypeDefinition dimensionType;
 
-    public PluginBackedChunkGenerator(
-            final WorldGenerator generator, final ChunkGenerator fallback, final int minY, final int height) {
+    public PluginBackedChunkGenerator(final WorldGenerator generator, final ChunkGenerator fallback) {
         this.generator = generator;
         this.fallback = fallback;
-        this.minY = minY;
-        this.height = height;
+        this.dimensionType = generator.dimensionType();
     }
 
     @Override
     public ChunkColumn generate(final int chunkX, final int chunkZ) {
-        final PluginGeneratedChunk chunk = new PluginGeneratedChunk(chunkX, chunkZ, minY, height, DEFAULT_BIOME);
+        final PluginGeneratedChunk chunk = new PluginGeneratedChunk(chunkX, chunkZ, dimensionType.minY(), dimensionType.height(), DEFAULT_BIOME);
         try {
             generator.generate(chunk);
             return chunk.column();
@@ -55,12 +53,7 @@ public final class PluginBackedChunkGenerator implements ChunkGenerator {
     }
 
     @Override
-    public int minY() {
-        return this.minY;
-    }
-
-    @Override
-    public int height() {
-        return this.height;
+    public DimensionTypeDefinition dimensionType() {
+        return dimensionType;
     }
 }

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/ServerWorld.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/ServerWorld.java
@@ -29,6 +29,7 @@ import fr.fidorial.world.BlockPos;
 import fr.fidorial.world.Chunk;
 import fr.fidorial.world.ChunkPos;
 import fr.fidorial.world.World;
+import fr.fidorial.world.dimension.DimensionTypeDefinition;
 import fr.fidorial.world.entity.EntitySpawnBridge;
 import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.longs.LongIterable;
@@ -60,6 +61,7 @@ public final class ServerWorld implements World {
     private final BlockStateRegistry blockStates;
     private final EntityManager entities = new EntityManager();
     private final WorldTimeEngine dayNightCycle;
+    private final DimensionTypeDefinition dimensionType;
     private final int minY;
     private final int height;
     private final WorldLightManager lightManager;
@@ -85,9 +87,7 @@ public final class ServerWorld implements World {
             final EntityRegionStorage entityStorage,
             final AnvilEntitySerializer entitySerializer,
             final ChunkGenerator generator,
-            final BlockStateRegistry blockStates,
-            final int minY,
-            final int height
+            final BlockStateRegistry blockStates
     ) {
         this.dimension = dimension;
         this.storage = storage;
@@ -96,8 +96,9 @@ public final class ServerWorld implements World {
         this.generator = generator;
         this.blockStates = blockStates;
         this.dayNightCycle = new WorldTimeEngine(WorldClocks.forDimension(dimension));
-        this.minY = minY;
-        this.height = height;
+        this.dimensionType = generator.dimensionType();
+        this.minY = dimensionType.minY();
+        this.height = dimensionType.height();
         this.lightManager = new WorldLightManager(new WorldLightAccess());
         this.fallbackEngine = new FloodFillLightEngine(minY, height);
     }
@@ -133,6 +134,11 @@ public final class ServerWorld implements World {
     @Override
     public int height() {
         return height;
+    }
+
+    @Override
+    public DimensionTypeDefinition dimensionType() {
+        return dimensionType;
     }
 
     public void setChunkLoader(final AsyncChunkLoader loader) {
@@ -261,7 +267,7 @@ public final class ServerWorld implements World {
         try {
             column = loaded.computeIfAbsent(k, _ -> {
                 try {
-                    final ChunkColumn fromDisk = storage.load(dimension, chunkX, chunkZ, generator.minY(), generator.height());
+                    final ChunkColumn fromDisk = storage.load(dimension, chunkX, chunkZ, dimensionType.minY(), dimensionType.height());
                     if (fromDisk != null) {
                         return fromDisk;
                     }

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/ServiceBackedChunkGenerator.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/ServiceBackedChunkGenerator.java
@@ -3,6 +3,7 @@ package fr.euphyllia.fidorial.server.world;
 import fr.euphyllia.fidorial.server.world.chunk.BlockState;
 import fr.euphyllia.fidorial.server.world.chunk.ChunkColumn;
 import fr.fidorial.service.ServiceRegistry;
+import fr.fidorial.world.dimension.DimensionTypeDefinition;
 import fr.fidorial.world.generation.GenerationDescriptor;
 import fr.fidorial.world.generation.WorldGenerator;
 import net.kyori.adventure.key.Key;
@@ -15,14 +16,10 @@ public class ServiceBackedChunkGenerator implements ChunkGenerator {
 
     private final ServiceRegistry services;
     private final ChunkGenerator fallback;
-    private final int minY;
-    private final int height;
 
-    public ServiceBackedChunkGenerator(final ServiceRegistry services, final ChunkGenerator fallback, final int minY, final int height) {
+    public ServiceBackedChunkGenerator(final ServiceRegistry services, final ChunkGenerator fallback) {
         this.services = services;
         this.fallback = fallback;
-        this.minY = minY;
-        this.height = height;
     }
 
     @Override
@@ -32,7 +29,7 @@ public class ServiceBackedChunkGenerator implements ChunkGenerator {
             return fallback.generate(chunkX, chunkZ);
         }
 
-        final PluginGeneratedChunk chunk = new PluginGeneratedChunk(chunkX, chunkZ, minY, height, DEFAULT_BIOME);
+        final PluginGeneratedChunk chunk = new PluginGeneratedChunk(chunkX, chunkZ, custom.dimensionType().minY(), custom.dimensionType().height(), DEFAULT_BIOME);
         try {
             custom.generate(chunk);
             return chunk.column();
@@ -63,14 +60,12 @@ public class ServiceBackedChunkGenerator implements ChunkGenerator {
     }
 
     @Override
-    public int minY() {
+    public DimensionTypeDefinition dimensionType() {
         final WorldGenerator custom = services.find(WorldGenerator.class).orElse(null);
-        return custom != null ? custom.minY() : this.minY;
-    }
+        if (custom == null) {
+            return fallback.dimensionType();
+        }
 
-    @Override
-    public int height() {
-        final WorldGenerator custom = services.find(WorldGenerator.class).orElse(null);
-        return custom != null ? custom.height() : this.height;
+        return custom.dimensionType();
     }
 }

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/WorldManager.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/WorldManager.java
@@ -14,6 +14,7 @@ import fr.euphyllia.fidorial.server.world.storage.LevelData;
 import fr.euphyllia.fidorial.server.world.storage.WorldPaths;
 import fr.euphyllia.fidorial.server.world.time.WorldTimeEngine;
 import fr.fidorial.registry.keys.BlockTypeKeys;
+import fr.fidorial.world.dimension.types.VanillaDimensionTypes;
 import fr.fidorial.world.entity.EntitySpawnBridge;
 import fr.fidorial.world.generation.WorldGenerator;
 import net.kyori.adventure.key.Key;
@@ -86,8 +87,7 @@ public final class WorldManager implements AutoCloseable {
 
     public ServerWorld registerDimension(final Dimension dim, final ChunkGenerator generator) {
         return worlds.computeIfAbsent(dim.id(), _ -> {
-            final ServerWorld world = new ServerWorld(
-                    dim, storage, entityStorage, entitySerializer, generator, blockStates, generator.minY(), generator.height());
+            final ServerWorld world = new ServerWorld(dim, storage, entityStorage, entitySerializer, generator, blockStates);
             if (chunkLoader != null) {
                 world.setChunkLoader(chunkLoader);
             }
@@ -151,7 +151,7 @@ public final class WorldManager implements AutoCloseable {
     public ServerWorld overworld() {
         final ChunkGenerator chunkGenerator = defaultGenerator;
         final ChunkGenerator generator =
-                chunkGenerator != null ? chunkGenerator : FlatChunkGenerator.cobblestone(WorldConstants.MIN_Y, WorldConstants.HEIGHT);
+                chunkGenerator != null ? chunkGenerator : FlatChunkGenerator.cobblestone(VanillaDimensionTypes.OVERWORLD);
         return registerDimension(Dimension.OVERWORLD, generator);
     }
 
@@ -160,11 +160,12 @@ public final class WorldManager implements AutoCloseable {
     }
 
     public ServerWorld createWorld(final Key key, final long seed, final @Nullable WorldGenerator generator) {
-        final Dimension dim = Dimension.datapack(key.namespace(), key.value());
         final ChunkGenerator chunkGenerator = generator != null
                 ? new PluginBackedChunkGenerator(
-                generator, FlatChunkGenerator.cobblestone(generator.minY(), generator.height()), generator.minY(), generator.height())
-                : FlatChunkGenerator.cobblestone(WorldConstants.MIN_Y, WorldConstants.HEIGHT);
+                generator, FlatChunkGenerator.cobblestone(generator.dimensionType()))
+                : FlatChunkGenerator.cobblestone(VanillaDimensionTypes.OVERWORLD);
+
+        final Dimension dim = Dimension.datapack(key, chunkGenerator.dimensionType().key());
 
         final boolean existed = worlds.containsKey(dim.id());
         final ServerWorld world = registerDimension(dim, chunkGenerator);

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/fluid/FluidEngine.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/fluid/FluidEngine.java
@@ -332,7 +332,7 @@ public final class FluidEngine implements FluidManager {
         if (key == null || Dimension.OVERWORLD.id().equals(key)) {
             return worlds.overworld();
         }
-        return worlds.dimension(Dimension.datapack(key.namespace(), key.value()));
+        return worlds.dimension(Dimension.datapack(key));
     }
 
     public void setLightHook(final LightHook hook) {

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/storage/Dimension.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/storage/Dimension.java
@@ -1,24 +1,24 @@
 package fr.euphyllia.fidorial.server.world.storage;
 
+import fr.fidorial.registry.keys.DimensionTypeKeys;
 import net.kyori.adventure.key.Key;
 import org.jspecify.annotations.Nullable;
 
 public record Dimension(
-        String namespace,
-        String path,
+        Key id,
         @Nullable String legacyFolder,
-        Key id
+        Key dimensionType
 ) {
 
-    public static final Dimension OVERWORLD = new Dimension(Key.MINECRAFT_NAMESPACE, "overworld", null);
-    public static final Dimension THE_NETHER = new Dimension(Key.MINECRAFT_NAMESPACE, "the_nether", "DIM-1");
-    public static final Dimension THE_END = new Dimension(Key.MINECRAFT_NAMESPACE, "the_end", "DIM1");
+    public static final Dimension OVERWORLD = new Dimension(Key.key("overworld"), null, DimensionTypeKeys.OVERWORLD.key());
+    public static final Dimension THE_NETHER = new Dimension(Key.key("the_nether"), "DIM-1", DimensionTypeKeys.THE_NETHER.key());
+    public static final Dimension THE_END = new Dimension(Key.key("the_end"), "DIM1", DimensionTypeKeys.THE_END.key());
 
-    public Dimension(final String namespace, final String path, final @Nullable String legacyFolder) {
-        this(namespace, path, legacyFolder, Key.key(namespace, path));
+    public static Dimension datapack(final Key id, final Key dimensionType) {
+        return new Dimension(id, null, dimensionType);
     }
 
-    public static Dimension datapack(final String namespace, final String path) {
-        return new Dimension(namespace, path, null);
+    public static Dimension datapack(final Key id) {
+        return datapack(id, DimensionTypeKeys.OVERWORLD.key());
     }
 }

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/storage/WorldPaths.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/storage/WorldPaths.java
@@ -26,7 +26,7 @@ public class WorldPaths {
     }
 
     private Path modernDimensionRoot(final Dimension dim) {
-        return worldRoot.resolve("dimensions").resolve(dim.namespace()).resolve(dim.path());
+        return worldRoot.resolve("dimensions").resolve(dim.id().namespace()).resolve(dim.id().value());
     }
 
     private Path legacyDimensionRoot(final Dimension dim) {

--- a/fidorial-test-plugin/src/main/java/fr/euphyllia/fidorial/testplugin/TestPlugin.java
+++ b/fidorial-test-plugin/src/main/java/fr/euphyllia/fidorial/testplugin/TestPlugin.java
@@ -11,6 +11,7 @@ import fr.euphyllia.fidorial.testplugin.mob.BullMobs;
 import fr.euphyllia.fidorial.testplugin.mob.CompanionMobs;
 import fr.euphyllia.fidorial.testplugin.pregen.PregenTask;
 import fr.euphyllia.fidorial.testplugin.terrain.TestBiomes;
+import fr.euphyllia.fidorial.testplugin.terrain.TestDimensionTypes;
 import fr.euphyllia.fidorial.testplugin.worldgen.GeneratorSettings;
 import fr.euphyllia.fidorial.testplugin.worldgen.OverworldGenerator;
 import fr.fidorial.Server;
@@ -107,6 +108,8 @@ public final class TestPlugin implements Plugin {
         TestBiomes.registerAll(context.server().biomes(), context.logger());
 
         TestDialogs.registerAll(context.server().dialogs(), context.logger());
+
+        TestDimensionTypes.registerAll(context.server().dimensionTypes(), context.logger());
 
 //        BullMobs.attachToCows(context.server().mobs(), this, context.logger());
        BullMobs.registerBull(context.server().mobs(), this, context.logger());

--- a/fidorial-test-plugin/src/main/java/fr/euphyllia/fidorial/testplugin/TestPlugin.java
+++ b/fidorial-test-plugin/src/main/java/fr/euphyllia/fidorial/testplugin/TestPlugin.java
@@ -160,6 +160,7 @@ public final class TestPlugin implements Plugin {
         server.commands().unregisterNamespace(context.meta());
         TestBiomes.unregisterAll(server.biomes());
         TestDialogs.unregisterAll(server.dialogs());
+        TestDimensionTypes.unregisterAll(context.server().dimensionTypes());
         BullMobs.unregisterAll(server.mobs(), this);
         server.mobs().unregisterAll(this);
         TestPluginTranslations.unregister();

--- a/fidorial-test-plugin/src/main/java/fr/euphyllia/fidorial/testplugin/command/ApiTestCommand.java
+++ b/fidorial-test-plugin/src/main/java/fr/euphyllia/fidorial/testplugin/command/ApiTestCommand.java
@@ -569,7 +569,7 @@ public final class ApiTestCommand {
                 "[TestPlugin] Monde cree: " + world.key()
                         + " | minY=" + world.minY()
                         + " | height=" + world.height()
-                        + " | type=" + world.dimensionType()
+                        + " | type=" + world.dimensionType().key()
                         + " | total=" + plugin.server().worlds().size());
 
         return Command.SINGLE_SUCCESS;

--- a/fidorial-test-plugin/src/main/java/fr/euphyllia/fidorial/testplugin/command/ApiTestCommand.java
+++ b/fidorial-test-plugin/src/main/java/fr/euphyllia/fidorial/testplugin/command/ApiTestCommand.java
@@ -9,6 +9,8 @@ import fr.euphyllia.fidorial.testplugin.CounterService;
 import fr.euphyllia.fidorial.testplugin.TestPlugin;
 import fr.euphyllia.fidorial.testplugin.command.argument.BaguetteArgument;
 import fr.euphyllia.fidorial.testplugin.terrain.HillsGenerator;
+import fr.euphyllia.fidorial.testplugin.terrain.SwamplandGenerator;
+import fr.euphyllia.fidorial.testplugin.worldgen.OverworldGenerator;
 import fr.fidorial.command.CommandSender;
 import fr.fidorial.command.CommandSource;
 import fr.fidorial.command.MessageComponentSerializer;
@@ -59,6 +61,10 @@ public final class ApiTestCommand {
 
     private final Map<UUID, Map<Key, BossBar>> playerBossBars = new ConcurrentHashMap<>();
 
+    private static final List<String> GENERATOR_NAMES = List.of(
+            "swampland", "hills", "overworld"
+    );
+
     public ApiTestCommand(final TestPlugin plugin) {
         ApiTestCommand.plugin = plugin;
     }
@@ -106,9 +112,23 @@ public final class ApiTestCommand {
                         .then(argument("name", ArgumentTypes.world())
                                 .executes(ctx -> tpWorld(plugin, ctx, ctx.getArgument("name", World.class).key()))))
                 .then(literal("createworld")
-                        .executes(ctx -> createWorld(ctx, Key.key(UUID.randomUUID().toString())))
+                        .executes(ctx -> createWorld(ctx, Key.key(UUID.randomUUID().toString()), "overworld"))
                         .then(argument("name", ArgumentTypes.key())
-                                .executes(ctx -> createWorld(ctx, ctx.getArgument("name", Key.class)))))
+                                .executes(ctx -> createWorld(ctx, ctx.getArgument("name", Key.class), "overworld"))
+                                .then(argument("generator", ArgumentTypes.greedyString())
+                                        .suggests((_, builder) -> {
+                                            final String remaining = builder.getRemaining().toLowerCase(Locale.ROOT);
+                                            for (final String name : GENERATOR_NAMES) {
+                                                if (name.startsWith(remaining)) {
+                                                    builder.suggest(name);
+                                                }
+                                            }
+                                            return builder.buildFuture();
+                                        })
+                                        .executes(ctx -> createWorld(
+                                                ctx,
+                                                ctx.getArgument("name", Key.class),
+                                                ctx.getArgument("generator", String.class))))))
                 .then(literal("unloadworld")
                         .executes(ctx -> unloadWorld(ctx, Key.key(UUID.randomUUID().toString())))
                         .then(argument("name", ArgumentTypes.world())
@@ -331,8 +351,6 @@ public final class ApiTestCommand {
         final CommandSender sender = ctx.getSource().sender();
 
         if (!(sender instanceof final Player player)) {
-            // placeholder, the server command should support non players executors as it will need the players selected
-            // look at mc brigadier commands https://mcsrc.dev/1/26.2/net/minecraft/server/commands/BossBarCommands
             plugin.msg(sender, "<red>[TestPlugin] Run this command in-game.</red>");
             return Command.SINGLE_SUCCESS;
         }
@@ -519,8 +537,17 @@ public final class ApiTestCommand {
         return Command.SINGLE_SUCCESS;
     }
 
+    private static WorldGenerator resolveGenerator(final String name, final long seed) {
+        return switch (name.toLowerCase(Locale.ROOT)) {
+            case "swampland" -> new SwamplandGenerator(seed, 68, 5, 62, 110);
+            case "hills" -> new HillsGenerator(seed, 64, 24, 60);
+            case "overworld" -> new OverworldGenerator(seed);
+            default -> throw new IllegalArgumentException("Unknown generator: " + name);
+        };
+    }
+
     private static int createWorld(
-            final CommandContext<CommandSource> ctx, final Key key) {
+            final CommandContext<CommandSource> ctx, final Key key, final String generatorName) {
         final CommandSender sender = ctx.getSource().sender();
 
         if (plugin.server().world(key).isPresent()) {
@@ -529,7 +556,7 @@ public final class ApiTestCommand {
         }
 
         final long seed = 20260716L;
-        final WorldGenerator generator = new HillsGenerator(seed, 64, 24, 60);
+        final WorldGenerator generator = resolveGenerator(generatorName, seed);
         final WorldBuilder spec = WorldBuilder.builder(key)
                 .seed(seed)
                 .generator(generator)
@@ -542,6 +569,7 @@ public final class ApiTestCommand {
                 "[TestPlugin] Monde cree: " + world.key()
                         + " | minY=" + world.minY()
                         + " | height=" + world.height()
+                        + " | type=" + world.dimensionType()
                         + " | total=" + plugin.server().worlds().size());
 
         return Command.SINGLE_SUCCESS;

--- a/fidorial-test-plugin/src/main/java/fr/euphyllia/fidorial/testplugin/terrain/HillsGenerator.java
+++ b/fidorial-test-plugin/src/main/java/fr/euphyllia/fidorial/testplugin/terrain/HillsGenerator.java
@@ -1,6 +1,9 @@
 package fr.euphyllia.fidorial.testplugin.terrain;
 
+import fr.fidorial.world.dimension.DimensionTypeDefinition;
+import fr.fidorial.world.dimension.types.VanillaDimensionTypes;
 import fr.fidorial.world.generation.GeneratedChunk;
+import fr.fidorial.world.generation.GenerationDescriptor;
 import fr.fidorial.world.generation.WorldGenerator;
 import net.kyori.adventure.key.Key;
 
@@ -39,13 +42,21 @@ public final class HillsGenerator implements WorldGenerator {
     private final PerlinNoise heightNoise;
     private final PerlinNoise detailNoise;
 
+    private final DimensionTypeDefinition dimensionType;
+
     public HillsGenerator(final long seed, final int baseHeight, final int amplitude, final int seaLevel) {
+        this(seed, baseHeight, amplitude, seaLevel, VanillaDimensionTypes.OVERWORLD);
+    }
+
+    public HillsGenerator(final long seed, final int baseHeight, final int amplitude, final int seaLevel,
+                          final DimensionTypeDefinition dimensionType) {
         this.baseHeight = baseHeight;
         this.amplitude = amplitude;
         this.seaLevel = seaLevel;
         this.highlandLevel = baseHeight + amplitude / 2;
         this.heightNoise = new PerlinNoise(seed);
         this.detailNoise = new PerlinNoise(seed * 31 + 7);
+        this.dimensionType = dimensionType;
     }
 
     @Override
@@ -91,8 +102,8 @@ public final class HillsGenerator implements WorldGenerator {
                 if ((x & 3) == 0 && (z & 3) == 0) {
                     final Key biome = underWater ? BIOME_RIVER
                             : surface <= seaLevel + 2 ? BIOME_BEACH
-                              : surface >= highlandLevel ? BIOME_PEAKS
-                                : BIOME_PLAINS;
+                            : surface >= highlandLevel ? BIOME_PEAKS
+                            : BIOME_PLAINS;
                     for (int y = minY; y < minY + chunk.height(); y += 4) {
                         chunk.setBiome(x, y, z, biome);
                     }
@@ -108,5 +119,15 @@ public final class HillsGenerator implements WorldGenerator {
         final double hills = heightNoise.fbm(worldX * 0.004, worldZ * 0.004, 4);
         final double detail = detailNoise.fbm(worldX * 0.02, worldZ * 0.02, 2);
         return baseHeight + (int) Math.round(hills * amplitude + detail * 4);
+    }
+
+    @Override
+    public DimensionTypeDefinition dimensionType() {
+        return dimensionType;
+    }
+
+    @Override
+    public GenerationDescriptor describeForSave() {
+        return GenerationDescriptor.noise(dimensionType.key(), Key.key("fidorial", "hills"));
     }
 }

--- a/fidorial-test-plugin/src/main/java/fr/euphyllia/fidorial/testplugin/terrain/SwamplandGenerator.java
+++ b/fidorial-test-plugin/src/main/java/fr/euphyllia/fidorial/testplugin/terrain/SwamplandGenerator.java
@@ -1,0 +1,381 @@
+package fr.euphyllia.fidorial.testplugin.terrain;
+
+import fr.fidorial.world.dimension.DimensionTypeDefinition;
+import fr.fidorial.world.generation.GeneratedChunk;
+import fr.fidorial.world.generation.GenerationDescriptor;
+import fr.fidorial.world.generation.WorldGenerator;
+import net.kyori.adventure.key.Key;
+
+public final class SwamplandGenerator implements WorldGenerator {
+
+    private static final Key BEDROCK = Key.key("bedrock");
+    private static final Key STONE = Key.key("stone");
+    private static final Key DEEPSLATE = Key.key("deepslate");
+    private static final Key COBBLESTONE = Key.key("cobblestone");
+    private static final Key GRAVEL = Key.key("gravel");
+    private static final Key COARSE_DIRT = Key.key("coarse_dirt");
+    private static final Key ASH = Key.key("gray_concrete_powder");
+    private static final Key SCORCHED_ROCK = Key.key("blackstone");
+    private static final Key CRACKED_STONE_BRICKS = Key.key("cracked_stone_bricks");
+    private static final Key CRACKED_DEEPSLATE_BRICKS = Key.key("cracked_deepslate_bricks");
+    private static final Key WATER = Key.key("water");
+    private static final Key LAVA = Key.key("lava");
+    private static final Key MAGMA_BLOCK = Key.key("magma_block");
+    private static final Key BASALT = Key.key("basalt");
+    private static final Key DEAD_BUSH = Key.key("dead_bush");
+    private static final Key WITHER_ROSE = Key.key("wither_rose");
+    private static final Key IRON_BLOCK = Key.key("iron_block");
+    private static final Key CHAIN = Key.key("chain");
+    private static final Key SEA_LANTERN = Key.key("sea_lantern");
+    private static final Key MUSHROOM_STEM = Key.key("mushroom_stem");
+    private static final Key RED_MUSHROOM_BLOCK = Key.key("red_mushroom_block");
+    private static final Key BROWN_MUSHROOM_BLOCK = Key.key("brown_mushroom_block");
+    private static final Key RED_MUSHROOM = Key.key("red_mushroom");
+    private static final Key BROWN_MUSHROOM = Key.key("brown_mushroom");
+
+    private static final Key BIOME_CRATER = TestBiomes.TOXIC_CRATERS.key();
+    private static final Key BIOME_MOLTEN = TestBiomes.MOLTEN_CRATERS.key();
+    private static final Key BIOME_RUBBLE_FLATS = TestBiomes.RUBBLE_FLATS.key();
+    private static final Key BIOME_WASTELAND = TestBiomes.ASHEN_WASTELAND.key();
+    private static final Key BIOME_RIDGES = TestBiomes.IRRADIATED_RIDGES.key();
+
+    private final int baseHeight;
+    private final int reliefAmplitude;
+    private final int seaLevel;
+    private final int ridgeHeight;
+    private final int craterDepth;
+
+    private static final double RIDGE_THRESHOLD = 0.74;
+    private static final double CRATER_THRESHOLD = 0.6;
+    private static final double POOL_THRESHOLD = 0.80;
+    private static final double POOL_THRESHOLD_FOOT_BONUS = 0.14;
+    private static final double POOL_FOOT_RANGE_FRACTION = 0.22;
+    private static final double LAVA_THRESHOLD = 0.52;
+    private static final double FOOTHILL_FRACTION = 0.22;
+    private final int ashLine;
+    private static final double ASH_BLEND_HALF_RANGE_FRACTION = 0.12;
+    private static final int STONE_BLEND_MIN_DEPTH = 2;
+    private static final int STONE_BLEND_MAX_DEPTH = 6;
+
+    private final PerlinNoise terrainNoise;
+    private final PerlinNoise ridgeNoise;
+    private final PerlinNoise craterNoise;
+    private final PerlinNoise detailNoise;
+    private final PerlinNoise hazardNoise;
+    private final PerlinNoise poolNoise;
+    private final PerlinNoise ashBlendNoise;
+    private final PerlinNoise blendNoise;
+
+    private final DimensionTypeDefinition dimensionType;
+
+    public SwamplandGenerator(final long seed, final int baseHeight, final int reliefAmplitude,
+                              final int seaLevel, final int ridgeHeight) {
+        this(seed, baseHeight, reliefAmplitude, seaLevel, ridgeHeight, TestDimensionTypes.IRRADIATED_WASTELAND);
+    }
+
+    public SwamplandGenerator(final long seed, final int baseHeight, final int reliefAmplitude,
+                              final int seaLevel, final int ridgeHeight,
+                              final DimensionTypeDefinition dimensionType) {
+        this.baseHeight = baseHeight;
+        this.reliefAmplitude = reliefAmplitude;
+        this.seaLevel = seaLevel;
+        this.ridgeHeight = ridgeHeight;
+        this.craterDepth = Math.max(4, ridgeHeight / 2);
+        this.ashLine = baseHeight + (int) (ridgeHeight * 0.65);
+        this.terrainNoise = new PerlinNoise(seed);
+        this.ridgeNoise = new PerlinNoise(seed * 31 + 7);
+        this.craterNoise = new PerlinNoise(seed * 53 + 101);
+        this.detailNoise = new PerlinNoise(seed * 131 + 17);
+        this.hazardNoise = new PerlinNoise(seed * 271 + 43);
+        this.poolNoise = new PerlinNoise(seed * 401 + 67);
+        this.ashBlendNoise = new PerlinNoise(seed * 601 + 89);
+        this.blendNoise = new PerlinNoise(seed * 811 + 131);
+        this.dimensionType = dimensionType;
+    }
+
+    @Override
+    public void generate(final GeneratedChunk chunk) {
+        final int minY = chunk.minY();
+        final int maxY = minY + chunk.height() - 1;
+        final int baseX = chunk.chunkX() << 4;
+        final int baseZ = chunk.chunkZ() << 4;
+
+        for (int x = 0; x < 16; x++) {
+            for (int z = 0; z < 16; z++) {
+                final int worldX = baseX + x;
+                final int worldZ = baseZ + z;
+
+                final double ridge = ridgeField(worldX, worldZ);
+                final boolean isRidge = ridge > RIDGE_THRESHOLD;
+                final double crater = isRidge ? 0.0 : craterField(worldX, worldZ);
+                int surface = surfaceHeight(worldX, worldZ, ridge, crater, maxY);
+
+                boolean ridgePool = false;
+                int poolRim = surface;
+                if (isRidge) {
+                    final int elevation = surface - baseHeight;
+                    final double footRange = ridgeHeight * POOL_FOOT_RANGE_FRACTION;
+                    final double linear = Math.clamp(1.0 - elevation / footRange, 0.0, 1.0);
+                    final double footFactor = linear * linear * linear;
+                    final double effectiveThreshold = POOL_THRESHOLD - footFactor * POOL_THRESHOLD_FOOT_BONUS;
+                    final double pool = poolField(worldX, worldZ);
+                    if (pool > effectiveThreshold) {
+                        final double intensity = (pool - effectiveThreshold) / (1.0 - effectiveThreshold);
+                        final int poolDepth = Math.max(
+                                3, (int) Math.round(Math.pow(intensity, 1.3) * Math.min(10, ridgeHeight / 2)));
+                        poolRim = surface;
+                        surface -= poolDepth;
+                        ridgePool = true;
+                    }
+                }
+
+                final boolean underLiquid = ridgePool || surface < seaLevel;
+                final boolean isLava = underLiquid && hazardField(worldX, worldZ) > LAVA_THRESHOLD;
+
+                final boolean ashCapped;
+                if (isRidge && !underLiquid) {
+                    final double halfRange = ridgeHeight * ASH_BLEND_HALF_RANGE_FRACTION;
+                    final double ashT = Math.clamp(
+                            (surface - (ashLine - halfRange)) / (2.0 * halfRange), 0.0, 1.0);
+                    if (ashT <= 0.0) {
+                        ashCapped = false;
+                    } else if (ashT >= 1.0) {
+                        ashCapped = true;
+                    } else {
+                        final double patch = (ashBlendNoise.fbm(worldX * 0.04, worldZ * 0.04, 2) + 1.0) / 2.0;
+                        ashCapped = patch < ashT;
+                    }
+                } else {
+                    ashCapped = false;
+                }
+
+                chunk.setBlock(x, minY, z, BEDROCK);
+
+                final int deepslateTop = Math.min(surface - 4, minY + (chunk.height() / 3));
+                for (int y = minY + 1; y <= deepslateTop; y++) {
+                    chunk.setBlock(x, y, z, DEEPSLATE);
+                }
+                for (int y = Math.max(minY + 1, deepslateTop + 1); y <= surface - 4; y++) {
+                    chunk.setBlock(x, y, z, STONE);
+                }
+
+                if (underLiquid && isLava) {
+                    placeLavaBed(chunk, x, z, worldX, worldZ, minY, surface);
+                } else if (underLiquid) {
+                    placeSludgeBed(chunk, x, z, minY, surface);
+                } else if (isRidge) {
+                    placeRidgeSurface(chunk, x, z, worldX, worldZ, minY, surface, ashCapped);
+                } else if (surface <= seaLevel + 1) {
+                    final int depth = blendDepth(worldX, worldZ);
+                    for (int y = Math.max(minY + 1, surface - depth); y <= surface; y++) {
+                        chunk.setBlock(x, y, z, ASH);
+                    }
+                } else {
+                    final Key topBlock = pickWastelandTop(worldX, worldZ);
+                    final int depth = blendDepth(worldX, worldZ);
+                    for (int y = Math.max(minY + 1, surface - depth); y < surface; y++) {
+                        chunk.setBlock(x, y, z, COARSE_DIRT);
+                    }
+                    chunk.setBlock(x, surface, z, topBlock);
+                }
+
+                if (underLiquid) {
+                    final Key liquid = isLava ? LAVA : WATER;
+                    final int ceiling = ridgePool ? poolRim : seaLevel;
+                    for (int y = surface + 1; y <= ceiling; y++) {
+                        chunk.setBlock(x, y, z, liquid);
+                    }
+                }
+
+                if (!isRidge && !underLiquid && surface + 1 <= maxY) {
+                    final double deco = hash01(worldX * 7 + 3, worldZ * 7 + 3);
+                    if (deco < 0.06) {
+                        chunk.setBlock(x, surface + 1, z, DEAD_BUSH);
+                    } else if (deco < 0.075) {
+                        chunk.setBlock(x, surface + 1, z, WITHER_ROSE);
+                    } else if (deco < 0.085) {
+                        final Key scrap = hash01(worldX * 13 + 9, worldZ * 13 + 9) < 0.5 ? IRON_BLOCK : CHAIN;
+                        chunk.setBlock(x, surface + 1, z, scrap);
+                    } else if (deco < 0.105) {
+                        final Key mushroom =
+                                hash01(worldX * 17 + 5, worldZ * 17 + 5) < 0.5 ? RED_MUSHROOM : BROWN_MUSHROOM;
+                        chunk.setBlock(x, surface + 1, z, mushroom);
+                    } else if (deco < 0.107) {
+                        placeGiantMushroom(
+                                chunk, x, z, worldX, worldZ, surface, maxY,
+                                hash01(worldX * 19 + 23, worldZ * 19 + 23) < 0.5);
+                    }
+                }
+
+                if (!underLiquid && surface - 1 >= minY + 1
+                        && hash01(worldX * 191 + 29, worldZ * 191 + 29) < 0.009) {
+                    chunk.setBlock(x, surface - 1, z, SEA_LANTERN);
+                }
+
+                if ((x & 3) == 0 && (z & 3) == 0) {
+                    final Key biome = isRidge && !underLiquid ? BIOME_RIDGES
+                            : underLiquid && isLava ? BIOME_MOLTEN
+                            : underLiquid ? BIOME_CRATER
+                            : surface <= seaLevel + 2 ? BIOME_RUBBLE_FLATS
+                            : BIOME_WASTELAND;
+                    for (int y = minY; y < minY + chunk.height(); y += 4) {
+                        chunk.setBiome(x, y, z, biome);
+                    }
+                }
+            }
+        }
+    }
+
+    private void placeLavaBed(final GeneratedChunk chunk, final int x, final int z,
+                              final int worldX, final int worldZ, final int minY, final int surface) {
+        for (int y = Math.max(minY + 1, surface - 3); y < surface; y++) {
+            chunk.setBlock(x, y, z, BASALT);
+        }
+        final boolean molten = hash01(worldX * 251 + 41, worldZ * 251 + 41) < 0.3;
+        chunk.setBlock(x, surface, z, molten ? MAGMA_BLOCK : BASALT);
+    }
+
+    private void placeSludgeBed(final GeneratedChunk chunk, final int x, final int z,
+                                final int minY, final int surface) {
+        for (int y = Math.max(minY + 1, surface - 3); y <= surface; y++) {
+            chunk.setBlock(x, y, z, GRAVEL);
+        }
+    }
+
+    private void placeRidgeSurface(final GeneratedChunk chunk, final int x, final int z,
+                                   final int worldX, final int worldZ, final int minY,
+                                   final int surface, final boolean ashCapped) {
+        final int elevation = surface - baseHeight;
+        final int depth = blendDepth(worldX, worldZ);
+
+        if (ashCapped) {
+            for (int y = Math.max(minY + 1, surface - depth); y < surface; y++) {
+                chunk.setBlock(x, y, z, SCORCHED_ROCK);
+            }
+            chunk.setBlock(x, surface, z, ASH);
+            return;
+        }
+
+        if (elevation < ridgeHeight * FOOTHILL_FRACTION) {
+            for (int y = Math.max(minY + 1, surface - depth); y < surface; y++) {
+                chunk.setBlock(x, y, z, COARSE_DIRT);
+            }
+            chunk.setBlock(x, surface, z, GRAVEL);
+            return;
+        }
+
+        for (int y = Math.max(minY + 1, surface - depth); y < surface; y++) {
+            chunk.setBlock(x, y, z, SCORCHED_ROCK);
+        }
+        chunk.setBlock(x, surface, z, pickScreeTop(worldX, worldZ));
+    }
+
+    private void placeGiantMushroom(
+            final GeneratedChunk chunk, final int x, final int z, final int worldX, final int worldZ,
+            final int surface, final int maxY, final boolean red) {
+
+        final int height = 3 + (int) (hash01(worldX * 337 + 11, worldZ * 337 + 11) * 3.0);
+        final int top = surface + height;
+        if (top + 1 > maxY) {
+            return;
+        }
+
+        for (int y = surface + 1; y < top; y++) {
+            chunk.setBlock(x, y, z, MUSHROOM_STEM);
+        }
+
+        final Key cap = red ? RED_MUSHROOM_BLOCK : BROWN_MUSHROOM_BLOCK;
+        for (int dz = -2; dz <= 2; dz++) {
+            for (int dx = -2; dx <= 2; dx++) {
+                if (Math.abs(dx) == 2 && Math.abs(dz) == 2) {
+                    continue;
+                }
+                final int cx = x + dx;
+                final int cz = z + dz;
+                if (cx < 0 || cx > 15 || cz < 0 || cz > 15) {
+                    continue;
+                }
+                chunk.setBlock(cx, top, cz, cap);
+            }
+        }
+    }
+
+    private double ridgeField(final int worldX, final int worldZ) {
+        final double n = ridgeNoise.fbm(worldX * 0.0015, worldZ * 0.0015, 5);
+        return 1.0 - Math.abs(n);
+    }
+
+    private double craterField(final int worldX, final int worldZ) {
+        final double n = craterNoise.fbm(worldX * 0.004, worldZ * 0.004, 4);
+        return 1.0 - Math.abs(n);
+    }
+
+    private double hazardField(final int worldX, final int worldZ) {
+        return (hazardNoise.fbm(worldX * 0.0016, worldZ * 0.0016, 3) + 1.0) / 2.0;
+    }
+
+    private double poolField(final int worldX, final int worldZ) {
+        return (poolNoise.fbm(worldX * 0.01, worldZ * 0.01, 3) + 1.0) / 2.0;
+    }
+
+    private int blendDepth(final int worldX, final int worldZ) {
+        final double n = (blendNoise.fbm(worldX * 0.09, worldZ * 0.09, 2) + 1.0) / 2.0;
+        return STONE_BLEND_MIN_DEPTH
+                + (int) Math.round(n * (STONE_BLEND_MAX_DEPTH - STONE_BLEND_MIN_DEPTH));
+    }
+
+    private int surfaceHeight(final int worldX, final int worldZ, final double ridge,
+                              final double crater, final int maxY) {
+        final double relief = terrainNoise.fbm(worldX * 0.01, worldZ * 0.01, 3);
+        int surface = baseHeight + (int) Math.round(relief * reliefAmplitude);
+
+        if (ridge > RIDGE_THRESHOLD) {
+            final double intensity = (ridge - RIDGE_THRESHOLD) / (1.0 - RIDGE_THRESHOLD);
+            surface += (int) Math.round(Math.pow(intensity, 1.5) * ridgeHeight);
+        } else if (crater > CRATER_THRESHOLD) {
+            final double intensity = (crater - CRATER_THRESHOLD) / (1.0 - CRATER_THRESHOLD);
+            surface -= (int) Math.round(Math.pow(intensity, 1.2) * craterDepth);
+        }
+
+        return Math.min(surface, maxY - 2);
+    }
+
+    private Key pickWastelandTop(final int worldX, final int worldZ) {
+        final double n = (detailNoise.fbm(worldX * 0.05, worldZ * 0.05, 3) + 1.0) / 2.0;
+        if (n < 0.35) {
+            return ASH;
+        } else if (n < 0.65) {
+            return COARSE_DIRT;
+        } else if (n < 0.85) {
+            return CRACKED_STONE_BRICKS;
+        }
+        return GRAVEL;
+    }
+
+    private Key pickScreeTop(final int worldX, final int worldZ) {
+        final double h = hash01(worldX * 11 + 5, worldZ * 11 + 5);
+        if (h < 0.65) {
+            return SCORCHED_ROCK;
+        } else if (h < 0.85) {
+            return CRACKED_DEEPSLATE_BRICKS;
+        }
+        return COBBLESTONE;
+    }
+
+    private static double hash01(final int x, final int z) {
+        long h = x * 374_761_393L + z * 668_265_263L;
+        h = (h ^ (h >>> 13)) * 1_274_126_177L;
+        h ^= (h >>> 16);
+        return (h & 0x7FFFFFFFL) / (double) Integer.MAX_VALUE;
+    }
+
+    @Override
+    public DimensionTypeDefinition dimensionType() {
+        return dimensionType;
+    }
+
+    @Override
+    public GenerationDescriptor describeForSave() {
+        return GenerationDescriptor.noise(dimensionType.key(), Key.key("fidorial", "wasteland"));
+    }
+}

--- a/fidorial-test-plugin/src/main/java/fr/euphyllia/fidorial/testplugin/terrain/TestBiomes.java
+++ b/fidorial-test-plugin/src/main/java/fr/euphyllia/fidorial/testplugin/terrain/TestBiomes.java
@@ -80,8 +80,92 @@ public final class TestBiomes {
             .skyColor(0x5DB7EF)
             .build();
 
+    public static final BiomeDefinition ASHEN_WASTELAND = BiomeDefinition
+            .builder(Key.key("fidorial", "ashen_wasteland"))
+            .temperature(1.6F)
+            .downfall(0.0F)
+            .hasPrecipitation(false)
+            .effects(effects -> effects
+                    .waterColor(0x6B6252)
+                    .grassColor(0x8A7A5C)
+                    .foliageColor(0x746653))
+            .skyColor(0x9C9484)
+            .fogColor(0xA69D8C)
+            .waterFogColor(0x4A4436)
+            .addAmbientParticle(AmbientParticle.of(Key.key("ash"), 0.01F))
+            .ambientSounds(new AmbientSounds(
+                    Key.key("ambient.basalt_deltas.loop"),
+                    MoodSound.CAVE,
+                    AdditionsSound.of(Key.key("ambient.basalt_deltas.additions"), 0.0111F)))
+            .attributes(attributes -> attributes
+                    .increasedFireBurnout(false)
+                    .snowGolemMelts(true)
+                    .waterEvaporates(true))
+            .build();
+
+    public static final BiomeDefinition TOXIC_CRATERS = BiomeDefinition
+            .builder(Key.key("fidorial", "toxic_craters"))
+            .temperature(0.9F)
+            .downfall(0.9F)
+            .effects(effects -> effects
+                    .waterColor(0x8FA83B)
+                    .grassColor(0x6B6B34)
+                    .foliageColor(0x6B6B34)
+                    .grassColorModifier(GrassColorModifier.SWAMP))
+            .skyColor(0x746B4A)
+            .waterFogColor(0x1F2410)
+            .attributes(attributes -> attributes
+                    .waterFogEndDistance(0.25F, Modifier.MULTIPLY)
+                    .increasedFireBurnout(true))
+            .build();
+
+    public static final BiomeDefinition MOLTEN_CRATERS = BiomeDefinition
+            .builder(Key.key("fidorial", "molten_craters"))
+            .temperature(2.0F)
+            .downfall(0.0F)
+            .hasPrecipitation(false)
+            .effects(effects -> effects
+                    .waterColor(0xB33F00)
+                    .grassColor(0x5C3A22)
+                    .foliageColor(0x4A2E1A))
+            .skyColor(0x8C3300)
+            .fogColor(0x4A1D08)
+            .waterFogColor(0x3A1200)
+            .addAmbientParticle(AmbientParticle.of(Key.key("white_ash"), 0.02F))
+            .ambientSounds(new AmbientSounds(
+                    Key.key("ambient.nether_wastes.loop"),
+                    MoodSound.CAVE,
+                    AdditionsSound.of(Key.key("ambient.nether_wastes.additions"), 0.0111F)))
+            .attributes(attributes -> attributes
+                    .increasedFireBurnout(true)
+                    .snowGolemMelts(true)
+                    .waterEvaporates(true))
+            .build();
+
+    public static final BiomeDefinition RUBBLE_FLATS = BiomeDefinition
+            .builder(Key.key("fidorial", "rubble_flats"))
+            .temperature(1.3F)
+            .downfall(0.2F)
+            .effects(effects -> effects.waterColor(0x736B5C))
+            .skyColor(0x8C8579)
+            .build();
+
+    public static final BiomeDefinition IRRADIATED_RIDGES = BiomeDefinition
+            .builder(Key.key("fidorial", "irradiated_ridges"))
+            .temperature(0.3F)
+            .downfall(0.1F)
+            .hasPrecipitation(false)
+            .effects(effects -> effects
+                    .waterColor(0x536655)
+                    .grassColor(0x4C5A3E))
+            .skyColor(0x554F42)
+            .fogColor(0x726A54)
+            .addAmbientParticle(AmbientParticle.of(Key.key("ash"), 0.015F))
+            .build();
+
     private static final List<BiomeDefinition> ALL =
-            List.of(VOLCANIC_PLAINS, FROZEN_PEAKS, TOXIC_RIVER, CRYSTAL_SHORE);
+            List.of(VOLCANIC_PLAINS, FROZEN_PEAKS, TOXIC_RIVER, CRYSTAL_SHORE,
+                    ASHEN_WASTELAND, TOXIC_CRATERS, MOLTEN_CRATERS, RUBBLE_FLATS, IRRADIATED_RIDGES);
 
     private TestBiomes() {
         throw new UnsupportedOperationException("TestBiomes cannot be instantiated.");

--- a/fidorial-test-plugin/src/main/java/fr/euphyllia/fidorial/testplugin/terrain/TestDimensionTypes.java
+++ b/fidorial-test-plugin/src/main/java/fr/euphyllia/fidorial/testplugin/terrain/TestDimensionTypes.java
@@ -1,0 +1,176 @@
+package fr.euphyllia.fidorial.testplugin.terrain;
+
+import fr.fidorial.world.dimension.CardinalLight;
+import fr.fidorial.world.dimension.DimensionTypeDefinition;
+import fr.fidorial.world.dimension.DimensionTypeRegistry;
+import fr.fidorial.world.dimension.IntProvider;
+import fr.fidorial.world.dimension.Skybox;
+import fr.fidorial.world.dimension.TimelineReference;
+import fr.fidorial.world.environment.BedRule;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.logger.slf4j.ComponentLogger;
+
+import java.util.List;
+import java.util.Optional;
+
+public final class TestDimensionTypes {
+
+    public static final DimensionTypeDefinition VOLCANIC_DEPTHS = DimensionTypeDefinition
+            .builder(Key.key("fidorial", "volcanic_depths"))
+            .coordinateScale(8.0)
+            .hasSkylight(false)
+            .hasCeiling(true)
+            .hasEnderDragonFight(false)
+            .ambientLight(0.15F)
+            .hasFixedTime(true)
+            .monsterSpawnBlockLightLimit(15)
+            .monsterSpawnLightLevel(IntProvider.constant(7))
+            .logicalHeight(128)
+            .bounds(0, 256)
+            .infiniburn(Key.key("infiniburn_nether"))
+            .skybox(Skybox.NONE)
+            .cardinalLight(CardinalLight.NETHER)
+            .attributes(attributes -> attributes
+                    .skyColor(0xDB0000)
+                    .fogColor(0x240006)
+                    .respawnAnchorWorks(true)
+                    .canStartRaid(false)
+                    .piglinsZombify(false)
+                    .bedRule(new BedRule(
+                            BedRule.AccessCondition.NEVER,
+                            BedRule.AccessCondition.WHEN_DARK,
+                            false,
+                            Optional.of(
+                                    Component.translatable("fidorial.bed.sleep.not_allowed")
+                            ))
+                    )
+            )
+            .addTimeline(TimelineReference.tag(Key.key("in_nether")))
+            .build();
+
+    public static final DimensionTypeDefinition FROZEN_VOID = DimensionTypeDefinition
+            .builder(Key.key("fidorial", "frozen_void"))
+            .coordinateScale(1.0)
+            .hasSkylight(true)
+            .hasCeiling(false)
+            .hasEnderDragonFight(false)
+            .ambientLight(0.4F)
+            .hasFixedTime(true)
+            .monsterSpawnBlockLightLimit(0)
+            .monsterSpawnLightLevel(IntProvider.constant(15))
+            .logicalHeight(192)
+            .bounds(0, 192)
+            .infiniburn(Key.key("infiniburn_end"))
+            .skybox(Skybox.END)
+            .defaultClock(Key.key("the_end"))
+            .addTimeline(TimelineReference.tag(Key.key("in_end")))
+            .attributes(attributes -> attributes
+                    .respawnAnchorWorks(false)
+                    .skyColor(0x0A0F2C)
+                    .fogColor(0x1C2450)
+            )
+            .build();
+
+    public static final DimensionTypeDefinition SKYLANDS = DimensionTypeDefinition
+            .builder(Key.key("fidorial", "skylands"))
+            .coordinateScale(4.0)
+            .hasSkylight(true)
+            .hasCeiling(false)
+            .hasEnderDragonFight(false)
+            .ambientLight(0.0F)
+            .hasFixedTime(false)
+            .monsterSpawnBlockLightLimit(0)
+            .monsterSpawnLightLevel(IntProvider.biasedToBottom(0, 7))
+            .logicalHeight(384)
+            .bounds(-16, 384)
+            .infiniburn(Key.key("infiniburn_overworld"))
+            .defaultClock(Key.key("overworld"))
+            .addTimeline(TimelineReference.tag(Key.key("in_overworld")))
+            .attributes(attributes -> attributes
+                    .respawnAnchorWorks(false)
+                    .skyColor(0x8FD3FF)
+                    .fogColor(0xD8F1FF)
+            )
+            .build();
+
+    public static final DimensionTypeDefinition TOXIC_SWAMPLAND = DimensionTypeDefinition
+            .builder(Key.key("fidorial", "toxic_swampland"))
+            .coordinateScale(1.0)
+            .hasSkylight(true)
+            .hasCeiling(false)
+            .hasEnderDragonFight(false)
+            .ambientLight(0.0F)
+            .hasFixedTime(false)
+            .monsterSpawnBlockLightLimit(3)
+            .monsterSpawnLightLevel(IntProvider.uniform(0, 10))
+            .logicalHeight(384)
+            .bounds(-64, 384)
+            .infiniburn(Key.key("infiniburn_overworld"))
+            .defaultClock(Key.key("overworld"))
+            .addTimeline(TimelineReference.tag(Key.key("in_overworld")))
+            .attributes(attributes -> attributes
+                    .respawnAnchorWorks(false)
+                    .waterEvaporates(false)
+                    .skyColor(0x5C6B3E)
+                    .fogColor(0x40492B)
+            )
+            .build();
+
+    public static final DimensionTypeDefinition IRRADIATED_WASTELAND = DimensionTypeDefinition
+            .builder(Key.key("fidorial", "irradiated_wasteland"))
+            .coordinateScale(1.0)
+            .hasSkylight(true)
+            .hasCeiling(false)
+            .hasEnderDragonFight(false)
+            .ambientLight(0.0F)
+            .hasFixedTime(false)
+            .monsterSpawnBlockLightLimit(7)
+            .monsterSpawnLightLevel(IntProvider.uniform(0, 12))
+            .logicalHeight(384)
+            .bounds(-64, 384)
+            .infiniburn(Key.key("infiniburn_overworld"))
+            .defaultClock(Key.key("overworld"))
+            .addTimeline(TimelineReference.tag(Key.key("in_overworld")))
+            .cardinalLight(CardinalLight.NETHER)
+            .attributes(attributes -> attributes
+                    .respawnAnchorWorks(false)
+                    .waterEvaporates(true)
+                    .skyColor(0x8C7A5E)
+                    .fogColor(0x6B5A42)
+                    .skyLightColor(0xB8B36A)
+                    .skyLightFactor(0.7F)
+                    .cloudColor(0xFF8A8063)
+                    .ambientLightColor(0x9A9668)
+                    .waterFogColor(0x4F5540)
+            )
+            .build();
+
+    private static final List<DimensionTypeDefinition> ALL =
+            List.of(VOLCANIC_DEPTHS, FROZEN_VOID, SKYLANDS, TOXIC_SWAMPLAND, IRRADIATED_WASTELAND);
+
+    private TestDimensionTypes() {
+        throw new UnsupportedOperationException("TestDimensionTypes cannot be instantiated.");
+    }
+
+    public static List<DimensionTypeDefinition> all() {
+        return ALL;
+    }
+
+    public static void registerAll(final DimensionTypeRegistry dimensions, final ComponentLogger logger) {
+        for (final DimensionTypeDefinition dimensionType : ALL) {
+            dimensions.overwrite(dimensionType);
+            logger.info("[TestPlugin] dimension type {} registered (network id {})",
+                    dimensionType.key().asString(), dimensions.networkId(dimensionType.key()));
+        }
+
+        logger.info("[TestPlugin] {} dimension types registered, {} of them defined by the server",
+                dimensions.totalRegistered(), dimensions.definitions().size());
+    }
+
+    public static void unregisterAll(final DimensionTypeRegistry dimensions) {
+        for (final DimensionTypeDefinition dimensionType : ALL) {
+            dimensions.unregister(dimensionType.key());
+        }
+    }
+}

--- a/fidorial-test-plugin/src/main/java/fr/euphyllia/fidorial/testplugin/worldgen/OverworldGenerator.java
+++ b/fidorial-test-plugin/src/main/java/fr/euphyllia/fidorial/testplugin/worldgen/OverworldGenerator.java
@@ -10,6 +10,8 @@ import fr.euphyllia.fidorial.testplugin.worldgen.stage.OreStage;
 import fr.euphyllia.fidorial.testplugin.worldgen.stage.RavineCarver;
 import fr.euphyllia.fidorial.testplugin.worldgen.stage.SurfaceStage;
 import fr.euphyllia.fidorial.testplugin.worldgen.stage.TerrainStage;
+import fr.fidorial.world.dimension.DimensionTypeDefinition;
+import fr.fidorial.world.dimension.types.VanillaDimensionTypes;
 import fr.fidorial.world.generation.GeneratedChunk;
 import fr.fidorial.world.generation.GenerationDescriptor;
 import fr.fidorial.world.generation.WorldGenerator;
@@ -19,6 +21,7 @@ import org.jspecify.annotations.Nullable;
 public final class OverworldGenerator implements WorldGenerator {
 
     private final GeneratorSettings settings;
+    private final DimensionTypeDefinition dimensionType;
     private final ClimateSampler climate;
     private final TerrainStage terrain;
     private final BiomeStage biomes;
@@ -30,7 +33,12 @@ public final class OverworldGenerator implements WorldGenerator {
     private final ThreadLocal<ChunkScratch> scratches = ThreadLocal.withInitial(ChunkScratch::new);
 
     public OverworldGenerator(final GeneratorSettings settings) {
+        this(settings, VanillaDimensionTypes.OVERWORLD);
+    }
+
+    public OverworldGenerator(final GeneratorSettings settings, final DimensionTypeDefinition dimensionType) {
         this.settings = settings;
+        this.dimensionType = dimensionType;
         this.climate = new ClimateSampler(settings.seed());
 
         final TerrainShaper shaper = new TerrainShaper(settings.seaLevel());
@@ -72,8 +80,13 @@ public final class OverworldGenerator implements WorldGenerator {
     }
 
     @Override
+    public DimensionTypeDefinition dimensionType() {
+        return dimensionType;
+    }
+
+    @Override
     public GenerationDescriptor describeForSave() {
-        return GenerationDescriptor.noise(Key.key("overworld"), Key.key("overworld"));
+        return GenerationDescriptor.noise(dimensionType.key(), Key.key("fidorial", "overworld"));
     }
 
     public ClimatePoint climateAt(final int worldX, final int worldZ) {

--- a/fidorial-test-plugin/src/main/resources/languages/en_us.json
+++ b/fidorial-test-plugin/src/main/resources/languages/en_us.json
@@ -1,4 +1,5 @@
 {
   "fidorial.baguette.unknown": "<red>Unknown baguette type: '<arg:0>'</red>",
-  "console.fidorial.baguette.unknown": "<red>Unknown baguette type: '<arg:0>'</red>"
+  "console.fidorial.baguette.unknown": "<red>Unknown baguette type: '<arg:0>'</red>",
+  "fidorial.bed.sleep.not_allowed": "<red>You cannot sleep in this dimension. You can only set your spawn point at night."
 }

--- a/fidorial-test-plugin/src/main/resources/languages/fr_fr.json
+++ b/fidorial-test-plugin/src/main/resources/languages/fr_fr.json
@@ -1,4 +1,5 @@
 {
   "fidorial.baguette.unknown": "<red>Type de baguette inconnu : '<arg:0>'</red>",
-  "console.fidorial.baguette.unknown": "<red>Type de baguette inconnu : '<arg:0>'</red>"
+  "console.fidorial.baguette.unknown": "<red>Type de baguette inconnu : '<arg:0>'</red>",
+  "fidorial.bed.sleep.not_allowed": "<red>Vous ne pouvez pas dormir dans cette dimension. Vous ne pouvez définir votre point de réapparition que la nuit."
 }


### PR DESCRIPTION
The API shape mirrors the existing biome and dialog APIs.

## Changes
- `ChunkGenerator` and `WorldGenerator` no longer have `minY()` and `height()` methods, as they have been replaced by the new `DimensionTypeDefinition`, that can be overriden with custom dimension types.
- `EnvironmentAttributes` have been expanded to *hopefully* support all vanilla attribute types
- A new `SwamplandGenerator` has been added to the plugin (had claude generate it for testing and then decided to keep it as imo it looks cool), and the `/apitest createworld` command now accepts a generator to use for the world

### Showcases
<img width="1916" height="991" alt="image" src="https://github.com/user-attachments/assets/91657715-af85-4a6c-944c-611ba30a28ba" />
<img width="1917" height="1001" alt="image" src="https://github.com/user-attachments/assets/7edc7ef8-f433-497e-9906-3cf75b5def3c" />
<img width="1919" height="1011" alt="image" src="https://github.com/user-attachments/assets/ff51258d-5938-41a1-9e1b-dc7be647595d" />

- and messages on discord