### PR TITLE
Allow encrypting connections when online-mode is false

### DIFF
--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/ServerConfig.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/ServerConfig.java
@@ -20,6 +20,7 @@ import java.util.UUID;
 public record ServerConfig(
         int port,
         boolean onlineMode,
+        boolean encryptOfflineModeConnections,
         int viewDistance,
         int sendDistance,
         int compressionThreshold,
@@ -96,6 +97,7 @@ public record ServerConfig(
         return new ServerConfig(
                 25565,
                 true,
+                false,
                 10,
                 10,
                 256,
@@ -148,6 +150,7 @@ public record ServerConfig(
         final ServerConfig config = new ServerConfig(
                 readInt(props, "port", defaults.port()),
                 readBool(props, "online-mode", defaults.onlineMode()),
+                readBool(props, "encrypt-offline-mode-connections", defaults.encryptOfflineModeConnections()),
                 readInt(props, "view-distance", defaults.viewDistance()),
                 readInt(props, "send-distance", defaults.sendDistance()),
                 readInt(props, "compression-threshold", defaults.compressionThreshold()),
@@ -295,6 +298,7 @@ public record ServerConfig(
         final Properties props = new Properties();
         props.setProperty("port", Integer.toString(port));
         props.setProperty("online-mode", Boolean.toString(onlineMode));
+        props.setProperty("encrypt-offline-mode-connections", Boolean.toString(encryptOfflineModeConnections));
         props.setProperty("view-distance", Integer.toString(viewDistance));
         props.setProperty("send-distance", Integer.toString(sendDistance));
         props.setProperty("compression-threshold", Integer.toString(compressionThreshold));

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/listener/LoginPacketHandler.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/listener/LoginPacketHandler.java
@@ -6,7 +6,6 @@ import fr.euphyllia.fidorial.server.FidorialServer;
 import fr.euphyllia.fidorial.server.ServerConfig;
 import fr.euphyllia.fidorial.server.network.ClientConnection;
 import fr.euphyllia.fidorial.server.network.ConnectionState;
-import fr.euphyllia.fidorial.server.network.protocol.ProtocolConstants;
 import fr.euphyllia.fidorial.server.network.protocol.packet.clientbound.login.ClientboundCustomQueryPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.clientbound.login.ClientboundHelloPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.clientbound.login.ClientboundLoginCompressionPacket;
@@ -62,11 +61,15 @@ public final class LoginPacketHandler implements LoginPacketListener {
         if (server.config().proxyMode() == ServerConfig.ProxyMode.VELOCITY) {
             sendVelocityForwardingRequest();
         } else if (server.config().onlineMode()) {
-            sendEncryptionRequest();
+            sendEncryptionRequest(true);
         } else {
             LOGGER.warn("Offline connection (unauthenticated): {}", pendingUsername);
-            enableCompression();
-            sendLoginSuccess(offlineProfile(pendingUsername));
+            if (server.config().encryptOfflineModeConnections()) {
+                sendEncryptionRequest(false);
+            } else {
+                enableCompression();
+                sendLoginSuccess(offlineProfile(pendingUsername));
+            }
         }
     }
 
@@ -74,7 +77,6 @@ public final class LoginPacketHandler implements LoginPacketListener {
         final UUID uuid = UUID.nameUUIDFromBytes(("OfflinePlayer:" + username).getBytes(StandardCharsets.UTF_8));
         return new GameProfile(uuid, username, UUID.randomUUID(), List.of());
     }
-
 
     private void sendVelocityForwardingRequest() {
         this.velocityTransactionId = ThreadLocalRandom.current().nextInt(0, Integer.MAX_VALUE);
@@ -118,11 +120,11 @@ public final class LoginPacketHandler implements LoginPacketListener {
         }
     }
 
-    private void sendEncryptionRequest() {
+    private void sendEncryptionRequest(final boolean shouldAuthenticate) {
         this.encryptionRequested = true;
         this.verifyToken = EncryptionUtils.generateVerifyToken();
         final byte[] publicKey = server.keyPair().getPublic().getEncoded();
-        connection.send(new ClientboundHelloPacket("", publicKey, verifyToken, true));
+        connection.send(new ClientboundHelloPacket("", publicKey, verifyToken, shouldAuthenticate));
     }
 
     @Override
@@ -155,6 +157,11 @@ public final class LoginPacketHandler implements LoginPacketListener {
         try {
             final Optional<GameProfile> profile = server.sessionService().hasJoined(username, serverHash);
             connection.execute(() -> {
+                if (!server.config().onlineMode()) {
+                    enableCompression();
+                    sendLoginSuccess(offlineProfile(username));
+                    return;
+                }
                 if (profile.isEmpty()) {
                     disconnect(Component.translatable("disconnect.loginFailedInfo.invalidSession"));
                 } else {

--- a/fidorial-server/src/main/resources/fidorial.properties
+++ b/fidorial-server/src/main/resources/fidorial.properties
@@ -3,6 +3,8 @@
 port=25565
 # false = no Mojang authentication (test server only)
 online-mode=true
+# whether offline mode connections should be encrypted, false = vanilla default
+encrypt-offline-mode-connections = false
 # distance advertised to the client, in chunks
 view-distance=8
 # actual streaming radius; must be <= view-distance


### PR DESCRIPTION
Defaults to `false` to match the Vanilla server 
https://minecraft.wiki/w/Java_Edition_protocol/Packets#Login_2