### PR TITLE
Feat: Allow resending players to the CONFIGURATION phase.

### DIFF
--- a/fidorial-api/src/main/java/fr/fidorial/entity/Player.java
+++ b/fidorial-api/src/main/java/fr/fidorial/entity/Player.java
@@ -2,6 +2,8 @@ package fr.fidorial.entity;
 
 import fr.fidorial.command.CommandSender;
 import fr.fidorial.command.CommandSource;
+import fr.fidorial.event.player.PlayerJoinEvent;
+import fr.fidorial.event.player.PlayerQuitEvent;
 import fr.fidorial.inventory.EnderChestInventory;
 import fr.fidorial.inventory.PlayerInventory;
 import fr.fidorial.permission.PermissionHolder;
@@ -127,4 +129,15 @@ public interface Player extends LivingEntity, PermissionHolder, CommandSource, C
     default void setRespawnPoint(final Location location) {
         setRespawnPoint(new RespawnPoint(world(), location));
     }
+
+    /**
+     * Switches this player's connection status from PLAY to CONFIGURATION.
+     * Useful for resending data synced during the CONFIGURATION phase.
+     *
+     * @since 0.1.0
+     * @apiNote This removes the player from the world fully and creates them anew,
+     * firing {@link PlayerQuitEvent}, {@link PlayerJoinEvent}, and saving their data to disk.
+     * Any reference to this {@link Player} held before this call should be considered stale.
+     */
+    void enterConfigurationPhase();
 }

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/FidorialServer.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/FidorialServer.java
@@ -254,6 +254,7 @@ public final class FidorialServer implements Server {
             loadPlugins();
             openWorlds();
             regionizer.registerTickHandler(new EntityTickHandler(worldManager, this));
+            syncServerStatusToRegistries(true);
             if (!headless) {
                 network.bind();
                 startAutoSave();
@@ -272,6 +273,11 @@ public final class FidorialServer implements Server {
         }
     }
 
+    private void syncServerStatusToRegistries(final boolean started) {
+        biomeRegistry().started.getAndSet(started);
+        dimensionTypes().started.getAndSet(started);
+    }
+
     @Override
     public void shutdown() {
         if (!running.compareAndSet(true, false)) {
@@ -281,6 +287,7 @@ public final class FidorialServer implements Server {
         LOGGER.info("Stopping the Fidorial server...");
         events.post(new ServerStoppingEvent(this));
         onlinePlayers().forEach(player -> player.kick(Component.translatable("commands.stop.stopping")));
+        syncServerStatusToRegistries(false);
 
         closeQuietly("plugins", pluginManager::close);
         closeQuietly("spark", this::disableSpark);

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/EntityTracker.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/EntityTracker.java
@@ -5,6 +5,7 @@ import ca.spottedleaf.concurrentutil.list.COWArrayList;
 import ca.spottedleaf.concurrentutil.map.concurrent.ints.ConcurrentChainedInt2ReferenceHashTable;
 import fr.euphyllia.fidorial.server.entity.player.ServerPlayer;
 import fr.euphyllia.fidorial.server.network.ClientConnection;
+import fr.euphyllia.fidorial.server.network.ConnectionState;
 import fr.euphyllia.fidorial.server.network.protocol.packet.ClientboundPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.clientbound.play.ClientboundRemoveEntitiesPacket;
 import fr.fidorial.entity.Entity;
@@ -57,6 +58,9 @@ public final class EntityTracker {
                 continue;
             }
             final ClientConnection connection = player.connection();
+            if (connection.state() != ConnectionState.PLAY) {
+                continue; // re-configuring
+            }
             final boolean tracked = current.contains(connection);
             final double limit = tracked ? untrackDistanceSq : trackDistanceSq;
             final boolean visible =

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/player/ServerPlayer.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/player/ServerPlayer.java
@@ -618,6 +618,11 @@ public final class ServerPlayer extends AbstractLivingEntity implements Player, 
                 ClientboundSetEntityMetadataPacket.Entry.ofByte(MD_DISPLAYED_SKIN_PARTS, connection().displayedSkinParts())));
     }
 
+    @Override
+    public void enterConfigurationPhase() {
+        connection.enterConfiguration();
+    }
+
     public int nextTeleportId() {
         final var id = lastTeleportId;
         lastTeleportId = id + 1;

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/ClientConnection.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/ClientConnection.java
@@ -58,7 +58,10 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -66,6 +69,8 @@ import java.util.concurrent.TimeUnit;
 public final class ClientConnection extends SimpleChannelInboundHandler<ByteBuf> implements Audience {
 
     private static final ComponentLogger LOGGER = ComponentLogger.logger(ClientConnection.class);
+
+    private static final Executor VIRTUAL_THREAD_EXECUTOR = Executors.newVirtualThreadPerTaskExecutor();
 
     private static final int KEEP_ALIVE_INTERVAL_SECONDS = 10;
     private static final int LATENCY_SMOOTHING = 3;
@@ -247,6 +252,13 @@ public final class ClientConnection extends SimpleChannelInboundHandler<ByteBuf>
                 : (int) ((previous * (long) LATENCY_SMOOTHING + sample) / (LATENCY_SMOOTHING + 1));
     }
 
+    public void pauseKeepAlive() {
+        if (keepAliveTask != null) {
+            keepAliveTask.cancel(false);
+            keepAliveTask = null;
+        }
+    }
+
     public int ping() {
         return latencyMillis;
     }
@@ -265,29 +277,34 @@ public final class ClientConnection extends SimpleChannelInboundHandler<ByteBuf>
         saveInventoryOnDisconnect();
     }
 
-    private void saveInventoryOnDisconnect() {
+    public void enterConfiguration() {
+        execute(() -> {
+            if (listener instanceof final PlayPacketHandler play) {
+                play.enterConfiguration();
+            }
+        });
+    }
+
+    public CompletableFuture<Void> saveInventoryOnDisconnect() {
         final ServerPlayer disconnecting = this.player;
         if (disconnecting == null) {
-            return;
+            return CompletableFuture.completedFuture(null);
         }
         this.player = null;
-        Thread.startVirtualThread(() -> {
+        return CompletableFuture.runAsync(() -> {
             try {
                 server.playerInventoryStorage().save(disconnecting.uuid(), disconnecting.inventory());
                 server.playerEnderChestStorage().save(disconnecting.uuid(), disconnecting.enderChest());
                 final RespawnPoint point = disconnecting.respawnPoint();
-                server.playerDataStorage()
-                        .save(
-                                disconnecting.uuid(),
-                                new PlayerDataStorage.PlayerData(
-                                        disconnecting.gameMode(),
-                                        point == null ? null : point.world().key(),
-                                        point == null ? null : point.location()));
+                server.playerDataStorage().save(disconnecting.uuid(), new PlayerDataStorage.PlayerData(
+                        disconnecting.gameMode(),
+                        point == null ? null : point.world().key(),
+                        point == null ? null : point.location()));
                 LOGGER.debug("Inventory + Ender Chest and data for {} saved", disconnecting.name());
             } catch (final Exception e) {
                 LOGGER.error("Unable to save inventory for {}", disconnecting.name(), e);
             }
-        });
+        }, VIRTUAL_THREAD_EXECUTOR);
     }
 
     @Override

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/listener/PlayPacketHandler.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/listener/PlayPacketHandler.java
@@ -10,6 +10,7 @@ import fr.euphyllia.fidorial.server.entity.player.ServerPlayer;
 import fr.euphyllia.fidorial.server.inventory.ContainerMenu;
 import fr.euphyllia.fidorial.server.inventory.EnderChestMenu;
 import fr.euphyllia.fidorial.server.network.ClientConnection;
+import fr.euphyllia.fidorial.server.network.ConnectionState;
 import fr.euphyllia.fidorial.server.network.protocol.packet.clientbound.play.ClientboundAnimatePacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.clientbound.play.ClientboundBlockChangedAckPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.clientbound.play.ClientboundBlockEventPacket;
@@ -28,10 +29,12 @@ import fr.euphyllia.fidorial.server.network.protocol.packet.clientbound.play.Cli
 import fr.euphyllia.fidorial.server.network.protocol.packet.clientbound.play.ClientboundSetEntityMetadataPacket.Entry;
 import fr.euphyllia.fidorial.server.network.protocol.packet.clientbound.play.ClientboundSetHealthPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.clientbound.play.ClientboundSoundPacket;
+import fr.euphyllia.fidorial.server.network.protocol.packet.clientbound.play.ClientboundStartConfigurationPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.clientbound.play.ClientboundSystemChatPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.listener.PlayPacketListener;
 import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.common.ServerboundClientInformationPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.play.ServerboundAcceptTeleportationPacket;
+import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.play.ServerboundAcknowledgeConfigurationPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.play.ServerboundAttackPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.play.ServerboundChatCommandPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.play.ServerboundChatPacket;
@@ -292,6 +295,22 @@ public final class PlayPacketHandler implements PlayPacketListener {
     @Override
     public void handleAcceptTeleportation(final ServerboundAcceptTeleportationPacket packet) {
         // Confirmation du client : rien a faire tant que l'anti-cheat n'existe pas.
+    }
+
+    public void enterConfiguration() {
+        LOGGER.debug("Switching player {}, uuid {} from PLAY -> CONFIGURATION phase", player.name(), player.uuid());
+        // vanilla removes the player fully and creates a new one, so we do the same
+        onDisconnect();
+        connection.pauseKeepAlive();
+        connection.saveInventoryOnDisconnect().thenRunAsync(() -> {
+            connection.send(new ClientboundStartConfigurationPacket());
+            connection.setState(ConnectionState.CONFIGURATION);
+        }, connection::execute);
+    }
+
+    @Override
+    public void handleAcknowledgeConfiguration(final ServerboundAcknowledgeConfigurationPacket packet) {
+        // Confirmation du client
     }
 
     @Override

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/protocol/packet/clientbound/play/ClientboundStartConfigurationPacket.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/protocol/packet/clientbound/play/ClientboundStartConfigurationPacket.java
@@ -1,0 +1,20 @@
+package fr.euphyllia.fidorial.server.network.protocol.packet.clientbound.play;
+
+import fr.euphyllia.fidorial.server.network.PacketBuffer;
+import fr.euphyllia.fidorial.server.network.protocol.catalog.PlayClientboundPackets;
+import fr.euphyllia.fidorial.server.network.protocol.packet.ClientboundPacket;
+import net.kyori.adventure.key.Key;
+
+// https://minecraft.wiki/w/Java_Edition_protocol/Packets#Start_Configuration
+// used when registries are updated to resync their contents to clients
+public record ClientboundStartConfigurationPacket() implements ClientboundPacket {
+
+    @Override
+    public Key name() {
+        return PlayClientboundPackets.START_CONFIGURATION;
+    }
+
+    @Override
+    public void write(PacketBuffer buf) {
+    }
+}

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/protocol/packet/listener/PlayPacketListener.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/protocol/packet/listener/PlayPacketListener.java
@@ -2,6 +2,7 @@ package fr.euphyllia.fidorial.server.network.protocol.packet.listener;
 
 import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.common.ServerboundClientInformationPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.play.ServerboundAcceptTeleportationPacket;
+import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.play.ServerboundAcknowledgeConfigurationPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.play.ServerboundAttackPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.play.ServerboundChatCommandPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.play.ServerboundChatPacket;
@@ -29,6 +30,8 @@ public interface PlayPacketListener extends PacketListener {
     void handlePlayerLoaded(ServerboundPlayerLoadedPacket packet);
 
     void handleAcceptTeleportation(ServerboundAcceptTeleportationPacket packet);
+
+    void handleAcknowledgeConfiguration(ServerboundAcknowledgeConfigurationPacket packet);
 
     void handleKeepAlive(ServerboundKeepAlivePacket packet);
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/protocol/packet/serverbound/play/ServerboundAcknowledgeConfigurationPacket.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/network/protocol/packet/serverbound/play/ServerboundAcknowledgeConfigurationPacket.java
@@ -1,0 +1,14 @@
+package fr.euphyllia.fidorial.server.network.protocol.packet.serverbound.play;
+
+import fr.euphyllia.fidorial.server.network.protocol.packet.listener.PlayPacketListener;
+import fr.fidorial.protocol.PacketListener;
+import fr.fidorial.protocol.ServerboundPacket;
+
+// https://minecraft.wiki/w/Java_Edition_protocol/Packets#Acknowledge_Configuration
+public record ServerboundAcknowledgeConfigurationPacket() implements ServerboundPacket {
+
+    @Override
+    public void handle(PacketListener listener) {
+        ((PlayPacketListener) listener).handleAcknowledgeConfiguration(this);
+    }
+}

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/registry/biome/FidorialBiomeRegistry.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/registry/biome/FidorialBiomeRegistry.java
@@ -1,6 +1,8 @@
 package fr.euphyllia.fidorial.server.registry.biome;
 
+import fr.euphyllia.fidorial.server.FidorialServer;
 import fr.euphyllia.fidorial.server.codecs.world.BiomeCodecs;
+import fr.euphyllia.fidorial.server.entity.player.ServerPlayer;
 import fr.euphyllia.fidorial.server.registry.RegistryEntry;
 import fr.euphyllia.fidorial.server.registry.RegistryHolder;
 import fr.fidorial.registry.Registry;
@@ -31,7 +33,7 @@ public final class FidorialBiomeRegistry implements BiomeRegistry, Registry<Biom
     private static final ComponentLogger LOGGER = ComponentLogger.logger(FidorialBiomeRegistry.class);
 
     private final Key fallback;
-    private final AtomicBoolean started = new AtomicBoolean(false);
+    public final AtomicBoolean started = new AtomicBoolean(false);
 
     private volatile Snapshot snapshot;
 
@@ -203,8 +205,9 @@ public final class FidorialBiomeRegistry implements BiomeRegistry, Registry<Biom
     private void publish(final Map<Key, @Nullable BiomeDefinition> next, final String action, final Key key) {
         this.snapshot = Snapshot.of(next);
         if (started.get()) {
-            LOGGER.warn("Biome {} {} after startup: only clients connecting from now on will see the change.",
+            LOGGER.warn("Biome {} {} after startup: clients will be sent to the configuration phase to see the change.",
                     key.asString(), action);
+            FidorialServer.getInstance().players().forEach(ServerPlayer::enterConfigurationPhase);
         } else {
             LOGGER.debug("Biome {} {}.", key.asString(), action);
         }

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/registry/dimension/FidorialDimensionTypeRegistry.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/registry/dimension/FidorialDimensionTypeRegistry.java
@@ -2,7 +2,7 @@ package fr.euphyllia.fidorial.server.registry.dimension;
 
 import fr.euphyllia.fidorial.server.FidorialServer;
 import fr.euphyllia.fidorial.server.codecs.world.DimensionTypeCodecs;
-import fr.euphyllia.fidorial.server.network.protocol.packet.clientbound.play.ClientboundStartConfigurationPacket;
+import fr.euphyllia.fidorial.server.entity.player.ServerPlayer;
 import fr.euphyllia.fidorial.server.registry.RegistryEntry;
 import fr.euphyllia.fidorial.server.registry.RegistryHolder;
 import fr.fidorial.registry.Registry;
@@ -182,7 +182,7 @@ public final class FidorialDimensionTypeRegistry implements DimensionTypeRegistr
         if (started.get()) {
             LOGGER.warn("Dimension type {} {} after startup: clients will be sent to the configuration phase to see the change.",
                     key.asString(), action);
-            FidorialServer.getInstance().players().forEach(player -> player.connection().send(new ClientboundStartConfigurationPacket()));
+            FidorialServer.getInstance().players().forEach(ServerPlayer::enterConfigurationPhase);
         } else {
             LOGGER.debug("Dimension type {} {}.", key.asString(), action);
         }

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/registry/dimension/FidorialDimensionTypeRegistry.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/registry/dimension/FidorialDimensionTypeRegistry.java
@@ -1,6 +1,8 @@
 package fr.euphyllia.fidorial.server.registry.dimension;
 
+import fr.euphyllia.fidorial.server.FidorialServer;
 import fr.euphyllia.fidorial.server.codecs.world.DimensionTypeCodecs;
+import fr.euphyllia.fidorial.server.network.protocol.packet.clientbound.play.ClientboundStartConfigurationPacket;
 import fr.euphyllia.fidorial.server.registry.RegistryEntry;
 import fr.euphyllia.fidorial.server.registry.RegistryHolder;
 import fr.fidorial.registry.Registry;
@@ -30,7 +32,7 @@ public final class FidorialDimensionTypeRegistry implements DimensionTypeRegistr
 
     private static final ComponentLogger LOGGER = ComponentLogger.logger(FidorialDimensionTypeRegistry.class);
 
-    private final AtomicBoolean started = new AtomicBoolean(false);
+    public final AtomicBoolean started = new AtomicBoolean(false);
 
     private volatile Snapshot snapshot;
 
@@ -178,8 +180,9 @@ public final class FidorialDimensionTypeRegistry implements DimensionTypeRegistr
     private void publish(final Map<Key, @Nullable DimensionTypeDefinition> next, final String action, final Key key) {
         this.snapshot = Snapshot.of(next);
         if (started.get()) {
-            LOGGER.warn("Dimension type {} {} after startup: only clients connecting from now on will see the change.",
+            LOGGER.warn("Dimension type {} {} after startup: clients will be sent to the configuration phase to see the change.",
                     key.asString(), action);
+            FidorialServer.getInstance().players().forEach(player -> player.connection().send(new ClientboundStartConfigurationPacket()));
         } else {
             LOGGER.debug("Dimension type {} {}.", key.asString(), action);
         }

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/WorldManager.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/WorldManager.java
@@ -176,6 +176,8 @@ public final class WorldManager implements AutoCloseable {
                     seed,
                     generator != null ? generator.getClass().getName() : "flat");
         }
+        // resend worlds
+        FidorialServer.getInstance().players().forEach(ServerPlayer::enterConfigurationPhase);
         return world;
     }
 
@@ -211,6 +213,8 @@ public final class WorldManager implements AutoCloseable {
         }
         worlds.remove(key);
         LOGGER.debug("Removing world '{}' from manager (save={})", key, save);
+        // resend worlds
+        FidorialServer.getInstance().players().forEach(ServerPlayer::enterConfigurationPhase);
 
         return world;
     }

--- a/fidorial-test-plugin/src/main/java/fr/euphyllia/fidorial/testplugin/command/ApiTestCommand.java
+++ b/fidorial-test-plugin/src/main/java/fr/euphyllia/fidorial/testplugin/command/ApiTestCommand.java
@@ -41,6 +41,7 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.event.ClickCallback;
 import net.kyori.adventure.text.event.ClickEvent;
 import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 
 import java.net.URI;
@@ -204,7 +205,18 @@ public final class ApiTestCommand {
                                         })
                                         .executes(this::bossBarHide)))
                 )
+                .then(literal("reenter_configuration")
+                        .executes(ApiTestCommand::reenterConfigurationPhase))
                 .build();
+    }
+
+    private static int reenterConfigurationPhase(CommandContext<CommandSource> ctx) {
+        plugin.server().sendMessage(Component.text("[TestPlugin] Resending all players to the CONFIGURATION phase..."));
+        plugin.server().onlinePlayers().forEach(Player::enterConfigurationPhase);
+        plugin.server().sendMessage(Component.text("[TestPlugin] Resent ")
+                .append(Component.text(plugin.server().onlinePlayers().size()).decorate(TextDecoration.BOLD)
+                        .append(Component.text(" player(s)."))).color(NamedTextColor.GREEN));
+        return Command.SINGLE_SUCCESS;
     }
 
     private static int tabListBroadcast(final CommandContext<CommandSource> ctx) {


### PR DESCRIPTION
This is extremely useful for resyncing dynamic registries, such as biomes and worlds, as now the clients don't need to reconnect but instead are sent to the config phase to have their local data updated.

The current implementation has been made to match Vanilla, and thus the player instance is removed and created anew on every change to the config phase; a new API for this has been exposed which documents this.