### PR TITLE
feat(scheduler): add SchedulerSource for entity and chunk scheduling

### DIFF
--- a/fidorial-api/src/main/java/fr/fidorial/entity/Entity.java
+++ b/fidorial-api/src/main/java/fr/fidorial/entity/Entity.java
@@ -1,6 +1,7 @@
 package fr.fidorial.entity;
 
 import fr.fidorial.command.CommandSource;
+import fr.fidorial.scheduler.SchedulerSource;
 import fr.fidorial.world.ChunkPos;
 import fr.fidorial.world.Location;
 import fr.fidorial.world.World;
@@ -11,7 +12,7 @@ import net.kyori.adventure.text.event.HoverEventSource;
 
 import java.util.UUID;
 
-public interface Entity extends CommandSource, HoverEventSource<HoverEvent.ShowEntity>, Sound.Emitter, Sound.Source.Provider {
+public interface Entity extends CommandSource, HoverEventSource<HoverEvent.ShowEntity>, Sound.Emitter, Sound.Source.Provider, SchedulerSource {
 
     int entityId();
 

--- a/fidorial-api/src/main/java/fr/fidorial/scheduler/RegionizedScheduler.java
+++ b/fidorial-api/src/main/java/fr/fidorial/scheduler/RegionizedScheduler.java
@@ -5,13 +5,54 @@ import net.kyori.adventure.key.Key;
 
 import java.util.List;
 
+/**
+ * Schedules tasks to run on the region thread that owns a given world position.
+ *
+ * <p>The server world is split into independently-ticked regions, each owned by a single worker
+ * thread. Tasks submitted through this scheduler run on whichever thread currently owns the
+ * targeted {@code (worldName, pos)}, rather than on the calling thread.</p>
+ *
+ * @since 0.1.0
+ */
 public interface RegionizedScheduler {
 
+    /**
+     * Schedules {@code task} to run as soon as possible on the region thread owning {@code pos}.
+     *
+     * @param worldName the key of the world the position belongs to
+     * @param pos       the chunk position identifying the target region
+     * @param task      the task to run
+     * @since 0.1.0
+     */
     void execute(Key worldName, ChunkPos pos, Runnable task);
 
+    /**
+     * Schedules {@code task} to run on the region thread owning {@code pos}, after at least
+     * {@code delayTicks} server ticks have elapsed.
+     *
+     * @param worldName  the key of the world the position belongs to
+     * @param pos        the chunk position identifying the target region
+     * @param task       the task to run
+     * @param delayTicks the minimum number of ticks to wait before running the task
+     * @since 0.1.0
+     */
     void executeDelayed(Key worldName, ChunkPos pos, Runnable task, long delayTicks);
 
+    /**
+     * @param worldName the key of the world the position belongs to
+     * @param pos       the chunk position identifying the target region
+     * @return {@code true} if the calling thread is the region thread that currently owns
+     * {@code pos}
+     * @since 0.1.0
+     */
     boolean isOwnedByCurrentThread(Key worldName, ChunkPos pos);
 
+    /**
+     * Takes a snapshot of the current per-region tick performance.
+     *
+     * @return the tick performance of every currently active region, ordered by ascending TPS
+     * (worst-performing regions first)
+     * @since 0.1.0
+     */
     List<? extends RegionTps> tpsSnapshots();
 }

--- a/fidorial-api/src/main/java/fr/fidorial/scheduler/SchedulerSource.java
+++ b/fidorial-api/src/main/java/fr/fidorial/scheduler/SchedulerSource.java
@@ -2,6 +2,7 @@ package fr.fidorial.scheduler;
 
 /**
  * Represents a {@code SchedulerSource}, capable of having tasks scheduled to it.
+ * @see RegionizedScheduler
  * @since 0.1.0
  */
 public interface SchedulerSource {

--- a/fidorial-api/src/main/java/fr/fidorial/scheduler/SchedulerSource.java
+++ b/fidorial-api/src/main/java/fr/fidorial/scheduler/SchedulerSource.java
@@ -1,0 +1,25 @@
+package fr.fidorial.scheduler;
+
+/**
+ * Represents a {@code SchedulerSource}, capable of having tasks scheduled to it.
+ * @since 0.1.0
+ */
+public interface SchedulerSource {
+    /**
+     * @return {@code false} if the source is removed and the task was not scheduled
+     * @since 0.1.0
+     */
+    boolean execute(Runnable task);
+
+    /**
+     * @return {@code false} if the source is removed and the task was not scheduled
+     * @since 0.1.0
+     */
+    boolean executeDelayed(Runnable task, long delayTicks);
+
+    /**
+     * @return {@code false} if the source is not owned by the current thread
+     * @since 0.1.0
+     */
+    boolean isOwnedByCurrentThread();
+}

--- a/fidorial-api/src/main/java/fr/fidorial/world/Chunk.java
+++ b/fidorial-api/src/main/java/fr/fidorial/world/Chunk.java
@@ -1,6 +1,8 @@
 package fr.fidorial.world;
 
-public interface Chunk {
+import fr.fidorial.scheduler.SchedulerSource;
+
+public interface Chunk extends SchedulerSource {
 
     World world();
 

--- a/fidorial-api/src/main/java/fr/fidorial/world/World.java
+++ b/fidorial-api/src/main/java/fr/fidorial/world/World.java
@@ -1,6 +1,7 @@
 package fr.fidorial.world;
 
 import fr.fidorial.entity.Entity;
+import fr.fidorial.scheduler.RegionizedScheduler;
 import fr.fidorial.world.dimension.DimensionTypeDefinition;
 import fr.fidorial.world.time.DayNightCycle;
 import net.kyori.adventure.audience.ForwardingAudience;
@@ -26,6 +27,13 @@ public interface World extends Keyed, ForwardingAudience {
     DimensionTypeDefinition dimensionType();
 
     DayNightCycle dayNightCycle();
+
+    /**
+     * {@return the scheduler responsible for running tasks against positions in this world}
+     *
+     * @since 0.1.0
+     */
+    RegionizedScheduler scheduler();
 
     CompletableFuture<Chunk> getChunkAsync(int chunkX, int chunkZ);
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/FidorialServer.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/FidorialServer.java
@@ -167,7 +167,7 @@ public final class FidorialServer implements Server {
     private final NbtPlayerEnderChestStorage defaultEnderChestStorage =
             new NbtPlayerEnderChestStorage(config.worldPath().resolve("player"), false);
     private final ChestViewerTracker chestViewers = new ChestViewerTracker();
-    private final WorldManager worldManager = WorldManager.openOrCreate(config.worldPath(), blockStateRegistry);
+    private final WorldManager worldManager = WorldManager.openOrCreate(config.worldPath(), blockStateRegistry, regionizer);
     private final FluidEngine fluidEngine =
             new FluidEngine(worldManager, regionizer, blockStateRegistry, this::broadcast);
     private final WeatherEngine weatherEngine = new WeatherEngine(worldManager.levelData(), this::broadcast);

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/AbstractEntity.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/entity/AbstractEntity.java
@@ -1,6 +1,7 @@
 package fr.euphyllia.fidorial.server.entity;
 
 import fr.euphyllia.fidorial.server.FidorialServer;
+import fr.euphyllia.fidorial.server.entity.mob.AbstractMob;
 import fr.euphyllia.fidorial.server.network.ClientConnection;
 import fr.euphyllia.fidorial.server.network.protocol.packet.ClientboundPacket;
 import fr.euphyllia.fidorial.server.network.protocol.packet.clientbound.play.ClientboundAddEntityPacket;
@@ -9,6 +10,7 @@ import fr.euphyllia.fidorial.server.world.ServerWorld;
 import fr.fidorial.command.CommandSender;
 import fr.fidorial.entity.Entity;
 import fr.fidorial.entity.EntityType;
+import fr.fidorial.scheduler.RegionizedScheduler;
 import fr.fidorial.world.Location;
 import fr.fidorial.world.World;
 import net.kyori.adventure.text.Component;
@@ -158,10 +160,16 @@ public abstract class AbstractEntity implements Entity {
             } else {
                 if (from instanceof final ServerWorld old) {
                     old.removeEntity(this);
+                    if (this instanceof AbstractMob) {
+                        server().regionizer().removeTicket(old.key(), previous.chunk());
+                    }
                 }
                 setWorld(target);
                 setLocation(location);
                 target.addEntity(this);
+                if (this instanceof AbstractMob) {
+                    server().regionizer().addTicket(target.key(), location.chunk());
+                }
             }
 
             sendToTrackers(new ClientboundEntityPositionSyncPacket(
@@ -186,5 +194,40 @@ public abstract class AbstractEntity implements Entity {
     @Override
     public HoverEvent<HoverEvent.ShowEntity> asHoverEvent(final UnaryOperator<HoverEvent.ShowEntity> op) {
         return HoverEvent.showEntity(op.apply(HoverEvent.ShowEntity.showEntity(type().key(), uuid(), displayName())));
+    }
+
+    @Override
+    public boolean execute(final Runnable task) {
+        if (isRemoved()) {
+            return false;
+        }
+        server().scheduler().execute(world().key(), chunk(), task);
+        return true;
+    }
+
+    @Override
+    public boolean executeDelayed(final Runnable task, final long delayTicks) {
+        if (isRemoved()) {
+            return false;
+        }
+        server().scheduler().executeDelayed(world().key(), chunk(), () -> runOrChase(task), delayTicks);
+        return true;
+    }
+
+    @Override
+    public boolean isOwnedByCurrentThread() {
+        return !isRemoved() && server().scheduler().isOwnedByCurrentThread(world().key(), chunk());
+    }
+
+    private void runOrChase(final Runnable task) {
+        if (isRemoved()) {
+            return;
+        }
+        final RegionizedScheduler scheduler = server().scheduler();
+        if (scheduler.isOwnedByCurrentThread(world().key(), chunk())) {
+            task.run();
+        } else {
+            scheduler.execute(world().key(), chunk(), () -> runOrChase(task));
+        }
     }
 }

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/tests/BlockStateTests.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/tests/BlockStateTests.java
@@ -2,7 +2,6 @@ package fr.euphyllia.fidorial.server.tests;
 
 import fr.euphyllia.fidorial.server.FidorialServer;
 import fr.euphyllia.fidorial.server.world.BlockStateRegistry;
-import fr.euphyllia.fidorial.server.world.WorldConstants;
 import fr.euphyllia.fidorial.server.world.chunk.BlockState;
 import fr.fidorial.registry.keys.BlockTypeKeys;
 import fr.fidorial.testing.ScenarioTestHelper;
@@ -20,7 +19,7 @@ public final class BlockStateTests {
     public static void belowWorldIsAir(final ScenarioTestHelper helper) {
         final World world = helper.world();
         final BlockStateRegistry registry = FidorialServer.getInstance().blockStateRegistry();
-        final BlockPos pos = new BlockPos(0, WorldConstants.MIN_Y - 1, 0);
+        final BlockPos pos = new BlockPos(0, world.dimensionType().minY() - 1, 0);
 
         final BlockState actual = registry.byId(world.getBlockStateId(pos));
         helper.assertTrue(actual.isAir(),

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/ServerChunk.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/ServerChunk.java
@@ -84,4 +84,27 @@ public final class ServerChunk implements Chunk {
     private int worldZ(final int localZ) {
         return (column.chunkZ() << 4) | (localZ & 15);
     }
+
+    @Override
+    public boolean execute(final Runnable task) {
+        if (world.isChunkLoaded(column.chunkX(), column.chunkZ())) {
+            world().scheduler().execute(world().key(), pos(), task);
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public boolean executeDelayed(final Runnable task, final long delayTicks) {
+        if (world.isChunkLoaded(column.chunkX(), column.chunkZ())) {
+            world().scheduler().executeDelayed(world().key(), pos(), task, delayTicks);
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public boolean isOwnedByCurrentThread() {
+        return world().scheduler().isOwnedByCurrentThread(world().key(), pos());
+    }
 }

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/ServerWorld.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/ServerWorld.java
@@ -6,8 +6,10 @@ import ca.spottedleaf.concurrentutil.list.COWArrayList;
 import ca.spottedleaf.concurrentutil.map.concurrent.longs.ConcurrentChainedLong2ReferenceHashTable;
 import fr.euphyllia.fidorial.server.entity.AbstractEntity;
 import fr.euphyllia.fidorial.server.entity.EntityManager;
+import fr.euphyllia.fidorial.server.entity.mob.AbstractMob;
 import fr.euphyllia.fidorial.server.entity.player.ServerPlayer;
 import fr.euphyllia.fidorial.server.schedulers.LightUpdateDispatcher;
+import fr.euphyllia.fidorial.server.schedulers.ThreadedRegionRegionizer;
 import fr.euphyllia.fidorial.server.util.ConcurrentLongSet;
 import fr.euphyllia.fidorial.server.world.chunk.BlockState;
 import fr.euphyllia.fidorial.server.world.chunk.ChunkColumn;
@@ -25,6 +27,7 @@ import fr.euphyllia.fidorial.server.world.time.WorldClocks;
 import fr.euphyllia.fidorial.server.world.time.WorldTimeEngine;
 import fr.fidorial.entity.Entity;
 import fr.fidorial.registry.keys.BlockTypeKeys;
+import fr.fidorial.scheduler.RegionizedScheduler;
 import fr.fidorial.world.BlockPos;
 import fr.fidorial.world.Chunk;
 import fr.fidorial.world.ChunkPos;
@@ -68,6 +71,7 @@ public final class ServerWorld implements World {
     private final WorldLightManager lightManager;
     private volatile @Nullable LightUpdateDispatcher lightDispatcher;
     private final FloodFillLightEngine fallbackEngine;
+    private final ThreadedRegionRegionizer scheduler;
 
     private final ConcurrentChainedLong2ReferenceHashTable<ChunkColumn> loaded =
             ConcurrentChainedLong2ReferenceHashTable.createWithExpected(1024);
@@ -88,7 +92,8 @@ public final class ServerWorld implements World {
             final EntityRegionStorage entityStorage,
             final AnvilEntitySerializer entitySerializer,
             final ChunkGenerator generator,
-            final BlockStateRegistry blockStates
+            final BlockStateRegistry blockStates,
+            final ThreadedRegionRegionizer scheduler
     ) {
         this.dimension = dimension;
         this.storage = storage;
@@ -102,6 +107,7 @@ public final class ServerWorld implements World {
         this.height = dimensionType.height();
         this.lightManager = new WorldLightManager(new WorldLightAccess());
         this.fallbackEngine = new FloodFillLightEngine(minY, height);
+        this.scheduler = scheduler;
     }
 
     public void setEntityBridge(final IntSupplier entityIdSupplier, final EntitySpawnBridge entityBridge) {
@@ -147,6 +153,11 @@ public final class ServerWorld implements World {
     }
 
     @Override
+    public RegionizedScheduler scheduler() {
+        return scheduler;
+    }
+
+    @Override
     public CompletableFuture<Chunk> getChunkAsync(final int chunkX, final int chunkZ) {
         final ChunkColumn cached = loaded.get(ChunkPos.chunkKey(chunkX, chunkZ));
         if (cached != null) {
@@ -166,7 +177,7 @@ public final class ServerWorld implements World {
     @Override
     public Optional<Chunk> getChunkIfLoaded(final int chunkX, final int chunkZ) {
         final ChunkColumn cached = loaded.get(ChunkPos.chunkKey(chunkX, chunkZ));
-        return Optional.of(cached).map(this::wrap);
+        return Optional.ofNullable(cached).map(this::wrap);
     }
 
     @Override
@@ -255,6 +266,9 @@ public final class ServerWorld implements World {
         if (!from.equals(to)) {
             markEntitiesDirty(from.x(), from.z());
             markEntitiesDirty(to.x(), to.z());
+            if (entity instanceof AbstractMob) {
+                scheduler.moveTicket(key(), from, to);
+            }
         }
     }
 

--- a/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/WorldManager.java
+++ b/fidorial-server/src/main/java/fr/euphyllia/fidorial/server/world/WorldManager.java
@@ -4,6 +4,7 @@ import fr.euphyllia.fidorial.server.FidorialServer;
 import fr.euphyllia.fidorial.server.entity.AbstractEntity;
 import fr.euphyllia.fidorial.server.entity.player.ServerPlayer;
 import fr.euphyllia.fidorial.server.schedulers.LightUpdateDispatcher;
+import fr.euphyllia.fidorial.server.schedulers.ThreadedRegionRegionizer;
 import fr.euphyllia.fidorial.server.world.chunk.AnvilChunkSerializer;
 import fr.euphyllia.fidorial.server.world.chunk.BlockState;
 import fr.euphyllia.fidorial.server.world.entity.AnvilEntitySerializer;
@@ -39,6 +40,7 @@ public final class WorldManager implements AutoCloseable {
     private final ChunkStorage storage;
     private final EntityRegionStorage entityStorage;
     private final AnvilEntitySerializer entitySerializer;
+    private final ThreadedRegionRegionizer scheduler;
     private final Map<Key, ServerWorld> worlds = new ConcurrentHashMap<>();
     private volatile @Nullable LightUpdateDispatcher lightDispatcher;
     private final BlockStateRegistry blockStates;
@@ -53,7 +55,8 @@ public final class WorldManager implements AutoCloseable {
             final ChunkStorage storage,
             final EntityRegionStorage entityStorage,
             final AnvilEntitySerializer entitySerializer,
-            final BlockStateRegistry blockStates
+            final BlockStateRegistry blockStates,
+            final ThreadedRegionRegionizer scheduler
     ) {
         this.paths = paths;
         this.levelData = levelData;
@@ -61,9 +64,10 @@ public final class WorldManager implements AutoCloseable {
         this.entityStorage = entityStorage;
         this.entitySerializer = entitySerializer;
         this.blockStates = blockStates;
+        this.scheduler = scheduler;
     }
 
-    public static WorldManager openOrCreate(final Path worldRoot, final BlockStateRegistry blockStates) throws IOException {
+    public static WorldManager openOrCreate(final Path worldRoot, final BlockStateRegistry blockStates, final ThreadedRegionRegionizer scheduler) throws IOException {
         final WorldPaths paths = new WorldPaths(worldRoot, WorldPaths.Layout.MODERN);
 
         final LevelData levelData;
@@ -82,12 +86,12 @@ public final class WorldManager implements AutoCloseable {
         final EntityRegionStorage entityStorage = new EntityRegionStorage(paths);
         final AnvilEntitySerializer entitySerializer = new AnvilEntitySerializer();
 
-        return new WorldManager(paths, levelData, storage, entityStorage, entitySerializer, blockStates);
+        return new WorldManager(paths, levelData, storage, entityStorage, entitySerializer, blockStates, scheduler);
     }
 
     public ServerWorld registerDimension(final Dimension dim, final ChunkGenerator generator) {
         return worlds.computeIfAbsent(dim.id(), _ -> {
-            final ServerWorld world = new ServerWorld(dim, storage, entityStorage, entitySerializer, generator, blockStates);
+            final ServerWorld world = new ServerWorld(dim, storage, entityStorage, entitySerializer, generator, blockStates, scheduler);
             if (chunkLoader != null) {
                 world.setChunkLoader(chunkLoader);
             }


### PR DESCRIPTION
This PR introduces a scheduler for entities and chunks that follows them across the server lifecycle.

Also backported an NPE fix from https://github.com/Fidorial/Fidorial/pull/95